### PR TITLE
Expose time_to_first_token_ms on /api/models

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "kapsl-backends"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "kapsl-core"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "flate2",
  "fs2",
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "kapsl-engine-api"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "kapsl-hal"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "cudarc",
  "half",
@@ -2088,7 +2088,7 @@ dependencies = [
 [[package]]
 name = "kapsl-ipc"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2106,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "kapsl-kernels"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "cudarc",
  "half",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "kapsl-llm"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2149,7 +2149,7 @@ dependencies = [
 [[package]]
 name = "kapsl-loader"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "half",
  "kapsl-hal",
@@ -2164,7 +2164,7 @@ dependencies = [
 [[package]]
 name = "kapsl-monitor"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2178,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "kapsl-quantization"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "anyhow",
  "half",
@@ -2193,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag-sdk"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "futures",
@@ -2225,7 +2225,7 @@ dependencies = [
 [[package]]
 name = "kapsl-scheduler"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "kapsl-shm"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "kapsl-transport"
 version = "0.1.0"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2357,7 +2357,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#c045d82023f41be65dd19f2d27bc81746f05964b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?branch=develop#0a55728b4249c0d951a2de22bde21f65fc0b726c"
 dependencies = [
  "bindgen",
  "cc",

--- a/kapsl-runtime/crates/kapsl-cli/src/http/models/reader.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/http/models/reader.rs
@@ -56,6 +56,7 @@ pub(crate) fn build_model_reader_routes(
             onnx_session_pool_wait_seconds_total: f64,
             avg_latency_ms: f64,
             p99_latency_ms: f64,
+            time_to_first_token_ms: f64,
             healthy: bool,
         }
 
@@ -151,6 +152,12 @@ pub(crate) fn build_model_reader_routes(
                 .get(&model.id)
                 .map(|window| (window.average_ms(), window.p99_ms()))
                 .unwrap_or((0.0, 0.0));
+            // Most recent time-to-first-token, recorded by the monitoring
+            // middleware into a per-model gauge.
+            let time_to_first_token_ms = metrics_for_list
+                .model_ttft_ms
+                .with_label_values(&[&model_id_str])
+                .get();
 
             statuses.push(ModelStatus {
                 info: model,
@@ -175,6 +182,7 @@ pub(crate) fn build_model_reader_routes(
                 onnx_session_pool_wait_seconds_total,
                 avg_latency_ms,
                 p99_latency_ms,
+                time_to_first_token_ms,
                 healthy,
             });
         }


### PR DESCRIPTION
Surface the per-model TTFT from the new kapsl_model_ttft_ms gauge as time_to_first_token_ms on GET /api/models, alongside avg/p99 latency, so the enterprise KapslAutoscaler can scale on TTFT SLOs.

Requires the kapsl-monitor SDK change (per-model TTFT gauge): merge kapsl-sdk develop and `cargo update -p kapsl-monitor` before this compiles.