### PR TITLE
Add streaming inference endpoint (SSE)

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/http/models/infer_stream.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/http/models/infer_stream.rs
@@ -1,0 +1,99 @@
+use super::*;
+use futures::StreamExt;
+use warp::Filter;
+use warp::Reply;
+
+pub(crate) struct ModelInferStreamRouteConfig {
+    pub(crate) replica_pools: ReplicaPools,
+}
+
+/// `POST /api/models/:id/infer/stream` — streams generated tokens incrementally
+/// as Server-Sent Events. Each `data:` frame is a JSON-encoded engine output
+/// packet; the stream terminates with `data: [DONE]`. Backed by the replica
+/// pool's `infer_stream`, so the client sees tokens as they are produced rather
+/// than waiting for the full completion.
+pub(crate) fn build_model_infer_stream_route(
+    config: ModelInferStreamRouteConfig,
+) -> warp::filters::BoxedFilter<(warp::reply::Response,)> {
+    let ModelInferStreamRouteConfig { replica_pools } = config;
+
+    let route = warp::path!("api" / "models" / u32 / "infer" / "stream")
+        .and(warp::post())
+        .and(warp::body::bytes())
+        .and_then(move |model_id: u32, body: warp::hyper::body::Bytes| {
+            let pools = replica_pools.clone();
+            async move {
+                use warp::http::StatusCode;
+
+                let request = match parse_stream_request(body.as_ref()) {
+                    Ok(request) => request,
+                    Err(error) => {
+                        return Ok::<_, warp::Rejection>(
+                            warp::reply::with_status(
+                                warp::reply::json(&serde_json::json!({ "error": error })),
+                                StatusCode::BAD_REQUEST,
+                            )
+                            .into_response(),
+                        );
+                    }
+                };
+
+                let pool = pools.read().get(&model_id).cloned();
+                let Some(pool) = pool else {
+                    return Ok(warp::reply::with_status(
+                        warp::reply::json(
+                            &serde_json::json!({ "error": format!("Model {model_id} not found") }),
+                        ),
+                        StatusCode::NOT_FOUND,
+                    )
+                    .into_response());
+                };
+
+                let priority = scheduler_priority_for_request(&request);
+                let force_cpu = request
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.force_cpu)
+                    .unwrap_or(false);
+
+                match pool.infer_stream(request, priority, force_cpu).await {
+                    Ok(stream) => {
+                        // Map each engine packet to an SSE frame, then close with [DONE].
+                        let events = stream
+                            .map(|item| match item {
+                                Ok(packet) => serde_json::to_string(&packet)
+                                    .map(|json| warp::sse::Event::default().data(json)),
+                                Err(engine_error) => Ok(warp::sse::Event::default()
+                                    .event("error")
+                                    .data(engine_error.to_string())),
+                            })
+                            .chain(futures::stream::once(async {
+                                Ok(warp::sse::Event::default().data("[DONE]"))
+                            }));
+                        Ok(warp::sse::reply(warp::sse::keep_alive().stream(events)).into_response())
+                    }
+                    Err(engine_error) => {
+                        let status = status_code_for_engine_error(&engine_error);
+                        Ok(warp::reply::with_status(
+                            warp::reply::json(
+                                &serde_json::json!({ "error": engine_error.to_string() }),
+                            ),
+                            status,
+                        )
+                        .into_response())
+                    }
+                }
+            }
+        });
+
+    route.map(reply_into_response).boxed()
+}
+
+/// Accept either the binary inference envelope or a bare `InferenceRequest`.
+fn parse_stream_request(body: &[u8]) -> Result<InferenceRequest, String> {
+    if let Ok(envelope) = serde_json::from_slice::<InferPayloadEnvelope<InferenceRequest>>(body) {
+        return Ok(envelope.request);
+    }
+    serde_json::from_slice::<InferenceRequest>(body)
+        .map_err(|error| format!("Invalid inference request: {error}"))
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/http/models/mod.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/http/models/mod.rs
@@ -3,12 +3,14 @@ use serde::{Deserialize, Serialize};
 use warp::Filter;
 
 mod infer;
+mod infer_stream;
 mod lifecycle;
 mod reader;
 mod scaling;
 mod swap;
 
 use infer::{build_model_infer_route, ModelInferRouteConfig};
+use infer_stream::{build_model_infer_stream_route, ModelInferStreamRouteConfig};
 use lifecycle::{build_model_lifecycle_routes, ModelLifecycleRoutesConfig};
 use reader::{build_model_reader_routes, ModelReaderRoutesConfig};
 use scaling::{build_model_scaling_routes, ModelScalingRoutesConfig};
@@ -116,11 +118,16 @@ pub(crate) fn build_model_routes(config: ModelRoutesConfig) -> ModelRoutes {
         runtime_pressure_config: runtime_pressure_config.clone(),
     });
 
+    let infer_stream_route = build_model_infer_stream_route(ModelInferStreamRouteConfig {
+        replica_pools: replica_pools_clone.clone(),
+    });
+
     let scaling_routes = build_model_scaling_routes(ModelScalingRoutesConfig {
         auto_scaler: auto_scaler_api.clone(),
     });
 
     let reader = reader_routes
+        .or(infer_stream_route)
         .or(infer_route)
         .or(scaling_routes.reader)
         .map(reply_into_response)


### PR DESCRIPTION
POST /api/models/:id/infer/stream streams generated tokens incrementally as Server-Sent Events: each data: frame is a JSON-encoded engine output packet, terminated by data: [DONE]. Backed by the replica pool's existing infer_stream, so clients see tokens as produced instead of waiting for the full completion. The synchronous /infer route is unchanged.