### PR TITLE
Add opt-in GPU co-tenancy guard: foreign-aware KV ceiling + pressure …

### DIFF
--- a/kapsl-runtime/FULL_DOCUMENTATION.md
+++ b/kapsl-runtime/FULL_DOCUMENTATION.md
@@ -658,6 +658,15 @@ Server pressure env vars:
 - `KAPSL_SERVER_PRESSURE_CONSERVE_MAX_NEW_TOKENS`: max new tokens allowed per request in conserve state.
 - `KAPSL_SERVER_PRESSURE_EMERGENCY_MAX_NEW_TOKENS`: max new tokens allowed per request in emergency state.
 
+GPU co-tenancy env vars:
+
+- `KAPSL_COTENANCY_GUARD` (`1`/`true`/`on`, default off): probe each monitor tick (via `nvidia-smi --query-compute-apps`) for other processes using the GPU — e.g. a training job sharing the card. When enabled:
+  - The live KV block ceiling shrinks by the co-tenant's VRAM footprint (plus a safety reserve of 10% of the budget, 512 MiB minimum), so the scheduler admits fewer concurrent sequences instead of racing the neighbor into an OOM. The ceiling shrinks immediately but recovers gradually (a quarter of the gap per 2 s tick) so batch width doesn't flap with the trainer's allocation sawtooth. Excess requests queue and are subject to the normal `KAPSL_SCHEDULER_QUEUE_OVERFLOW_POLICY` ingress rejection.
+  - Co-tenant bytes are excluded from the GPU-memory pressure ratio, so a neighbor's usage no longer trips conserve/emergency and truncates request outputs — co-tenant pressure is answered with lower concurrency, not shorter answers.
+  - The auto-scaler suppresses queue-depth scale-ups while a co-tenant is squeezing the ceiling, since a new replica on the same starved device would thrash.
+  - Composes with `CUDA_DEVICE_MEMORY_LIMIT[_<id>]` / `KAPSL_GPU_MEMORY_LIMIT_MB`: the co-tenant footprint is subtracted from the declared slice, not the physical card.
+  - Limitation: this is a VRAM-capacity control only; SM/HBM-bandwidth interference from the neighbor still needs MPS thread percentages or MIG partitioning. Under CUDA MPS, per-process attribution collapses to the MPS server PID, so the probe under-reports foreign usage.
+
 Model cache / disk-check env vars (read by `kapsl-core` loader):
 
 - `KAPSL_MODEL_CACHE_DIR` (or `KAPSL_LITE_MODEL_CACHE_DIR`): override the model cache root directory (default: `.kapsl-model-cache/` next to the `.aimod` file).

--- a/kapsl-runtime/crates/kapsl-cli/src/app/constants.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/app/constants.rs
@@ -71,6 +71,13 @@ pub(crate) const PRESSURE_CONSERVE_MAX_TOKENS_ENV: &str =
     "KAPSL_SERVER_PRESSURE_CONSERVE_MAX_NEW_TOKENS";
 pub(crate) const PRESSURE_EMERGENCY_MAX_TOKENS_ENV: &str =
     "KAPSL_SERVER_PRESSURE_EMERGENCY_MAX_NEW_TOKENS";
+/// Opt-in co-tenancy guard: when truthy (`1`/`true`/`on`), the monitor loop
+/// probes for foreign GPU processes (e.g. a training job on the same card),
+/// shrinks the live KV ceiling by their footprint so batching backs off instead
+/// of OOMing the neighbor, and excludes their bytes from the runtime-pressure
+/// ratio so co-tenant load never truncates request outputs. Default off:
+/// single-tenant behavior is byte-for-byte unchanged.
+pub(crate) const COTENANCY_GUARD_ENV: &str = "KAPSL_COTENANCY_GUARD";
 /// HAMi's own per-process VRAM cap (software vGPU). A HAMi-managed pod sets this
 /// — or the per-device `CUDA_DEVICE_MEMORY_LIMIT_<id>` variant — so the engine
 /// self-limits its KV cache and reported total to the slice with zero extra

--- a/kapsl-runtime/crates/kapsl-cli/src/main.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/main.rs
@@ -315,6 +315,11 @@ async fn main() -> Result<(), DynError> {
         let mut nvidia_smi_retry_after: Option<Instant> = None;
         system.refresh_memory();
         let total_system_memory_bytes = Some(system.total_memory() as usize * 1024);
+        // Opt-in co-tenancy guard: probe for foreign GPU processes each tick,
+        // shrink the live KV ceiling by their footprint, and exclude their bytes
+        // from the pressure ratio. Default off — single-tenant behavior unchanged.
+        let cotenancy_guard = optional_env_var(COTENANCY_GUARD_ENV)
+            .is_some_and(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "on"));
 
         loop {
             interval.tick().await;
@@ -351,6 +356,22 @@ async fn main() -> Result<(), DynError> {
                     (0.0, None, None)
                 };
 
+            // Co-tenancy: measure foreign VRAM, push it into the live KV
+            // ceiling (concurrency lever), and report it to the pressure split
+            // (so it never drives output truncation). Shares the nvidia-smi
+            // backoff above: while the sampler is backing off, skip the probe
+            // too rather than shelling out to a broken nvidia-smi twice.
+            let foreign_gpu_memory_bytes = if cotenancy_guard
+                && has_cuda_for_sampler
+                && !nvidia_smi_retry_after.is_some_and(|retry_after| now < retry_after)
+            {
+                let foreign = sample_foreign_vram();
+                shared_kv_for_rebalance.refresh_ceilings(&foreign);
+                Some(foreign.values().sum::<usize>())
+            } else {
+                None
+            };
+
             let collected_at_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -362,6 +383,7 @@ async fn main() -> Result<(), DynError> {
                 gpu_utilization,
                 gpu_memory_bytes,
                 gpu_memory_total_bytes,
+                foreign_gpu_memory_bytes,
                 collected_at_ms,
             };
             *runtime_samples_for_sampler.write() = snapshot.clone();
@@ -373,14 +395,15 @@ async fn main() -> Result<(), DynError> {
             let previous = RuntimePressureState::from_u8(previous_raw);
             if previous != next_state {
                 log::warn!(
-                    "Runtime pressure state changed: {} -> {} (rss={}B total_mem={}B gpu_util={:.2} gpu_mem={:?}/{:?})",
+                    "Runtime pressure state changed: {} -> {} (rss={}B total_mem={}B gpu_util={:.2} gpu_mem={:?}/{:?} foreign_gpu_mem={:?})",
                     previous.as_str(),
                     next_state.as_str(),
                     snapshot.process_memory_bytes,
                     snapshot.total_system_memory_bytes.unwrap_or(0),
                     snapshot.gpu_utilization,
                     snapshot.gpu_memory_bytes,
-                    snapshot.gpu_memory_total_bytes
+                    snapshot.gpu_memory_total_bytes,
+                    snapshot.foreign_gpu_memory_bytes
                 );
             }
         }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/autoscaler.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/autoscaler.rs
@@ -188,6 +188,22 @@ pub(crate) fn spawn_auto_scaler_task(config: AutoScalerTaskConfig) {
                 );
 
                 if let Some(target_replicas) = should_scale_up {
+                    // Queue depth driven by a co-tenant squeezing the GPU is not
+                    // load growth: a new replica would land on the same starved
+                    // device and thrash. Skip and re-evaluate next tick — the
+                    // ceiling's grow-slow recovery provides the hysteresis.
+                    if shared_kv_for_scaler.foreign_pressure_active() {
+                        log::warn!(
+                            "Auto-scaler: model {} queue depth {} exceeds threshold, but a \
+                             co-tenant GPU process is limiting the KV ceiling; suppressing \
+                             scale-up from {} to {} replicas",
+                            base_model_id,
+                            total_queue_depth,
+                            current_replicas,
+                            target_replicas
+                        );
+                        continue;
+                    }
                     let onnx_tuning = onnx_tuning_profile_for_scaler.resolve(base_model_id);
                     let capped_target = cap_scale_up_target_by_memory_headroom(
                         current_replicas,

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/monitor.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/monitor.rs
@@ -7,6 +7,14 @@ pub(crate) struct RuntimeSamples {
     pub(crate) gpu_utilization: f64,
     pub(crate) gpu_memory_bytes: Option<usize>,
     pub(crate) gpu_memory_total_bytes: Option<usize>,
+    /// VRAM held by co-tenant processes (summed across devices), from
+    /// `sample_foreign_vram`. Subtracted from `gpu_memory_bytes` in the pressure
+    /// calculation so a trainer sharing the GPU throttles kapsl's *concurrency*
+    /// (via the KV ceiling) rather than tripping Conserve/Emergency and
+    /// truncating every request's max_new_tokens. `None` when the co-tenancy
+    /// probe is disabled or unavailable, which leaves pressure behavior exactly
+    /// as before.
+    pub(crate) foreign_gpu_memory_bytes: Option<usize>,
     pub(crate) collected_at_ms: u64,
 }
 
@@ -112,9 +120,14 @@ pub(crate) fn evaluate_runtime_pressure_state(
         .map(|total| (samples.process_memory_bytes as f64 / total as f64).clamp(0.0, 1.0));
 
     let gpu_util_ratio = samples.gpu_utilization.clamp(0.0, 1.0);
+    // Pressure reasons about *our own* footprint: a co-tenant's bytes are
+    // subtracted so a trainer sharing the GPU is answered by the KV concurrency
+    // ceiling (smaller batches), not by truncating every request's output. With
+    // no probe data this is the historical device-wide ratio.
     let gpu_mem_ratio = match (samples.gpu_memory_bytes, samples.gpu_memory_total_bytes) {
         (Some(used), Some(total)) if total > 0 => {
-            Some((used as f64 / total as f64).clamp(0.0, 1.0))
+            let own = used.saturating_sub(samples.foreign_gpu_memory_bytes.unwrap_or(0));
+            Some((own as f64 / total as f64).clamp(0.0, 1.0))
         }
         _ => None,
     };
@@ -500,6 +513,104 @@ fn aggregate_gpu_samples(
     Some((avg_util, total_mem_bytes, total_mem_capacity_bytes))
 }
 
+/// Bytes of device VRAM held by compute processes that are NOT this engine,
+/// keyed by physical device index. Powers the co-tenancy ceiling: when another
+/// process (e.g. a training job) shares the GPU, its footprint is subtracted
+/// from the KV pool's effective ceiling so kapsl throttles concurrency instead
+/// of OOMing the neighbor.
+///
+/// Shells out to `nvidia-smi` twice: once to map each GPU's UUID to its device
+/// index (the compute-apps query reports UUID, not index), then to enumerate
+/// running compute apps. Our own PID is excluded. Returns an empty map on any
+/// failure so callers treat "no signal" as "no co-tenant" and default,
+/// single-tenant behavior is unchanged.
+///
+/// Caveat: under CUDA MPS every client's memory is attributed to the MPS server
+/// PID, so per-process filtering collapses. In that mode callers should fall
+/// back to device-wide `memory.used` minus kapsl's own known block bytes.
+pub(crate) fn sample_foreign_vram() -> HashMap<usize, usize> {
+    let uuid_to_index = query_gpu_uuid_index();
+    if uuid_to_index.is_empty() {
+        return HashMap::new();
+    }
+    let output = Command::new("nvidia-smi")
+        .args([
+            "--query-compute-apps=pid,used_memory,gpu_uuid",
+            "--format=csv,noheader,nounits",
+        ])
+        .output();
+    let stdout = match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
+        _ => return HashMap::new(),
+    };
+    aggregate_foreign_vram(&stdout, &uuid_to_index, std::process::id())
+}
+
+/// Map each GPU's UUID to its device index. The compute-apps query reports a
+/// UUID rather than the index the rest of the runtime keys on, so this bridges
+/// the two. Empty on any failure.
+fn query_gpu_uuid_index() -> HashMap<String, usize> {
+    let output = Command::new("nvidia-smi")
+        .args(["--query-gpu=uuid,index", "--format=csv,noheader,nounits"])
+        .output();
+    let stdout = match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
+        _ => return HashMap::new(),
+    };
+    parse_uuid_index(&stdout)
+}
+
+/// Parse `nvidia-smi --query-gpu=uuid,index` CSV into a UUID→index map. Split
+/// from the command invocation so it is unit-testable without a GPU.
+fn parse_uuid_index(stdout: &str) -> HashMap<String, usize> {
+    let mut map = HashMap::new();
+    for line in stdout.lines() {
+        let mut parts = line.split(',');
+        let (Some(uuid), Some(index)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if let Ok(index) = index.trim().parse::<usize>() {
+            map.insert(uuid.trim().to_string(), index);
+        }
+    }
+    map
+}
+
+/// Sum per-process VRAM by device index, excluding `own_pid`. Split out from the
+/// `nvidia-smi` invocation so it is unit-testable without a GPU. Rows whose UUID
+/// is not in `uuid_to_index` are skipped rather than misattributed to device 0.
+fn aggregate_foreign_vram(
+    stdout: &str,
+    uuid_to_index: &HashMap<String, usize>,
+    own_pid: u32,
+) -> HashMap<usize, usize> {
+    let mut foreign: HashMap<usize, usize> = HashMap::new();
+    for line in stdout.lines() {
+        let mut parts = line.split(',');
+        let (Some(pid_str), Some(used_str), Some(uuid_str)) =
+            (parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        let (Ok(pid), Ok(used_mb)) = (
+            pid_str.trim().parse::<u32>(),
+            used_str.trim().parse::<f64>(),
+        ) else {
+            continue;
+        };
+        if pid == own_pid {
+            continue;
+        }
+        let Some(&device) = uuid_to_index.get(uuid_str.trim()) else {
+            continue;
+        };
+        let used_bytes = (used_mb * 1024.0 * 1024.0) as usize;
+        let entry = foreign.entry(device).or_insert(0);
+        *entry = entry.saturating_add(used_bytes);
+    }
+    foreign
+}
+
 #[cfg(test)]
 mod latency_window_tests {
     use super::LatencyWindow;
@@ -619,6 +730,7 @@ mod vram_clamp_tests {
             gpu_utilization: 0.1,
             gpu_memory_bytes: Some(used),
             gpu_memory_total_bytes: Some(physical_total),
+            foreign_gpu_memory_bytes: None,
             collected_at_ms: 0,
         };
         assert_eq!(
@@ -636,5 +748,96 @@ mod vram_clamp_tests {
             evaluate_runtime_pressure_state(&capped, &config),
             RuntimePressureState::Emergency
         );
+    }
+
+    #[test]
+    fn foreign_bytes_are_excluded_from_the_pressure_ratio() {
+        let config = RuntimePressureConfig {
+            memory_conserve_ratio: 0.7,
+            memory_emergency_ratio: 0.9,
+            gpu_util_conserve_ratio: 0.8,
+            gpu_util_emergency_ratio: 0.95,
+            gpu_mem_conserve_ratio: 0.8,
+            gpu_mem_emergency_ratio: 0.85,
+            conserve_max_new_tokens: Some(256),
+            emergency_max_new_tokens: Some(128),
+        };
+        // 22 of 24 GiB used device-wide (92% → Emergency), but 16 GiB of that
+        // belongs to a trainer. Our own 6 GiB is 25% — calm. The trainer must be
+        // answered by the KV concurrency ceiling, not output truncation.
+        let shared = RuntimeSamples {
+            gpu_memory_bytes: Some(22 * GIB),
+            gpu_memory_total_bytes: Some(24 * GIB),
+            foreign_gpu_memory_bytes: Some(16 * GIB),
+            ..RuntimeSamples::default()
+        };
+        assert_eq!(
+            evaluate_runtime_pressure_state(&shared, &config),
+            RuntimePressureState::Normal
+        );
+        // Without the probe (None) the historical device-wide behavior holds.
+        let unprobed = RuntimeSamples {
+            foreign_gpu_memory_bytes: None,
+            ..shared
+        };
+        assert_eq!(
+            evaluate_runtime_pressure_state(&unprobed, &config),
+            RuntimePressureState::Emergency
+        );
+    }
+}
+
+#[cfg(test)]
+mod foreign_vram_tests {
+    use super::{aggregate_foreign_vram, parse_uuid_index};
+    use std::collections::HashMap;
+
+    const MIB: usize = 1024 * 1024;
+
+    fn uuid_index(pairs: &[(&str, usize)]) -> HashMap<String, usize> {
+        pairs.iter().map(|(u, i)| ((*u).to_string(), *i)).collect()
+    }
+
+    #[test]
+    fn parses_uuid_index_csv() {
+        let csv = "GPU-aaa, 0\nGPU-bbb, 1";
+        let map = parse_uuid_index(csv);
+        assert_eq!(map.get("GPU-aaa").copied(), Some(0));
+        assert_eq!(map.get("GPU-bbb").copied(), Some(1));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn sums_foreign_and_excludes_own_pid() {
+        // Our PID is 4242. A trainer (pid 99) holds 6 GiB; our own 2 GiB row is
+        // ignored so the ceiling only backs off for the neighbor's footprint.
+        let csv = "99, 6144, GPU-aaa\n4242, 2048, GPU-aaa";
+        let foreign = aggregate_foreign_vram(csv, &uuid_index(&[("GPU-aaa", 0)]), 4242);
+        assert_eq!(foreign.get(&0).copied(), Some(6144 * MIB));
+    }
+
+    #[test]
+    fn attributes_by_device_and_sums_multiple_foreign_procs() {
+        let csv = "10, 1024, GPU-aaa\n11, 2048, GPU-aaa\n12, 4096, GPU-bbb";
+        let foreign =
+            aggregate_foreign_vram(csv, &uuid_index(&[("GPU-aaa", 0), ("GPU-bbb", 1)]), 4242);
+        assert_eq!(foreign.get(&0).copied(), Some(3072 * MIB));
+        assert_eq!(foreign.get(&1).copied(), Some(4096 * MIB));
+    }
+
+    #[test]
+    fn skips_rows_with_unknown_uuid_rather_than_misattributing() {
+        // A GPU not in the index map (e.g. a MIG child or a device kapsl doesn't
+        // manage) must not be folded into device 0.
+        let csv = "10, 4096, GPU-unknown";
+        let foreign = aggregate_foreign_vram(csv, &uuid_index(&[("GPU-aaa", 0)]), 4242);
+        assert!(foreign.is_empty());
+    }
+
+    #[test]
+    fn empty_when_only_our_pid_present() {
+        let csv = "4242, 8192, GPU-aaa";
+        let foreign = aggregate_foreign_vram(csv, &uuid_index(&[("GPU-aaa", 0)]), 4242);
+        assert!(foreign.is_empty());
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
@@ -43,6 +43,17 @@ pub(crate) struct SharedKvStateInner {
     /// engine's health changes, reclaiming a degraded/dead engine's block quota
     /// for healthy engines without waiting for a full detach.
     last_health_epoch: AtomicU64,
+    /// Live per-device *soft* KV ceiling in bytes, foreign-aware. Refreshed by
+    /// `refresh_ceilings` from the monitor loop: the declared budget minus VRAM
+    /// held by co-tenant processes (e.g. a training job on the same card) minus
+    /// a safety reserve. Drives `rebalance_kv_caps` so concurrency backs off
+    /// under a noisy neighbor instead of OOMing it. Empty until the first
+    /// refresh, and never populated when the co-tenancy path is disabled, so the
+    /// soft budget falls back to `device_bytes` and default behavior is
+    /// unchanged. Distinct from the *hard* arena in `get_or_create_pool`, which
+    /// stays sized off `device_bytes` because handed-out blocks can't be
+    /// reclaimed.
+    live_ceiling: Mutex<HashMap<usize, Arc<AtomicUsize>>>,
     /// Per-device GPU pool registry for gguf-native/native backends.
     /// Stores compatible pools and their members so quota caps can be
     /// rebalanced by model priority.
@@ -86,6 +97,7 @@ impl SharedKvStateInner {
             model_engine_ids: Mutex::new(HashMap::new()),
             live_kv_caps: Mutex::new(HashMap::new()),
             last_health_epoch: AtomicU64::new(0),
+            live_ceiling: Mutex::new(HashMap::new()),
             #[cfg(any(feature = "gguf-native", feature = "gguf-cuda-shared-kv"))]
             gpu_pools: Mutex::new(HashMap::new()),
             #[cfg(any(feature = "gguf-native", feature = "gguf-cuda-shared-kv"))]
@@ -288,6 +300,72 @@ impl SharedKvStateInner {
         }
     }
 
+    /// Recompute the live, foreign-aware soft ceiling for every device from a
+    /// fresh co-tenancy sample and, if any ceiling actually moved, rebalance the
+    /// per-engine KV caps so admission backs off (or recovers). Called from the
+    /// monitor loop next to `maybe_rebalance_for_health`.
+    ///
+    /// The per-device value is smoothed asymmetrically (shrink fast, grow slow)
+    /// so a trainer's sawtooth footprint doesn't make the KV batch width flap,
+    /// and the rebalance is gated on an actual change so an idle GPU costs only a
+    /// map read. A ceiling that floors to zero is stored as-is; the
+    /// `MIN_BLOCKS_PER_ENGINE` clamp in `rebalance_kv_caps` keeps each engine at
+    /// a minimal batch rather than fully stalling.
+    pub(crate) fn refresh_ceilings(&self, foreign: &HashMap<usize, usize>) {
+        let mut changed = false;
+        {
+            let mut live = self.live_ceiling.lock();
+            for (&device_id, &declared) in &self.device_bytes {
+                let foreign_bytes = foreign.get(&device_id).copied().unwrap_or(0);
+                let target = effective_ceiling_bytes(device_id, declared, foreign_bytes);
+                let atom = live
+                    .entry(device_id)
+                    .or_insert_with(|| Arc::new(AtomicUsize::new(declared)));
+                let previous = atom.load(Ordering::Relaxed);
+                let smoothed = smooth_ceiling_bytes(previous, target);
+                if smoothed != previous {
+                    atom.store(smoothed, Ordering::Relaxed);
+                    changed = true;
+                }
+            }
+        }
+        if changed {
+            self.rebalance_kv_caps();
+        }
+    }
+
+    /// True while a co-tenant process is squeezing any device's KV ceiling:
+    /// the live soft ceiling sits below 90% of what it would be with no foreign
+    /// footprint (the reserve alone keeps the idle ceiling under the declared
+    /// bytes, so the comparison baseline is the no-foreign target, not the raw
+    /// budget). The autoscaler uses this to tell queue depth caused by a noisy
+    /// neighbor from real load growth — adding a replica on a starved GPU only
+    /// thrashes. The grow-slow smoothing keeps this true for a few ticks after
+    /// the neighbor exits, which doubles as scale-up hysteresis. Always false
+    /// when the co-tenancy guard is off (`live_ceiling` never populated).
+    pub(crate) fn foreign_pressure_active(&self) -> bool {
+        let live = self.live_ceiling.lock();
+        live.iter().any(|(device_id, atom)| {
+            let declared = self.device_bytes.get(device_id).copied().unwrap_or(0);
+            let idle_target = effective_ceiling_bytes(*device_id, declared, 0);
+            atom.load(Ordering::Relaxed) < idle_target.saturating_mul(9) / 10
+        })
+    }
+
+    /// The soft KV budget in bytes for a device: the live foreign-aware ceiling
+    /// when one has been refreshed, otherwise the static declared `device_bytes`.
+    /// A floored (zero) live ceiling is honored rather than falling back, so a
+    /// GPU fully claimed by a trainer shrinks engines to their block minimum
+    /// instead of resetting to the full budget.
+    fn device_soft_ceiling_bytes(&self, device_id: usize) -> usize {
+        self.live_ceiling
+            .lock()
+            .get(&device_id)
+            .map(|atom| atom.load(Ordering::Relaxed))
+            .or_else(|| self.device_bytes.get(&device_id).copied())
+            .unwrap_or(0)
+    }
+
     pub(crate) fn rebalance_kv_caps(&self) {
         const KV_BYTES_PER_BLOCK: usize = 2 * 1024 * 1024;
         const MIN_BLOCKS_PER_ENGINE: usize = 256;
@@ -317,7 +395,10 @@ impl SharedKvStateInner {
                     self.device_bytes.keys().next().copied()
                 })
                 .unwrap_or(0);
-            let total_bytes = self.device_bytes.get(&device_id).copied().unwrap_or(0);
+            // Soft budget: the live foreign-aware ceiling when refreshed, else the
+            // static declared bytes. The hard arena in get_or_create_pool keeps
+            // reading device_bytes so already-handed-out blocks are never revoked.
+            let total_bytes = self.device_soft_ceiling_bytes(device_id);
             let total_blocks = ((total_bytes / 2) / KV_BYTES_PER_BLOCK).max(MIN_BLOCKS_PER_ENGINE);
             let new_cap =
                 (total_blocks * budget.max_tokens / total_tokens).max(MIN_BLOCKS_PER_ENGINE);
@@ -444,6 +525,64 @@ mod vram_clamp_tests {
         let info = device_info(vec![cuda_device(4242, 24576)]);
         let state = SharedKvStateInner::new(&info);
         assert_eq!(state.device_bytes.get(&4242).copied(), Some(24 * GIB));
+    }
+
+    #[test]
+    fn refresh_ceilings_shrinks_fast_then_recovers_slowly() {
+        use std::collections::HashMap;
+        // 40 GiB card, no cap env → declared == physical.
+        let device_id = 4245;
+        let info = device_info(vec![cuda_device(device_id, 40 * 1024)]);
+        let state = SharedKvStateInner::new(&info);
+
+        // Before any refresh the soft ceiling is the full declared budget.
+        assert_eq!(state.device_soft_ceiling_bytes(device_id), 40 * GIB);
+
+        // A 6 GiB trainer appears: 40 - 6 - 4 (10% reserve) = 30 GiB, and a
+        // shrink is applied immediately (no damping on the safety side).
+        let mut foreign = HashMap::new();
+        foreign.insert(device_id, 6 * GIB);
+        state.refresh_ceilings(&foreign);
+        assert_eq!(state.device_soft_ceiling_bytes(device_id), 30 * GIB);
+
+        // Trainer exits: target recovers to 40 - 4 = 36 GiB but growth is damped
+        // to a quarter of the gap → 30 + (36 - 30)/4 = 31.5 GiB.
+        state.refresh_ceilings(&HashMap::new());
+        assert_eq!(
+            state.device_soft_ceiling_bytes(device_id),
+            30 * GIB + (6 * GIB) / 4
+        );
+    }
+
+    #[test]
+    fn foreign_pressure_tracks_the_squeeze_and_releases_with_hysteresis() {
+        use std::collections::HashMap;
+        let device_id = 4246;
+        let info = device_info(vec![cuda_device(device_id, 40 * 1024)]);
+        let state = SharedKvStateInner::new(&info);
+
+        // Guard off / never refreshed → never "under pressure".
+        assert!(!state.foreign_pressure_active());
+
+        // Idle refresh (no co-tenant): the reserve alone must not read as
+        // pressure, or the autoscaler would be permanently suppressed.
+        state.refresh_ceilings(&HashMap::new());
+        assert!(!state.foreign_pressure_active());
+
+        // A 12 GiB trainer squeezes the ceiling well below 90% of idle.
+        let mut foreign = HashMap::new();
+        foreign.insert(device_id, 12 * GIB);
+        state.refresh_ceilings(&foreign);
+        assert!(state.foreign_pressure_active());
+
+        // Trainer exits: grow-slow recovery keeps pressure asserted for a few
+        // ticks (scale-up hysteresis), then releases.
+        state.refresh_ceilings(&HashMap::new());
+        assert!(state.foreign_pressure_active());
+        for _ in 0..16 {
+            state.refresh_ceilings(&HashMap::new());
+        }
+        assert!(!state.foreign_pressure_active());
     }
 
     #[test]

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/tuning.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/tuning.rs
@@ -77,6 +77,37 @@ fn parse_cuda_memory_limit(value: &str) -> Option<usize> {
         .map(|amount| amount.saturating_mul(multiplier))
 }
 
+/// Instantaneous per-device KV ceiling in bytes under co-tenancy: the declared
+/// budget (the physical card, or the HAMi / kapsl software-vGPU cap when that is
+/// smaller), minus VRAM held by foreign processes, minus a safety reserve so a
+/// trainer's next allocation spike lands in slack instead of racing our
+/// allocator into an OOM. The reserve is 10% of the declared budget with a
+/// 512 MiB floor. Saturating throughout: a foreign footprint larger than the
+/// budget floors the ceiling at zero, and callers clamp back up to their
+/// per-engine block minimum. With no cap configured and no foreign process this
+/// returns `physical - reserve`, so single-tenant behavior only loses the small
+/// reserve band (and the whole path is gated off by default anyway).
+pub(crate) fn effective_ceiling_bytes(device_id: usize, physical: usize, foreign: usize) -> usize {
+    const RESERVE_FLOOR_BYTES: usize = 512 * 1024 * 1024;
+    let declared = device_vram_cap_bytes(device_id).map_or(physical, |cap| physical.min(cap));
+    let reserve = (declared / 10).max(RESERVE_FLOOR_BYTES);
+    declared.saturating_sub(foreign).saturating_sub(reserve)
+}
+
+/// Blend a freshly measured ceiling `target` toward the `previous` live value,
+/// asymmetrically. Shrink immediately (drop straight to the lower value) so a
+/// trainer's allocation is honored before it can OOM us; grow slowly (a quarter
+/// of the gap per tick) so a transient dip in the trainer's footprint between
+/// samples does not make the KV batch width flap. An unseeded `previous` of 0
+/// adopts the target directly. Downward "flap" is harmless — it just keeps us
+/// conservatively low — so only the grow side is damped.
+pub(crate) fn smooth_ceiling_bytes(previous: usize, target: usize) -> usize {
+    if previous == 0 || target <= previous {
+        return target;
+    }
+    previous + (target - previous) / 4
+}
+
 pub(crate) fn resolve_model_load_parallelism(model_count: usize) -> usize {
     if model_count <= 1 {
         return 1;
@@ -429,5 +460,60 @@ mod vram_cap_tests {
         std::env::set_var(&var, "8g");
         assert_eq!(device_vram_cap_bytes(device_id), Some(8 * GIB));
         std::env::remove_var(&var);
+    }
+}
+
+#[cfg(test)]
+mod ceiling_tests {
+    use super::{effective_ceiling_bytes, smooth_ceiling_bytes};
+    use crate::app::constants::CUDA_DEVICE_MEMORY_LIMIT_ENV;
+
+    const GIB: usize = 1024 * 1024 * 1024;
+    const RESERVE_FLOOR: usize = 512 * 1024 * 1024;
+
+    #[test]
+    fn subtracts_foreign_and_percentage_reserve_when_uncapped() {
+        // Unique device id with no cap env → declared == physical (40 GiB).
+        // Reserve is 10% (4 GiB, above the 512 MiB floor); a 6 GiB trainer
+        // leaves 40 - 6 - 4 = 30 GiB.
+        let ceiling = effective_ceiling_bytes(9101, 40 * GIB, 6 * GIB);
+        assert_eq!(ceiling, 30 * GIB);
+    }
+
+    #[test]
+    fn reserve_never_below_the_512mib_floor() {
+        // Tiny 2 GiB budget: 10% would be ~205 MiB, so the 512 MiB floor wins.
+        let ceiling = effective_ceiling_bytes(9102, 2 * GIB, 0);
+        assert_eq!(ceiling, 2 * GIB - RESERVE_FLOOR);
+    }
+
+    #[test]
+    fn ceiling_is_clamped_to_the_configured_cap_not_the_card() {
+        let device_id = 9103;
+        let var = format!("{CUDA_DEVICE_MEMORY_LIMIT_ENV}_{device_id}");
+        std::env::set_var(&var, "8g");
+        // Physical 40 GiB but capped to an 8 GiB slice; reserve is 10% of 8 GiB.
+        let ceiling = effective_ceiling_bytes(device_id, 40 * GIB, 0);
+        std::env::remove_var(&var);
+        assert_eq!(ceiling, 8 * GIB - (8 * GIB / 10));
+    }
+
+    #[test]
+    fn foreign_larger_than_budget_floors_at_zero() {
+        // A trainer holding more than the whole budget must not underflow.
+        let ceiling = effective_ceiling_bytes(9104, 8 * GIB, 16 * GIB);
+        assert_eq!(ceiling, 0);
+    }
+
+    #[test]
+    fn smoothing_shrinks_immediately_but_grows_a_quarter_at_a_time() {
+        // Unseeded adopts the target.
+        assert_eq!(smooth_ceiling_bytes(0, 30 * GIB), 30 * GIB);
+        // Shrink: drop straight to the lower value (safety).
+        assert_eq!(smooth_ceiling_bytes(30 * GIB, 10 * GIB), 10 * GIB);
+        // Grow: move a quarter of the 20 GiB gap → 10 + 5 = 15 GiB.
+        assert_eq!(smooth_ceiling_bytes(10 * GIB, 30 * GIB), 15 * GIB);
+        // Equal target is a no-op.
+        assert_eq!(smooth_ceiling_bytes(15 * GIB, 15 * GIB), 15 * GIB);
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/tests/http_route_tests.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/tests/http_route_tests.rs
@@ -41,6 +41,7 @@ async fn test_system_routes_report_health_and_pressure_state() {
         gpu_utilization: 7.5,
         gpu_memory_bytes: Some(10),
         gpu_memory_total_bytes: Some(20),
+        foreign_gpu_memory_bytes: None,
         collected_at_ms: 789,
     }));
     let pressure_state = Arc::new(AtomicU8::new(RuntimePressureState::Conserve as u8));

--- a/kapsl-runtime/crates/kapsl-cli/src/tests/security_tests.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/tests/security_tests.rs
@@ -829,6 +829,7 @@ fn test_evaluate_runtime_pressure_state_transitions() {
         gpu_utilization: 0.2,
         gpu_memory_bytes: Some(100),
         gpu_memory_total_bytes: Some(1000),
+        foreign_gpu_memory_bytes: None,
         collected_at_ms: 0,
     };
     assert_eq!(


### PR DESCRIPTION
…split

When another process (e.g. a training job) shares the GPU, kapsl's KV pool sized itself off the full declared budget and the runtime-pressure path silently counted the neighbor's VRAM, truncating request outputs.

Gated behind KAPSL_COTENANCY_GUARD (default off, single-tenant behavior unchanged):

- sample_foreign_vram() probes nvidia-smi compute-apps each monitor tick and attributes non-kapsl VRAM per device (own PID excluded).
- effective_ceiling_bytes() derives a live soft KV ceiling: declared budget (HAMi cap aware) minus foreign bytes minus a 10%/512MiB reserve, smoothed asymmetrically (shrink fast, grow a quarter of the gap per tick) so batch width doesn't flap with the trainer's sawtooth.
- SharedKvStateInner::refresh_ceilings() feeds the smoothed ceiling into rebalance_kv_caps, so per-engine block caps and admission back off instead of OOMing the neighbor. The hard arena stays sized off device_bytes: handed-out blocks are never revoked.
- Runtime pressure now subtracts foreign bytes from the GPU-mem ratio: a co-tenant lowers concurrency, it no longer truncates max_new_tokens.
- Auto-scaler suppresses queue-depth scale-ups while foreign pressure is active, since a new replica on the same starved device would thrash.

Capacity control only: SM/HBM-bandwidth isolation still needs MPS/MIG.