### PR TITLE
Disable Remove unless model is stopped

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/main.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/main.rs
@@ -12578,6 +12578,55 @@ async fn scale_down_model(
     Ok(())
 }
 
+fn force_stop_model_before_remove(
+    base_model_id: u32,
+    replicas: &[ModelInfo],
+    model_registry: &ModelRegistry,
+    replica_pools: &ReplicaPools,
+    swap_map: &Arc<RwLock<HashMap<u32, Vec<EngineHandle>>>>,
+    shared_kv: &SharedKvState,
+) {
+    for replica in replicas {
+        if let Err(e) = model_registry.set_status(replica.id, ModelStatus::Stopping) {
+            log::warn!(
+                "Failed to set model {} replica {} to Stopping before remove: {}",
+                base_model_id,
+                replica.replica_id,
+                e
+            );
+        }
+    }
+
+    if let Some(pool) = replica_pools.read().get(&base_model_id).cloned() {
+        for replica in replicas {
+            if !pool.remove_replica(replica.replica_id) {
+                log::debug!(
+                    "Replica {} for model {} was not present in the pool during remove",
+                    replica.replica_id,
+                    base_model_id
+                );
+            }
+        }
+    }
+
+    replica_pools.write().remove(&base_model_id);
+    swap_map.write().remove(&base_model_id);
+    shared_kv.detach_engine_for_model(base_model_id);
+    #[cfg(any(feature = "gguf-native", feature = "gguf-cuda-shared-kv"))]
+    shared_kv.detach_gpu_pool(base_model_id);
+
+    for replica in replicas {
+        if let Err(e) = model_registry.set_status(replica.id, ModelStatus::Inactive) {
+            log::warn!(
+                "Failed to set model {} replica {} to Inactive before remove: {}",
+                base_model_id,
+                replica.replica_id,
+                e
+            );
+        }
+    }
+}
+
 const MEMORY_HEADROOM_FRACTION: f64 = 0.80;
 
 fn cap_scale_up_target_by_memory_headroom(
@@ -14911,16 +14960,15 @@ async fn main() -> Result<(), DynError> {
                 let base_model_id = model_info.base_model_id;
                 let replicas = model_registry_for_remove.list_replicas(base_model_id);
 
-                for replica in &replicas {
-                    let _ = model_registry_for_remove.set_status(replica.id, ModelStatus::Stopping);
-                }
-
-                replica_pools_for_remove.write().remove(&base_model_id);
-                swap_map_for_remove.write().remove(&base_model_id);
+                force_stop_model_before_remove(
+                    base_model_id,
+                    &replicas,
+                    &model_registry_for_remove,
+                    &replica_pools_for_remove,
+                    &swap_map_for_remove,
+                    &shared_kv_for_remove,
+                );
                 model_paths_for_remove.write().remove(&base_model_id);
-                shared_kv_for_remove.detach_engine_for_model(base_model_id);
-                #[cfg(any(feature = "gguf-native", feature = "gguf-cuda-shared-kv"))]
-                shared_kv_for_remove.detach_gpu_pool(base_model_id);
 
                 for replica in replicas {
                     model_registry_for_remove.unregister(replica.id);

--- a/kapsl-runtime/ui/app.js
+++ b/kapsl-runtime/ui/app.js
@@ -2750,6 +2750,10 @@ class KapslApp {
     } else {
       startStopButton = `<button class="btn btn-disabled" type="button" disabled>${this.escapeHtml(statusText)}</button>`;
     }
+    const removeButton =
+      status === "inactive"
+        ? `<button class="btn btn-danger" type="button" onclick="event.stopPropagation(); app.removeModel(${model.id})">Remove</button>`
+        : `<button class="btn btn-disabled" type="button" disabled title="Stop the model before removing it">Remove</button>`;
 
     return `
       <div class="model-card" onclick="app.showModelDetail(${model.id})">
@@ -2805,7 +2809,7 @@ class KapslApp {
         <div class="model-actions">
           <button class="btn btn-secondary" type="button" onclick="event.stopPropagation(); app.showModelDetail(${model.id})">Details</button>
           ${startStopButton}
-          <button class="btn btn-danger" type="button" onclick="event.stopPropagation(); app.removeModel(${model.id})">Remove</button>
+          ${removeButton}
         </div>
       </div>
     `;
@@ -3561,6 +3565,15 @@ class KapslApp {
   }
 
   async removeModel(modelId) {
+    const model = (Array.isArray(this.modelsData) ? this.modelsData : []).find(
+      (candidate) => candidate.id === modelId,
+    );
+    if (!model || String(model.status || "").toLowerCase() !== "inactive") {
+      alert("Stop the model before removing it.");
+      this.fetchData();
+      return;
+    }
+
     if (
       !confirm(
         `Remove model ${modelId}? This unregisters the model and all replicas.`,
@@ -3698,6 +3711,10 @@ class KapslApp {
     } else {
       startStopButton = `<button class="btn btn-disabled" type="button" disabled>${this.escapeHtml(statusText)}</button>`;
     }
+    const removeButton =
+      status === "inactive"
+        ? `<button class="btn btn-danger" type="button" onclick="app.removeModel(${model.id})">Remove</button>`
+        : `<button class="btn btn-disabled" type="button" disabled title="Stop the model before removing it">Remove</button>`;
 
     modalBody.innerHTML = `
       <div class="modal-section">
@@ -3709,7 +3726,7 @@ class KapslApp {
           </div>
           <div class="modal-actions-buttons">
             ${startStopButton}
-            <button class="btn btn-danger" type="button" onclick="app.removeModel(${model.id})">Remove</button>
+            ${removeButton}
           </div>
         </div>
       </div>

--- a/kapsl-runtime/ui/styles.css
+++ b/kapsl-runtime/ui/styles.css
@@ -904,6 +904,17 @@ body.auth-locked {
     cursor: not-allowed;
 }
 
+.btn:disabled,
+.btn:disabled:hover {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+    background: var(--surface-2);
+    color: var(--text-3);
+    border-color: var(--border);
+}
+
 /* ─── Misc ─────────────────────────────────────────────────────────────── */
 .notice {
     font-size: 12px;


### PR DESCRIPTION
Add force_stop_model_before_remove to set replicas to Stopping, remove them from pools, detach shared (and GPU) resources, and mark replicas Inactive before unregistering. Replace inline removal logic with this helper.

Update UI to enable the Remove button only when a model is inactive and guard client-side removal with an alert. Add styles for disabled .buttons to visually indicate the disabled state.