### PR TITLE
Instrument per-model inference latency on /api/models

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/http/models/infer.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/http/models/infer.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(crate) struct ModelInferRouteConfig {
     pub(crate) replica_pools: ReplicaPools,
     pub(crate) model_registry: Arc<ModelRegistry>,
+    pub(crate) latency_samples: Arc<RwLock<HashMap<u32, LatencyWindow>>>,
     pub(crate) log_sensitive_ids: bool,
     pub(crate) rag_state: RagRuntimeState,
     pub(crate) inter_model_relay_state: Arc<InterModelRelayState>,
@@ -16,6 +17,7 @@ pub(crate) fn build_model_infer_route(
     let ModelInferRouteConfig {
         replica_pools: replica_pools_clone,
         model_registry: model_registry_clone,
+        latency_samples: latency_samples_clone,
         log_sensitive_ids: log_sensitive_ids_for_api,
         rag_state: rag_state_for_api,
         inter_model_relay_state,
@@ -26,6 +28,7 @@ pub(crate) fn build_model_infer_route(
     // POST /api/models/:id/infer - Synchronous inference
     let replica_pools_for_infer = replica_pools_clone.clone();
     let model_registry_for_infer = model_registry_clone.clone();
+    let latency_samples_for_infer = latency_samples_clone.clone();
     let request_adapters_for_infer = Arc::new(default_request_adapter_registry());
     let log_sensitive_ids_for_infer = log_sensitive_ids_for_api;
     let rag_state_for_infer = rag_state_for_api.clone();
@@ -38,6 +41,7 @@ pub(crate) fn build_model_infer_route(
     .and_then(move |model_id: u32, body: warp::hyper::body::Bytes| {
         let pools = replica_pools_for_infer.clone();
         let model_registry = model_registry_for_infer.clone();
+        let latency_samples = latency_samples_for_infer.clone();
         let request_adapters = request_adapters_for_infer.clone();
         let log_sensitive_ids = log_sensitive_ids_for_infer;
         let rag_state = rag_state_for_infer.clone();
@@ -329,6 +333,9 @@ pub(crate) fn build_model_infer_route(
                         .and_then(|metadata| metadata.timeout_ms)
                         .filter(|ms| *ms > 0);
 
+                    // End-to-end inference latency: scheduler queue wait + compute.
+                    // This is the signal the enterprise autoscaler scales SLOs on.
+                    let inference_started = std::time::Instant::now();
                     let infer_fut = pool.infer(&request, scheduler_priority, force_cpu);
                     let infer_result = if let Some(timeout_ms) = timeout_ms {
                         match tokio::time::timeout(
@@ -351,6 +358,12 @@ pub(crate) fn build_model_infer_route(
 
                     match infer_result {
                         Ok(output) => {
+                            let latency_ms = inference_started.elapsed().as_secs_f64() * 1000.0;
+                            latency_samples
+                                .write()
+                                .entry(model_id)
+                                .or_default()
+                                .record(latency_ms);
                             maybe_publish_inter_model_relays(
                                 &inter_model_relay,
                                 model_id,

--- a/kapsl-runtime/crates/kapsl-cli/src/http/models/mod.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/http/models/mod.rs
@@ -26,6 +26,7 @@ pub(crate) struct ModelRoutesConfig {
     pub(crate) throughput_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>>,
     pub(crate) generated_token_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>>,
     pub(crate) total_token_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>>,
+    pub(crate) latency_samples: Arc<RwLock<HashMap<u32, LatencyWindow>>>,
     pub(crate) device_info: Arc<DeviceInfo>,
     pub(crate) batch_size: usize,
     pub(crate) scheduler_queue_size: usize,
@@ -53,6 +54,7 @@ pub(crate) fn build_model_routes(config: ModelRoutesConfig) -> ModelRoutes {
         throughput_samples: throughput_samples_clone,
         generated_token_samples: generated_token_samples_clone,
         total_token_samples: total_token_samples_clone,
+        latency_samples: latency_samples_clone,
         device_info: device_info_for_api,
         batch_size,
         scheduler_queue_size,
@@ -79,6 +81,7 @@ pub(crate) fn build_model_routes(config: ModelRoutesConfig) -> ModelRoutes {
         throughput_samples: throughput_samples_clone.clone(),
         generated_token_samples: generated_token_samples_clone.clone(),
         total_token_samples: total_token_samples_clone.clone(),
+        latency_samples: latency_samples_clone.clone(),
     });
 
     let lifecycle_routes = build_model_lifecycle_routes(ModelLifecycleRoutesConfig {
@@ -105,6 +108,7 @@ pub(crate) fn build_model_routes(config: ModelRoutesConfig) -> ModelRoutes {
     let infer_route = build_model_infer_route(ModelInferRouteConfig {
         replica_pools: replica_pools_clone.clone(),
         model_registry: model_registry_clone.clone(),
+        latency_samples: latency_samples_clone.clone(),
         log_sensitive_ids: log_sensitive_ids_for_api,
         rag_state: rag_state_for_api.clone(),
         inter_model_relay_state: inter_model_relay_state.clone(),

--- a/kapsl-runtime/crates/kapsl-cli/src/http/models/reader.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/http/models/reader.rs
@@ -7,6 +7,7 @@ pub(crate) struct ModelReaderRoutesConfig {
     pub(crate) throughput_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>>,
     pub(crate) generated_token_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>>,
     pub(crate) total_token_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>>,
+    pub(crate) latency_samples: Arc<RwLock<HashMap<u32, LatencyWindow>>>,
 }
 
 pub(crate) fn build_model_reader_routes(
@@ -19,6 +20,7 @@ pub(crate) fn build_model_reader_routes(
         throughput_samples: throughput_samples_clone,
         generated_token_samples: generated_token_samples_clone,
         total_token_samples: total_token_samples_clone,
+        latency_samples: latency_samples_clone,
     } = config;
 
     let model_registry_for_list = model_registry_clone.clone();
@@ -27,6 +29,7 @@ pub(crate) fn build_model_reader_routes(
     let throughput_samples_for_list = throughput_samples_clone.clone();
     let generated_token_samples_for_list = generated_token_samples_clone.clone();
     let total_token_samples_for_list = total_token_samples_clone.clone();
+    let latency_samples_for_list = latency_samples_clone.clone();
     let list_models = warp::path!("api" / "models").and(warp::get()).map(move || {
         #[derive(Serialize)]
         struct ModelStatus {
@@ -51,6 +54,8 @@ pub(crate) fn build_model_reader_routes(
             onnx_session_pool_idle: usize,
             onnx_session_pool_waits_total: u64,
             onnx_session_pool_wait_seconds_total: f64,
+            avg_latency_ms: f64,
+            p99_latency_ms: f64,
             healthy: bool,
         }
 
@@ -59,6 +64,7 @@ pub(crate) fn build_model_reader_routes(
         let now = Instant::now();
         let mut seen_ids = HashSet::new();
         let mut throughput_samples = throughput_samples_for_list.write();
+        let mut latency_samples = latency_samples_for_list.write();
         let mut generated_token_samples = generated_token_samples_for_list.write();
         let mut total_token_samples = total_token_samples_for_list.write();
 
@@ -141,6 +147,11 @@ pub(crate) fn build_model_reader_routes(
                 0.0
             };
 
+            let (avg_latency_ms, p99_latency_ms) = latency_samples
+                .get(&model.id)
+                .map(|window| (window.average_ms(), window.p99_ms()))
+                .unwrap_or((0.0, 0.0));
+
             statuses.push(ModelStatus {
                 info: model,
                 active_inferences: active,
@@ -162,11 +173,14 @@ pub(crate) fn build_model_reader_routes(
                 onnx_session_pool_idle,
                 onnx_session_pool_waits_total,
                 onnx_session_pool_wait_seconds_total,
+                avg_latency_ms,
+                p99_latency_ms,
                 healthy,
             });
         }
 
         throughput_samples.retain(|id, _| seen_ids.contains(id));
+        latency_samples.retain(|id, _| seen_ids.contains(id));
         generated_token_samples.retain(|id, _| seen_ids.contains(id));
         total_token_samples.retain(|id, _| seen_ids.contains(id));
         warp::reply::json(&statuses)

--- a/kapsl-runtime/crates/kapsl-cli/src/main.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/main.rs
@@ -285,6 +285,8 @@ async fn main() -> Result<(), DynError> {
         Arc::new(RwLock::new(HashMap::new()));
     let total_token_samples: Arc<RwLock<HashMap<u32, ThroughputSample>>> =
         Arc::new(RwLock::new(HashMap::new()));
+    let latency_samples: Arc<RwLock<HashMap<u32, LatencyWindow>>> =
+        Arc::new(RwLock::new(HashMap::new()));
     let inter_model_relay_state = Arc::new(InterModelRelayState::from_env());
     if inter_model_relay_state.has_routes() {
         log::info!(
@@ -623,6 +625,7 @@ async fn main() -> Result<(), DynError> {
     let throughput_samples_clone = throughput_samples.clone();
     let generated_token_samples_clone = generated_token_samples.clone();
     let total_token_samples_clone = total_token_samples.clone();
+    let latency_samples_clone = latency_samples.clone();
     let onnx_tuning_profile_for_api = onnx_tuning_profile.clone();
 
     let extensions_root = state_layout.extensions_root.clone();
@@ -665,6 +668,7 @@ async fn main() -> Result<(), DynError> {
             throughput_samples: throughput_samples_clone.clone(),
             generated_token_samples: generated_token_samples_clone.clone(),
             total_token_samples: total_token_samples_clone.clone(),
+            latency_samples: latency_samples_clone.clone(),
             device_info: device_info_for_api.clone(),
             batch_size: args.batch_size,
             scheduler_queue_size: args.scheduler_queue_size,

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/monitor.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/monitor.rs
@@ -144,6 +144,53 @@ pub(crate) struct ThroughputSample {
     pub(crate) throughput: f64,
 }
 
+/// Maximum number of recent latency observations retained per model.
+pub(crate) const LATENCY_WINDOW_CAPACITY: usize = 256;
+
+/// Bounded ring of recent end-to-end inference latencies (milliseconds) for a
+/// single model. Surfaced as avg/p99 on `GET /api/models` so the enterprise
+/// autoscaler can scale workers on latency SLOs, not just queue depth.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LatencyWindow {
+    samples: std::collections::VecDeque<f64>,
+}
+
+impl LatencyWindow {
+    pub(crate) fn record(&mut self, latency_ms: f64) {
+        if !latency_ms.is_finite() || latency_ms < 0.0 {
+            return;
+        }
+        if self.samples.len() >= LATENCY_WINDOW_CAPACITY {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(latency_ms);
+    }
+
+    pub(crate) fn average_ms(&self) -> f64 {
+        if self.samples.is_empty() {
+            return 0.0;
+        }
+        self.samples.iter().sum::<f64>() / self.samples.len() as f64
+    }
+
+    pub(crate) fn p99_ms(&self) -> f64 {
+        self.percentile_ms(0.99)
+    }
+
+    /// Nearest-rank percentile over the current window; 0.0 when empty.
+    pub(crate) fn percentile_ms(&self, quantile: f64) -> f64 {
+        if self.samples.is_empty() {
+            return 0.0;
+        }
+        let mut sorted: Vec<f64> = self.samples.iter().copied().collect();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let rank = (quantile.clamp(0.0, 1.0) * sorted.len() as f64)
+            .ceil()
+            .max(1.0) as usize;
+        sorted[rank.min(sorted.len()) - 1]
+    }
+}
+
 pub(crate) type InterModelRoutes = HashMap<String, Vec<String>>;
 
 #[derive(Debug, Clone)]
@@ -434,4 +481,54 @@ pub(crate) fn sample_nvidia_smi() -> Option<(f64, usize, usize)> {
     let mem_bytes = (total_mem_mb * 1024.0 * 1024.0) as usize;
     let mem_capacity_bytes = (total_mem_capacity_mb * 1024.0 * 1024.0) as usize;
     Some((avg_util, mem_bytes, mem_capacity_bytes))
+}
+
+#[cfg(test)]
+mod latency_window_tests {
+    use super::LatencyWindow;
+    use super::LATENCY_WINDOW_CAPACITY;
+
+    #[test]
+    fn empty_window_reports_zero() {
+        let window = LatencyWindow::default();
+        assert_eq!(window.average_ms(), 0.0);
+        assert_eq!(window.p99_ms(), 0.0);
+    }
+
+    #[test]
+    fn computes_average_and_nearest_rank_p99() {
+        let mut window = LatencyWindow::default();
+        for ms in 1..=100 {
+            window.record(ms as f64);
+        }
+        assert!((window.average_ms() - 50.5).abs() < 1e-9);
+        // Nearest-rank p99 of 1..=100 is rank ceil(0.99*100)=99 -> value 99.
+        assert_eq!(window.p99_ms(), 99.0);
+        assert_eq!(window.percentile_ms(0.5), 50.0);
+        assert_eq!(window.percentile_ms(1.0), 100.0);
+    }
+
+    #[test]
+    fn discards_invalid_samples() {
+        let mut window = LatencyWindow::default();
+        window.record(f64::NAN);
+        window.record(-5.0);
+        window.record(f64::INFINITY);
+        assert_eq!(window.average_ms(), 0.0);
+        window.record(10.0);
+        assert_eq!(window.average_ms(), 10.0);
+    }
+
+    #[test]
+    fn evicts_oldest_beyond_capacity() {
+        let mut window = LatencyWindow::default();
+        for _ in 0..LATENCY_WINDOW_CAPACITY {
+            window.record(1.0);
+        }
+        // Newer, larger samples push out the old 1.0 values.
+        for _ in 0..LATENCY_WINDOW_CAPACITY {
+            window.record(9.0);
+        }
+        assert_eq!(window.average_ms(), 9.0);
+    }
 }


### PR DESCRIPTION
Record end-to-end inference latency (scheduler queue wait + compute) for each successful request into a bounded per-model ring buffer, and surface avg/p99 over that window as avg_latency_ms / p99_latency_ms on GET /api/models. This gives the enterprise KapslAutoscaler a real latency SLO signal to scale workers on, instead of queue depth alone.

The LatencyWindow lives alongside the existing throughput sample stores and is threaded through ModelRoutesConfig -> infer (record) and reader (expose). Nearest-rank p99 with unit tests. Time-to-first-token is deferred (needs first-token hooks in the streaming path). Prometheus histogram exposure on /metrics is a follow-up (requires the external kapsl-monitor crate).