### PR TITLE
fix(runtime): don't auto-select TensorRT for cpu/missing-provider man…

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/config.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/config.rs
@@ -581,7 +581,9 @@ pub(crate) fn select_mesh_devices(
             }
         };
         if device_info.has_cuda {
-            push_if_missing("tensorrt");
+            // Do not auto-upgrade cpu/missing-provider manifests to TensorRT:
+            // its EP rejects some quantized ONNX graphs (non-zero zero-points in
+            // Q/DQ). Only use TensorRT when a manifest explicitly requests it.
             push_if_missing("cuda");
         }
         if device_info.has_metal {


### PR DESCRIPTION
…ifests

fastest-mode device selection pushed `tensorrt` ahead of `cuda` when auto-upgrading a cpu/missing-provider manifest on NVIDIA hardware. The TensorRT EP rejects some quantized ONNX graphs (non-zero zero-points in Q/DQ), so models that ran on CPU/CUDA failed on GPU. Only use TensorRT when a manifest explicitly requests it.

Mirrors the kapsl-sdk fix (kapsl-llm/kapsl-backends).