### PR TITLE
refactor(cli): use EngineKind for framework dispatch

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "kapsl-backends"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "kapsl-core"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "flate2",
  "fs2",
@@ -2033,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "kapsl-engine-api"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "kapsl-hal"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "cudarc",
  "half",
@@ -2059,7 +2059,7 @@ dependencies = [
 [[package]]
 name = "kapsl-ipc"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "kapsl-kernels"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "cudarc",
  "half",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "kapsl-llm"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2120,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "kapsl-loader"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "half",
  "kapsl-hal",
@@ -2135,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "kapsl-monitor"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "kapsl-quantization"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "anyhow",
  "half",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2185,7 +2185,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag-sdk"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "futures",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "kapsl-scheduler"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "kapsl-shm"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "kapsl-transport"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2332,7 +2332,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#d3fde64fe5487b1428245be81bf1024eef5b2bb2"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#979008dc7e27af7f5ed91e9f30d8e245656ffdc2"
 dependencies = [
  "bindgen",
  "cc",

--- a/kapsl-runtime/crates/kapsl-cli/src/main.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/main.rs
@@ -12,7 +12,9 @@ use futures::{stream, StreamExt};
 use infer_adapter::{default_request_adapter_registry, parse_inference_request_with_registry};
 use kapsl_backends::{BackendFactory, OnnxRuntimeTuning};
 use kapsl_core::loader::Manifest;
-use kapsl_core::{AutoScaler, ModelInfo, ModelRegistry, ModelStatus, PackageLoader, ScalingPolicy};
+use kapsl_core::{
+    AutoScaler, EngineKind, ModelInfo, ModelRegistry, ModelStatus, PackageLoader, ScalingPolicy,
+};
 use kapsl_engine_api::{
     BinaryTensorPacket, Engine, EngineError, EngineHandle, EngineMetrics, EngineModelInfo,
     InferenceRequest, TensorDtype,
@@ -9166,7 +9168,7 @@ fn resolve_scheduler_tuning_for_framework(
     scheduler_max_micro_batch: usize,
     scheduler_queue_delay_ms: u64,
 ) -> (usize, u64) {
-    if !manifest.framework.eq_ignore_ascii_case("llm") {
+    if !EngineKind::resolve(manifest).is_onnx_generate() {
         return (scheduler_max_micro_batch, scheduler_queue_delay_ms);
     }
 
@@ -9198,7 +9200,7 @@ fn resolve_scheduler_tuning_for_framework(
 }
 
 fn export_gguf_auto_sizing_hint(manifest: &Manifest, batch_size: usize) {
-    if !manifest.framework.eq_ignore_ascii_case("llm") {
+    if !EngineKind::resolve(manifest).is_onnx_generate() {
         return;
     }
     if std::env::var_os(GGUF_MAX_CONCURRENT_ENV).is_some()
@@ -9337,7 +9339,8 @@ fn resolve_effective_topology_choice(
     let requested = requested_topology.trim().to_ascii_lowercase();
     let requested_degree = requested_tp_degree.max(1);
     let pipeline_stage_count = pipeline_stages.map(|stages| stages.len()).unwrap_or(0);
-    let pipeline_ready = manifest.framework == "llm" && pipeline_stage_count > 0;
+    let pipeline_ready =
+        EngineKind::resolve(manifest).is_onnx_generate() && pipeline_stage_count > 0;
 
     match requested.as_str() {
         "pipeline" | "pipeline-parallel" => {
@@ -10874,7 +10877,7 @@ fn load_model_blocking(
                 let provider = device.backend.to_string();
 
                 #[cfg(feature = "gguf-native")]
-                if loader.manifest.framework == "gguf" {
+                if EngineKind::resolve(&loader.manifest).is_gguf() {
                     let existing_handle = shared_kv.get_gpu_pool(device.id);
                     let mut b =
                         BackendFactory::create_gguf_native(device.id as i32, existing_handle)?;
@@ -10905,7 +10908,7 @@ fn load_model_blocking(
                 }
 
                 #[cfg(all(feature = "gguf-cuda-shared-kv", not(feature = "gguf-native")))]
-                if loader.manifest.framework == "gguf" {
+                if EngineKind::resolve(&loader.manifest).is_gguf() {
                     let existing_handle = shared_kv.get_gpu_pool(device.id);
                     let mut b = BackendFactory::create_gguf_cuda_shared_kv(
                         device.id as i32,
@@ -11278,7 +11281,7 @@ async fn load_model(
                 let provider = device.backend.to_string();
 
                 #[cfg(feature = "gguf-native")]
-                if loader.manifest.framework == "gguf" {
+                if EngineKind::resolve(&loader.manifest).is_gguf() {
                     let existing_handle = shared_kv.get_gpu_pool(device.id);
                     let mut b =
                         BackendFactory::create_gguf_native(device.id as i32, existing_handle)?;
@@ -11587,7 +11590,7 @@ async fn scale_up_model(
         #[allow(unused_labels)]
         'engine: {
             #[cfg(feature = "gguf-native")]
-            if loader.manifest.framework == "gguf" {
+            if EngineKind::resolve(&loader.manifest).is_gguf() {
                 let device_id =
                     loader.manifest.hardware_requirements.device_id.unwrap_or(0) as usize;
                 let existing_handle = shared_kv.get_gpu_pool(device_id);


### PR DESCRIPTION
Bump the kapsl-sdk pin to the develop commit that adds kapsl_core::EngineKind, and replace the 7 stringly-typed `framework == "gguf"/"llm"` reads in main.rs (LLM scheduler tuning, gguf auto-sizing hint, pipeline_ready, and the 4 gguf load sites) with EngineKind::resolve(...).is_gguf() / .is_onnx_generate().

Behavior-preserving: EngineKind maps the same legacy framework values. Completes the engine-side half of step 1 of the framework format/task split.