### PR TITLE
Fix v0.1.19 container image publishing

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -15,8 +15,31 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/kapsl-engine
 
 jobs:
+  wait-for-release-assets:
+    name: Wait for release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for tagged runtime bundle
+        if: github.ref_type == 'tag'
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          version="${RELEASE_VERSION#v}"
+          asset_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}/kapsl-${version}-linux-x86_64.tar.gz"
+          for attempt in $(seq 1 180); do
+            if curl -fsSLI "$asset_url" >/dev/null; then
+              echo "Runtime release assets are available."
+              exit 0
+            fi
+            echo "Runtime release assets are not available yet (attempt ${attempt}/180)."
+            sleep 10
+          done
+          echo "Timed out waiting for runtime release assets." >&2
+          exit 1
+
   build-and-push:
     name: Build ${{ matrix.variant }} image
+    needs: wait-for-release-assets
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -47,7 +70,7 @@ jobs:
         run: |
           cargo_version="$(grep -m1 '^version = ' kapsl-runtime/crates/kapsl-cli/Cargo.toml | cut -d '"' -f2)"
           # runtime_version is the exact published binary version (no dev- prefix)
-          # that the in-image install script downloads from downloads.kapsl.net.
+          # that the in-image installer downloads from GitHub Release assets.
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             release_version="${GITHUB_REF_NAME#v}"
             channel=stable

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -7,20 +7,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the pre-built kapsl binary, pinned to KAPSL_VERSION so this layer
-# cache-busts per release. Retry because runtime artifacts and container builds
-# are published by separate tag-triggered workflows.
+# Install the pre-built kapsl bundle from the matching GitHub Release. The
+# release-asset path stays reachable from GitHub-hosted container builders even
+# when the public download-domain WAF rejects their shared runner addresses.
+COPY docker/install-release-assets.sh /tmp/install-release-assets.sh
 ARG KAPSL_VERSION
 RUN set -eux; \
     test -n "${KAPSL_VERSION}"; \
-    attempt=1; \
-    until curl -fsSL https://downloads.kapsl.net/install.sh \
-        | KAPSL_VERSION="${KAPSL_VERSION}" KAPSL_INSTALL_DIR=/usr/local/bin \
-          sh -s -- --version "${KAPSL_VERSION}" --install-dir /usr/local/bin; do \
-        if [ "${attempt}" -ge 20 ]; then exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        sleep 15; \
-    done; \
+    KAPSL_VERSION="${KAPSL_VERSION}" \
+        sh /tmp/install-release-assets.sh cpu; \
+    rm /tmp/install-release-assets.sh; \
     kapsl --version; \
     test ! -e /usr/local/bin/libonnxruntime_providers_cuda.so; \
     test ! -e /usr/local/bin/libonnxruntime_providers_tensorrt.so; \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -7,22 +7,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the pre-built kapsl binary, pinned to KAPSL_VERSION so this layer
-# cache-busts per release. Retry because runtime artifacts and container builds
-# are published by separate tag-triggered workflows.
+# Install the pre-built runtime and CUDA provider pack from the matching GitHub
+# Release, pinned to KAPSL_VERSION so this layer cache-busts per release.
+COPY docker/install-release-assets.sh /tmp/install-release-assets.sh
 ARG KAPSL_VERSION
 RUN set -eux; \
     test -n "${KAPSL_VERSION}"; \
-    attempt=1; \
-    until curl -fsSL https://downloads.kapsl.net/install.sh \
-        | KAPSL_VERSION="${KAPSL_VERSION}" KAPSL_INSTALL_DIR=/usr/local/bin \
-          KAPSL_ACCELERATOR=cuda \
-          sh -s -- --version "${KAPSL_VERSION}" --install-dir /usr/local/bin \
-          --accelerator cuda; do \
-        if [ "${attempt}" -ge 20 ]; then exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        sleep 15; \
-    done; \
+    KAPSL_VERSION="${KAPSL_VERSION}" \
+        sh /tmp/install-release-assets.sh cuda; \
+    rm /tmp/install-release-assets.sh; \
     kapsl --version; \
     test -f /usr/local/bin/kapsl-provider-cuda12.json; \
     test -f /usr/local/bin/libonnxruntime_providers_cuda.so; \

--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -25,18 +25,12 @@ RUN echo "/opt/kapsl/tensorrt-package/tensorrt_libs" > /etc/ld.so.conf.d/kapsl-t
     && test -e /opt/kapsl/tensorrt-package/tensorrt_libs/libnvonnxparser.so.10
 
 ARG KAPSL_VERSION
+COPY docker/install-release-assets.sh /tmp/install-release-assets.sh
 RUN set -eux; \
     test -n "${KAPSL_VERSION}"; \
-    attempt=1; \
-    until curl -fsSL https://downloads.kapsl.net/install.sh \
-        | KAPSL_VERSION="${KAPSL_VERSION}" KAPSL_INSTALL_DIR=/usr/local/bin \
-          KAPSL_ACCELERATOR=tensorrt \
-          sh -s -- --version "${KAPSL_VERSION}" --install-dir /usr/local/bin \
-          --accelerator tensorrt; do \
-        if [ "${attempt}" -ge 20 ]; then exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        sleep 15; \
-    done; \
+    KAPSL_VERSION="${KAPSL_VERSION}" \
+        sh /tmp/install-release-assets.sh tensorrt; \
+    rm /tmp/install-release-assets.sh; \
     kapsl --version; \
     test -f /usr/local/bin/kapsl-provider-cuda12.json; \
     test -f /usr/local/bin/kapsl-provider-tensorrt10.json; \

--- a/docker/install-release-assets.sh
+++ b/docker/install-release-assets.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -eu
+
+: "${KAPSL_VERSION:?KAPSL_VERSION is required}"
+
+accelerator="${1:-cpu}"
+install_dir="${KAPSL_INSTALL_DIR:-/usr/local/bin}"
+release_base="${KAPSL_RELEASE_BASE_URL:-https://github.com/kapsl-runtime/kapsl-engine/releases/download/v${KAPSL_VERSION}}"
+
+case "$(uname -m)" in
+    x86_64 | amd64)
+        platform="linux-x86_64"
+        ;;
+    aarch64 | arm64)
+        platform="linux-aarch64"
+        ;;
+    *)
+        echo "Unsupported container architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+case "$accelerator" in
+    cpu) ;;
+    cuda | tensorrt)
+        if [ "$platform" != "linux-x86_64" ]; then
+            echo "${accelerator} images are supported only on Linux x86_64." >&2
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Unsupported accelerator: ${accelerator}" >&2
+        exit 1
+        ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+download() {
+    url="$1"
+    destination="$2"
+    curl -fL \
+        --connect-timeout 30 \
+        --retry 10 \
+        --retry-all-errors \
+        --retry-delay 5 \
+        "$url" \
+        -o "$destination"
+}
+
+download_verified_asset() {
+    asset_name="$1"
+    asset_path="${tmp_dir}/${asset_name}"
+    checksum_path="${asset_path}.sha256"
+
+    download "${release_base}/${asset_name}" "$asset_path"
+    download "${release_base}/${asset_name}.sha256" "$checksum_path"
+    expected_checksum="$(awk '{print $1}' "$checksum_path")"
+    actual_checksum="$(sha256sum "$asset_path" | awk '{print $1}')"
+    if [ "$actual_checksum" != "$expected_checksum" ]; then
+        echo "Checksum mismatch for ${asset_name}" >&2
+        exit 1
+    fi
+}
+
+extract_asset() {
+    asset_name="$1"
+    download_verified_asset "$asset_name"
+    tar -xzf "${tmp_dir}/${asset_name}" -C "$install_dir"
+}
+
+mkdir -p "$install_dir"
+
+runtime_asset="kapsl-${KAPSL_VERSION}-${platform}.tar.gz"
+extract_asset "$runtime_asset"
+
+case "$accelerator" in
+    cuda | tensorrt)
+        extract_asset "kapsl-provider-cuda12-${KAPSL_VERSION}-${platform}.tar.gz"
+        ;;
+esac
+
+if [ "$accelerator" = "tensorrt" ]; then
+    extract_asset "kapsl-provider-tensorrt10-${KAPSL_VERSION}-${platform}.tar.gz"
+fi
+
+chmod +x "${install_dir}/kapsl"


### PR DESCRIPTION
## Summary

- install container runtime bundles directly from GitHub Release assets
- verify release asset checksums before extraction
- wait for tagged runtime assets before starting the Docker build matrix
- avoid the downloads.kapsl.net WAF rejection affecting GitHub-hosted runners

## Validation

- `sh -n docker/install-release-assets.sh`
- release workflow YAML parsed successfully
- downloaded and verified the live v0.1.19 ARM64 runtime bundle
- downloaded and verified the v0.1.19 CUDA and TensorRT provider packs in Linux x86_64
- built `docker/Dockerfile.cpu` locally for Linux x86_64; `kapsl --version` reported 0.1.19