### PR TITLE
feat(runtime): cooperative VRAM-cap awareness for software vGPU

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/app/constants.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/app/constants.rs
@@ -71,3 +71,11 @@ pub(crate) const PRESSURE_CONSERVE_MAX_TOKENS_ENV: &str =
     "KAPSL_SERVER_PRESSURE_CONSERVE_MAX_NEW_TOKENS";
 pub(crate) const PRESSURE_EMERGENCY_MAX_TOKENS_ENV: &str =
     "KAPSL_SERVER_PRESSURE_EMERGENCY_MAX_NEW_TOKENS";
+/// HAMi's own per-process VRAM cap (software vGPU). A HAMi-managed pod sets this
+/// — or the per-device `CUDA_DEVICE_MEMORY_LIMIT_<id>` variant — so the engine
+/// self-limits its KV cache and reported total to the slice with zero extra
+/// config. Value is a byte count or a binary-suffixed size (e.g. `8g`, `2560m`).
+pub(crate) const CUDA_DEVICE_MEMORY_LIMIT_ENV: &str = "CUDA_DEVICE_MEMORY_LIMIT";
+/// kapsl alias for the per-device VRAM cap, in plain MiB, for non-HAMi
+/// deployments that still want cooperative self-limiting.
+pub(crate) const KAPSL_GPU_MEMORY_LIMIT_MB_ENV: &str = "KAPSL_GPU_MEMORY_LIMIT_MB";

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/monitor.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/monitor.rs
@@ -444,12 +444,27 @@ pub(crate) fn sample_nvidia_smi() -> Option<(f64, usize, usize)> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    aggregate_gpu_samples(&stdout, device_vram_cap_bytes)
+}
+
+/// Parse `nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total` CSV
+/// (one line per GPU, in device-index order) into average utilization plus
+/// summed used/total VRAM bytes. `cap_for_device` supplies the cooperative
+/// software-vGPU cap per device index: each GPU's reported *total* is clamped to
+/// its cap so back-pressure and the enterprise admission guard reason about the
+/// virtual slice, not the physical card. The cap never inflates the reported
+/// total (it is a `min`), and a missing cap leaves the device unchanged. Split
+/// out from the command invocation so the clamp is unit-testable without a GPU.
+fn aggregate_gpu_samples(
+    stdout: &str,
+    cap_for_device: impl Fn(usize) -> Option<usize>,
+) -> Option<(f64, usize, usize)> {
     let mut total_util = 0.0;
-    let mut total_mem_mb = 0.0;
-    let mut total_mem_capacity_mb = 0.0;
+    let mut total_mem_bytes: usize = 0;
+    let mut total_mem_capacity_bytes: usize = 0;
     let mut count = 0.0;
 
-    for line in stdout.lines() {
+    for (device_index, line) in stdout.lines().enumerate() {
         let mut parts = line.split(',');
         let util_str = parts.next().map(|s| s.trim());
         let mem_str = parts.next().map(|s| s.trim());
@@ -466,9 +481,13 @@ pub(crate) fn sample_nvidia_smi() -> Option<(f64, usize, usize)> {
             mem_str.parse::<f64>(),
             mem_total_str.parse::<f64>(),
         ) {
+            let mem_total_bytes = (mem_total_mb * 1024.0 * 1024.0) as usize;
+            let capped_total = cap_for_device(device_index)
+                .map_or(mem_total_bytes, |cap| mem_total_bytes.min(cap));
             total_util += util;
-            total_mem_mb += mem_mb;
-            total_mem_capacity_mb += mem_total_mb;
+            total_mem_bytes =
+                total_mem_bytes.saturating_add((mem_mb * 1024.0 * 1024.0) as usize);
+            total_mem_capacity_bytes = total_mem_capacity_bytes.saturating_add(capped_total);
             count += 1.0;
         }
     }
@@ -478,9 +497,7 @@ pub(crate) fn sample_nvidia_smi() -> Option<(f64, usize, usize)> {
     }
 
     let avg_util = (total_util / count) / 100.0;
-    let mem_bytes = (total_mem_mb * 1024.0 * 1024.0) as usize;
-    let mem_capacity_bytes = (total_mem_capacity_mb * 1024.0 * 1024.0) as usize;
-    Some((avg_util, mem_bytes, mem_capacity_bytes))
+    Some((avg_util, total_mem_bytes, total_mem_capacity_bytes))
 }
 
 #[cfg(test)]
@@ -530,5 +547,94 @@ mod latency_window_tests {
             window.record(9.0);
         }
         assert_eq!(window.average_ms(), 9.0);
+    }
+}
+
+#[cfg(test)]
+mod vram_clamp_tests {
+    use super::{
+        aggregate_gpu_samples, evaluate_runtime_pressure_state, RuntimePressureConfig,
+        RuntimePressureState, RuntimeSamples,
+    };
+
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    // One GPU reporting 4 GiB used of a 24 GiB physical card.
+    const ONE_GPU_CSV: &str = "30, 4096, 24576";
+
+    #[test]
+    fn no_cap_reports_physical_total() {
+        let (util, used, total) = aggregate_gpu_samples(ONE_GPU_CSV, |_| None).unwrap();
+        assert!((util - 0.30).abs() < 1e-9);
+        assert_eq!(used, (4096.0 * MIB) as usize);
+        // Physical 24 GiB is reported unchanged when no cap is configured.
+        assert_eq!(total, (24576.0 * MIB) as usize);
+    }
+
+    #[test]
+    fn cap_clamps_reported_total_to_the_slice() {
+        // An 8 GiB software-vGPU slice on the same 24 GiB card.
+        let (_, _, total) = aggregate_gpu_samples(ONE_GPU_CSV, |_| Some(8 * GIB)).unwrap();
+        assert_eq!(total, 8 * GIB);
+    }
+
+    #[test]
+    fn cap_larger_than_card_never_inflates_total() {
+        // A cap above the physical card is ignored (clamp is a min).
+        let (_, _, total) = aggregate_gpu_samples(ONE_GPU_CSV, |_| Some(64 * GIB)).unwrap();
+        assert_eq!(total, (24576.0 * MIB) as usize);
+    }
+
+    #[test]
+    fn per_device_caps_are_applied_by_index() {
+        // Two GPUs; only device 1 is capped to 8 GiB.
+        let csv = "10, 2048, 24576\n20, 2048, 24576";
+        let (_, _, total) = aggregate_gpu_samples(csv, |id| (id == 1).then_some(8 * GIB)).unwrap();
+        // device 0 physical (24 GiB) + device 1 capped (8 GiB).
+        assert_eq!(total, (24576.0 * MIB) as usize + 8 * GIB);
+    }
+
+    #[test]
+    fn pressure_ratio_is_computed_against_the_cap() {
+        // 7 GiB used on a 24 GiB card is calm (29%) physically, but against an
+        // 8 GiB slice it is 88% — the clamped total drives back-pressure into
+        // emergency, which is the whole point of the cooperative clamp.
+        let csv = "10, 7168, 24576";
+        let config = RuntimePressureConfig {
+            memory_conserve_ratio: 0.7,
+            memory_emergency_ratio: 0.9,
+            gpu_util_conserve_ratio: 0.8,
+            gpu_util_emergency_ratio: 0.95,
+            gpu_mem_conserve_ratio: 0.8,
+            gpu_mem_emergency_ratio: 0.85,
+            conserve_max_new_tokens: Some(256),
+            emergency_max_new_tokens: Some(128),
+        };
+
+        let (_, used, physical_total) = aggregate_gpu_samples(csv, |_| None).unwrap();
+        let physical = RuntimeSamples {
+            process_memory_bytes: 0,
+            total_system_memory_bytes: Some(64 * GIB),
+            gpu_utilization: 0.1,
+            gpu_memory_bytes: Some(used),
+            gpu_memory_total_bytes: Some(physical_total),
+            collected_at_ms: 0,
+        };
+        assert_eq!(
+            evaluate_runtime_pressure_state(&physical, &config),
+            RuntimePressureState::Normal
+        );
+
+        let (_, used, capped_total) = aggregate_gpu_samples(csv, |_| Some(8 * GIB)).unwrap();
+        let capped = RuntimeSamples {
+            gpu_memory_bytes: Some(used),
+            gpu_memory_total_bytes: Some(capped_total),
+            ..physical
+        };
+        assert_eq!(
+            evaluate_runtime_pressure_state(&capped, &config),
+            RuntimePressureState::Emergency
+        );
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
@@ -66,6 +66,12 @@ impl SharedKvStateInner {
                 continue;
             }
             let total = (device.memory_mb as usize).saturating_mul(1024 * 1024);
+            // Cooperative software-vGPU clamp: when a per-device VRAM cap is
+            // configured (HAMi env or the kapsl alias), size the KV budget to
+            // the slice rather than the whole card. A no-op when no cap is set
+            // or the cap exceeds the card, so default behavior is unchanged and
+            // a MIG slice (which already reports its true size) is never inflated.
+            let total = device_vram_cap_bytes(device.id).map_or(total, |cap| total.min(cap));
             device_bytes.insert(device.id, total);
             let kv_blocks = (total / 2) / KV_BYTES_PER_BLOCK;
             estimated_kv_tokens = estimated_kv_tokens.saturating_add(kv_blocks * KV_BLOCK_SIZE);
@@ -386,5 +392,73 @@ impl SharedKvStateInner {
                 sched.unregister_device(dev_id);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod vram_clamp_tests {
+    use super::SharedKvStateInner;
+    use crate::app::constants::CUDA_DEVICE_MEMORY_LIMIT_ENV;
+    use kapsl_hal::device::{Device, DeviceBackend, DeviceInfo};
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    fn cuda_device(id: usize, memory_mb: u64) -> Device {
+        Device {
+            id,
+            name: format!("test-gpu-{id}"),
+            backend: DeviceBackend::Cuda,
+            memory_mb,
+            compute_units: 1,
+            pci_bus_id: None,
+            partition_id: None,
+            driver_version: None,
+            cuda_version: None,
+            compute_capability: None,
+            utilization_gpu_pct: None,
+            temperature_c: None,
+            supports_fp16: true,
+            supports_int8: true,
+        }
+    }
+
+    fn device_info(devices: Vec<Device>) -> DeviceInfo {
+        DeviceInfo {
+            cpu_cores: 1,
+            total_memory: 0,
+            os_type: "test".to_string(),
+            os_release: "test".to_string(),
+            has_cuda: true,
+            has_metal: false,
+            has_rocm: false,
+            has_directml: false,
+            devices,
+        }
+    }
+
+    #[test]
+    fn device_bytes_unchanged_without_a_cap() {
+        // device id 4242 has no per-device cap env, and the bare
+        // CUDA_DEVICE_MEMORY_LIMIT / KAPSL_GPU_MEMORY_LIMIT_MB globals are never
+        // set by any test, so the cooperative clamp is a no-op here.
+        let info = device_info(vec![cuda_device(4242, 24576)]);
+        let state = SharedKvStateInner::new(&info);
+        assert_eq!(state.device_bytes.get(&4242).copied(), Some(24 * GIB));
+    }
+
+    #[test]
+    fn device_bytes_clamped_to_the_configured_cap() {
+        // Unique device index so the per-device env never collides with other
+        // tests running in parallel.
+        let device_id = 4243;
+        let var = format!("{CUDA_DEVICE_MEMORY_LIMIT_ENV}_{device_id}");
+        std::env::set_var(&var, "8g");
+        let info = device_info(vec![cuda_device(device_id, 24576)]);
+        let state = SharedKvStateInner::new(&info);
+        std::env::remove_var(&var);
+        // The KV budget sizes to the 8 GiB slice, not the 24 GiB physical card,
+        // so the whole downstream KV chain (pools, per-engine caps, rebalancing)
+        // self-limits.
+        assert_eq!(state.device_bytes.get(&device_id).copied(), Some(8 * GIB));
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/tuning.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/tuning.rs
@@ -14,6 +14,69 @@ pub(crate) fn optional_env_var_alias(primary: &str, legacy: &str) -> Option<Stri
     optional_env_var(primary).or_else(|| optional_env_var(legacy))
 }
 
+/// Resolve the per-device VRAM cap (bytes) for cooperative software-vGPU
+/// self-limiting, reading the environment so a HAMi-capped pod self-configures
+/// with zero model metadata. Returns `None` when nothing is configured (every
+/// clamp built on it is then a no-op, so default behavior is unchanged).
+///
+/// Priority order: HAMi's per-device `CUDA_DEVICE_MEMORY_LIMIT_<id>`, then its
+/// process-wide `CUDA_DEVICE_MEMORY_LIMIT`, then the kapsl alias
+/// `KAPSL_GPU_MEMORY_LIMIT_MB`. The model-metadata path
+/// (`HardwareRequirements::gpu_memory_limit_mb`) is intentionally routed through
+/// this same helper later; today it is env-only, which covers the HAMi case.
+pub(crate) fn device_vram_cap_bytes(device_id: usize) -> Option<usize> {
+    resolve_vram_cap_bytes(
+        optional_env_var(&format!("{CUDA_DEVICE_MEMORY_LIMIT_ENV}_{device_id}")),
+        optional_env_var(CUDA_DEVICE_MEMORY_LIMIT_ENV),
+        optional_env_var(KAPSL_GPU_MEMORY_LIMIT_MB_ENV),
+    )
+}
+
+/// Pure resolution of the cap-source priority, split out from environment access
+/// so it is unit-testable without touching process-global state. A malformed
+/// higher-priority value falls through to the next source rather than failing.
+fn resolve_vram_cap_bytes(
+    per_device: Option<String>,
+    process_wide: Option<String>,
+    kapsl_mb: Option<String>,
+) -> Option<usize> {
+    per_device
+        .as_deref()
+        .and_then(parse_cuda_memory_limit)
+        .or_else(|| process_wide.as_deref().and_then(parse_cuda_memory_limit))
+        .or_else(|| {
+            kapsl_mb
+                .as_deref()
+                .and_then(|value| value.trim().parse::<usize>().ok())
+                .filter(|mb| *mb > 0)
+                .map(|mb| mb.saturating_mul(1024 * 1024))
+        })
+}
+
+/// Parse a HAMi `CUDA_DEVICE_MEMORY_LIMIT` value into bytes. Accepts a plain
+/// byte count or a value with a binary unit suffix (`k`/`m`/`g`, optionally
+/// followed by `b`, case-insensitive — e.g. `2560m`, `4g`, `8gb`). Returns
+/// `None` for empty, zero, or otherwise malformed input.
+fn parse_cuda_memory_limit(value: &str) -> Option<usize> {
+    let lowered = value.trim().to_ascii_lowercase();
+    if lowered.is_empty() {
+        return None;
+    }
+    let digits = lowered.trim_end_matches(|c: char| c.is_ascii_alphabetic());
+    let multiplier: usize = match &lowered[digits.len()..] {
+        "" | "b" => 1,
+        "k" | "kb" => 1024,
+        "m" | "mb" => 1024 * 1024,
+        "g" | "gb" => 1024 * 1024 * 1024,
+        _ => return None,
+    };
+    digits
+        .parse::<usize>()
+        .ok()
+        .filter(|amount| *amount > 0)
+        .map(|amount| amount.saturating_mul(multiplier))
+}
+
 pub(crate) fn resolve_model_load_parallelism(model_count: usize) -> usize {
     if model_count <= 1 {
         return 1;
@@ -289,4 +352,82 @@ pub(crate) fn apply_performance_profile(
     }
 
     tuning
+}
+
+#[cfg(test)]
+mod vram_cap_tests {
+    use super::{device_vram_cap_bytes, parse_cuda_memory_limit, resolve_vram_cap_bytes};
+    use crate::app::constants::CUDA_DEVICE_MEMORY_LIMIT_ENV;
+
+    const MIB: usize = 1024 * 1024;
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    #[test]
+    fn parses_plain_bytes_and_binary_suffixes() {
+        assert_eq!(parse_cuda_memory_limit("1048576"), Some(MIB));
+        assert_eq!(parse_cuda_memory_limit("8g"), Some(8 * GIB));
+        assert_eq!(parse_cuda_memory_limit("2560m"), Some(2560 * MIB));
+        assert_eq!(parse_cuda_memory_limit("4gb"), Some(4 * GIB));
+        assert_eq!(parse_cuda_memory_limit("512k"), Some(512 * 1024));
+        // Case-insensitive and whitespace-tolerant.
+        assert_eq!(parse_cuda_memory_limit("  8G  "), Some(8 * GIB));
+    }
+
+    #[test]
+    fn rejects_empty_zero_and_malformed_values() {
+        assert_eq!(parse_cuda_memory_limit(""), None);
+        assert_eq!(parse_cuda_memory_limit("   "), None);
+        assert_eq!(parse_cuda_memory_limit("0"), None);
+        assert_eq!(parse_cuda_memory_limit("0g"), None);
+        assert_eq!(parse_cuda_memory_limit("abc"), None);
+        assert_eq!(parse_cuda_memory_limit("8t"), None);
+        assert_eq!(parse_cuda_memory_limit("8 g"), None);
+    }
+
+    #[test]
+    fn per_device_cap_wins_over_process_wide_and_kapsl_alias() {
+        let cap = resolve_vram_cap_bytes(
+            Some("4g".to_string()),
+            Some("8g".to_string()),
+            Some("16384".to_string()),
+        );
+        assert_eq!(cap, Some(4 * GIB));
+    }
+
+    #[test]
+    fn malformed_higher_priority_source_falls_through() {
+        // A malformed per-device value defers to the process-wide cap.
+        let cap = resolve_vram_cap_bytes(
+            Some("garbage".to_string()),
+            Some("8g".to_string()),
+            None,
+        );
+        assert_eq!(cap, Some(8 * GIB));
+    }
+
+    #[test]
+    fn kapsl_alias_is_plain_mib_converted_to_bytes() {
+        let cap = resolve_vram_cap_bytes(None, None, Some("2048".to_string()));
+        assert_eq!(cap, Some(2048 * MIB));
+        // Non-positive / malformed MiB is ignored.
+        assert_eq!(resolve_vram_cap_bytes(None, None, Some("0".to_string())), None);
+        assert_eq!(resolve_vram_cap_bytes(None, None, Some("x".to_string())), None);
+    }
+
+    #[test]
+    fn no_sources_configured_yields_no_cap() {
+        assert_eq!(resolve_vram_cap_bytes(None, None, None), None);
+    }
+
+    #[test]
+    fn device_vram_cap_bytes_reads_per_device_env() {
+        // Uses a unique device index so the process-global env never collides
+        // with other tests running in parallel; the suffixed var is checked
+        // first, so this is independent of any bare-name env state.
+        let device_id = 9090;
+        let var = format!("{CUDA_DEVICE_MEMORY_LIMIT_ENV}_{device_id}");
+        std::env::set_var(&var, "8g");
+        assert_eq!(device_vram_cap_bytes(device_id), Some(8 * GIB));
+        std::env::remove_var(&var);
+    }
 }


### PR DESCRIPTION
When several engines share one physical GPU via HAMi software fractioning, each engine must respect its VRAM slice instead of sizing the KV cache and back-pressure off the whole card — otherwise it over-commits the slice and OOM-thrashes. Teach the runtime to read a per-device VRAM cap and clamp the two inputs everything else derives from. This is the cooperative half of software vGPU (workstream 2); the hard memory fence is HAMi's job.

The cap is resolved from the environment so a HAMi-managed pod self-configures with zero model metadata, in priority order: HAMi's per-device `CUDA_DEVICE_MEMORY_LIMIT_<id>`, its process-wide `CUDA_DEVICE_MEMORY_LIMIT` (byte count or binary-suffixed size like `8g`/`2560m`), then a kapsl alias `KAPSL_GPU_MEMORY_LIMIT_MB` (plain MiB) for non-HAMi deployments. A single helper `device_vram_cap_bytes(device_id)` is the one source of truth; the `HardwareRequirements::gpu_memory_limit_mb` model-metadata path is intended to route through it later (kapsl-core is an external crate, so env-only for now, which covers the HAMi case).

Two clamps, both `min()` so they are no-ops when no cap is set or the cap exceeds the card (and a no-op under MIG, which already reports its slice's true size):

- SharedKvState::new clamps the per-device byte budget, so the KV pools, per-engine caps, and live rebalancing all self-limit to the slice with no further change.
- The nvidia-smi sampler clamps each GPU's reported *total* to its cap, so /api/system/stats reports the virtual size (the enterprise freeVramBytes admission guard then reasons about the slice) and the monitor's used/total pressure ratio enforces the cap with no new logic. nvidia-smi/NVML are not HAMi-intercepted, so injecting the cap here is what makes the virtual size visible.

Sampler parsing is split into a pure `aggregate_gpu_samples` taking an injected cap fn, and cap resolution into pure `resolve_vram_cap_bytes` / `parse_cuda_memory_limit`, so the clamps are unit-testable with no GPU. Adds 14 CPU-only tests: HAMi value parsing, cap-source priority + fall-through, the env wrapper, KV device-bytes clamp (clamped + unchanged), per-device stats clamp, cap-never-inflates, and pressure escalating to emergency against the slice.

Pairs with the enterprise `gpuMemoryBytes` request side (vgpu phase 1, WS1). See docs/vgpu-phase1-engine-ticket.md in kapsl-enterprise.