### PR TITLE
Build linux runtime installer on ubuntu-22.04 for glibc compatibility

### DIFF
--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -25,7 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # ubuntu-22.04 (not ubuntu-latest) so the linux-x86_64 binary links
+        # against glibc 2.35 instead of 24.04's 2.39 — see
+        # release-runtime-installers.yml for the full explanation.
+        os: [ubuntu-22.04, macos-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -26,7 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        # ubuntu-22.04 (not ubuntu-latest) so the linux-x86_64 binary links
+        # against glibc 2.35 instead of 24.04's 2.39 — ubuntu-latest moved to
+        # 24.04 and the resulting binary refused to run on 22.04 and other
+        # still-supported distros with older glibc.
+        os: [ubuntu-22.04, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
ubuntu-latest moved to Ubuntu 24.04 (glibc 2.39), so v0.1.19's linux-x86_64 installer binary refused to run on Ubuntu 22.04 and other still-supported distros with older glibc ("GLIBC_2.38/2.39 not found"). Reproduced on a fresh Ubuntu 22.04 GPU box; the CUDA docker image was unaffected since it bundles its own 24.04 userspace.