### PR TITLE
Fix modular accelerator packaging and linux glibc compatibility

### DIFF
--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -25,7 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # ubuntu-22.04 (not ubuntu-latest) so the linux-x86_64 binary links
+        # against glibc 2.35 instead of 24.04's 2.39 — see
+        # release-runtime-installers.yml for the full explanation.
+        os: [ubuntu-22.04, macos-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,46 @@
+name: Docker Smoke Tests
+
+on:
+  pull_request:
+    paths:
+      - "docker/**"
+      - ".github/workflows/docker-smoke.yml"
+      - ".github/workflows/release-docker-images.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-scripts:
+    name: Test release asset scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell syntax
+        run: sh -n docker/*.sh
+
+      - name: Test readiness and checksum handling
+        run: docker/test-release-scripts.sh
+
+  cpu-image:
+    name: Build CPU image
+    runs-on: ubuntu-latest
+    env:
+      KAPSL_SMOKE_VERSION: "0.1.19"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build CPU image
+        run: |
+          docker build \
+            --build-arg "KAPSL_VERSION=${KAPSL_SMOKE_VERSION}" \
+            --file docker/Dockerfile.cpu \
+            --tag kapsl-engine:pr-smoke \
+            .
+
+      - name: Run CPU image
+        run: docker run --rm kapsl-engine:pr-smoke --version

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -36,11 +36,23 @@ jobs:
 
       - name: Build CPU image
         run: |
-          docker build \
-            --build-arg "KAPSL_VERSION=${KAPSL_SMOKE_VERSION}" \
-            --file docker/Dockerfile.cpu \
-            --tag kapsl-engine:pr-smoke \
-            .
+          for attempt in 1 2 3; do
+            if docker build \
+              --build-arg "KAPSL_VERSION=${KAPSL_SMOKE_VERSION}" \
+              --file docker/Dockerfile.cpu \
+              --tag kapsl-engine:pr-smoke \
+              .; then
+              exit 0
+            fi
+
+            if [ "${attempt}" -eq 3 ]; then
+              echo "CPU image build failed after ${attempt} attempts." >&2
+              exit 1
+            fi
+
+            echo "CPU image build failed on attempt ${attempt}; retrying in 15 seconds."
+            sleep 15
+          done
 
       - name: Run CPU image
         run: docker run --rm kapsl-engine:pr-smoke --version

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -15,8 +15,31 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/kapsl-engine
 
 jobs:
+  wait-for-release-assets:
+    name: Wait for release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for tagged runtime bundle
+        if: github.ref_type == 'tag'
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          version="${RELEASE_VERSION#v}"
+          asset_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}/kapsl-${version}-linux-x86_64.tar.gz"
+          for attempt in $(seq 1 180); do
+            if curl -fsSLI "$asset_url" >/dev/null; then
+              echo "Runtime release assets are available."
+              exit 0
+            fi
+            echo "Runtime release assets are not available yet (attempt ${attempt}/180)."
+            sleep 10
+          done
+          echo "Timed out waiting for runtime release assets." >&2
+          exit 1
+
   build-and-push:
     name: Build ${{ matrix.variant }} image
+    needs: wait-for-release-assets
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -47,7 +70,7 @@ jobs:
         run: |
           cargo_version="$(grep -m1 '^version = ' kapsl-runtime/crates/kapsl-cli/Cargo.toml | cut -d '"' -f2)"
           # runtime_version is the exact published binary version (no dev- prefix)
-          # that the in-image install script downloads from downloads.kapsl.net.
+          # that the in-image installer downloads from GitHub Release assets.
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             release_version="${GITHUB_REF_NAME#v}"
             channel=stable

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -2,6 +2,16 @@ name: Release Docker Images
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Existing GitHub Release version to publish (for example, 0.1.19). Leave empty for a development image."
+        required: false
+        type: string
+      update_channel_tags:
+        description: "Also update mutable channel tags such as latest or beta."
+        required: false
+        default: false
+        type: boolean
   push:
     tags:
       - "v*"
@@ -15,31 +25,46 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/kapsl-engine
 
 jobs:
+  resolve-version:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      runtime_version: ${{ steps.version.outputs.runtime_version }}
+      channel: ${{ steps.version.outputs.channel }}
+      update_channel_tags: ${{ steps.version.outputs.update_channel_tags }}
+      wait_for_assets: ${{ steps.version.outputs.wait_for_assets }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        env:
+          DISPATCH_RELEASE_VERSION: ${{ inputs.release_version }}
+          DISPATCH_UPDATE_CHANNEL_TAGS: ${{ inputs.update_channel_tags }}
+        run: docker/resolve-release-version.sh
+
   wait-for-release-assets:
     name: Wait for release assets
+    needs: resolve-version
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for tagged runtime bundle
-        if: github.ref_type == 'tag'
+      - name: Checkout
+        if: needs.resolve-version.outputs.wait_for_assets == 'true'
+        uses: actions/checkout@v4
+
+      - name: Wait for complete release asset set
+        if: needs.resolve-version.outputs.wait_for_assets == 'true'
         env:
-          RELEASE_VERSION: ${{ github.ref_name }}
-        run: |
-          version="${RELEASE_VERSION#v}"
-          asset_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}/kapsl-${version}-linux-x86_64.tar.gz"
-          for attempt in $(seq 1 180); do
-            if curl -fsSLI "$asset_url" >/dev/null; then
-              echo "Runtime release assets are available."
-              exit 0
-            fi
-            echo "Runtime release assets are not available yet (attempt ${attempt}/180)."
-            sleep 10
-          done
-          echo "Timed out waiting for runtime release assets." >&2
-          exit 1
+          KAPSL_VERSION: ${{ needs.resolve-version.outputs.runtime_version }}
+        run: docker/wait-for-release-assets.sh
 
   build-and-push:
     name: Build ${{ matrix.variant }} image
-    needs: wait-for-release-assets
+    needs:
+      - resolve-version
+      - wait-for-release-assets
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -65,33 +90,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Resolve version
-        id: version
-        run: |
-          cargo_version="$(grep -m1 '^version = ' kapsl-runtime/crates/kapsl-cli/Cargo.toml | cut -d '"' -f2)"
-          # runtime_version is the exact published binary version (no dev- prefix)
-          # that the in-image installer downloads from GitHub Release assets.
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            release_version="${GITHUB_REF_NAME#v}"
-            channel=stable
-            case "${release_version}" in
-              *-beta*) channel=beta ;;
-              *-*) channel=prerelease ;;
-            esac
-            echo "version=${release_version}" >> "$GITHUB_OUTPUT"
-            echo "runtime_version=${release_version}" >> "$GITHUB_OUTPUT"
-            echo "channel=${channel}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=dev-${cargo_version}-${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
-            echo "runtime_version=${cargo_version}" >> "$GITHUB_OUTPUT"
-            echo "channel=development" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Resolve image tags
         id: tags
         env:
-          VERSION: ${{ steps.version.outputs.version }}
-          CHANNEL: ${{ steps.version.outputs.channel }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+          CHANNEL: ${{ needs.resolve-version.outputs.channel }}
+          UPDATE_CHANNEL_TAGS: ${{ needs.resolve-version.outputs.update_channel_tags }}
           VARIANT: ${{ matrix.variant }}
           SUFFIX: ${{ matrix.suffix }}
         run: |
@@ -99,12 +103,12 @@ jobs:
           {
             echo "tags<<EOF"
             echo "${image}:${VERSION}-${SUFFIX}"
-            if [ "${CHANNEL}" = "stable" ]; then
+            if [ "${UPDATE_CHANNEL_TAGS}" = "true" ] && [ "${CHANNEL}" = "stable" ]; then
               echo "${image}:latest-${SUFFIX}"
               if [ "${VARIANT}" = "cpu" ]; then
                 echo "${image}:latest"
               fi
-            elif [ "${CHANNEL}" = "beta" ]; then
+            elif [ "${UPDATE_CHANNEL_TAGS}" = "true" ] && [ "${CHANNEL}" = "beta" ]; then
               echo "${image}:beta-${SUFFIX}"
               if [ "${VARIANT}" = "cpu" ]; then
                 echo "${image}:beta"
@@ -134,7 +138,7 @@ jobs:
           push: true
           platforms: ${{ matrix.platforms }}
           build-args: |
-            KAPSL_VERSION=${{ steps.version.outputs.runtime_version }}
+            KAPSL_VERSION=${{ needs.resolve-version.outputs.runtime_version }}
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -26,7 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        # ubuntu-22.04 (not ubuntu-latest) so the linux-x86_64 binary links
+        # against glibc 2.35 instead of 24.04's 2.39 — ubuntu-latest moved to
+        # 24.04 and the resulting binary refused to run on 22.04 and other
+        # still-supported distros with older glibc.
+        os: [ubuntu-22.04, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -7,20 +7,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the pre-built kapsl binary, pinned to KAPSL_VERSION so this layer
-# cache-busts per release. Retry because runtime artifacts and container builds
-# are published by separate tag-triggered workflows.
+# Install the pre-built kapsl bundle from the matching GitHub Release. The
+# release-asset path stays reachable from GitHub-hosted container builders even
+# when the public download-domain WAF rejects their shared runner addresses.
+COPY docker/install-release-assets.sh /tmp/install-release-assets.sh
 ARG KAPSL_VERSION
 RUN set -eux; \
     test -n "${KAPSL_VERSION}"; \
-    attempt=1; \
-    until curl -fsSL https://downloads.kapsl.net/install.sh \
-        | KAPSL_VERSION="${KAPSL_VERSION}" KAPSL_INSTALL_DIR=/usr/local/bin \
-          sh -s -- --version "${KAPSL_VERSION}" --install-dir /usr/local/bin; do \
-        if [ "${attempt}" -ge 20 ]; then exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        sleep 15; \
-    done; \
+    KAPSL_VERSION="${KAPSL_VERSION}" \
+        sh /tmp/install-release-assets.sh cpu; \
+    rm /tmp/install-release-assets.sh; \
     kapsl --version; \
     test ! -e /usr/local/bin/libonnxruntime_providers_cuda.so; \
     test ! -e /usr/local/bin/libonnxruntime_providers_tensorrt.so; \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -7,22 +7,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the pre-built kapsl binary, pinned to KAPSL_VERSION so this layer
-# cache-busts per release. Retry because runtime artifacts and container builds
-# are published by separate tag-triggered workflows.
+# Install the pre-built runtime and CUDA provider pack from the matching GitHub
+# Release, pinned to KAPSL_VERSION so this layer cache-busts per release.
+COPY docker/install-release-assets.sh /tmp/install-release-assets.sh
 ARG KAPSL_VERSION
 RUN set -eux; \
     test -n "${KAPSL_VERSION}"; \
-    attempt=1; \
-    until curl -fsSL https://downloads.kapsl.net/install.sh \
-        | KAPSL_VERSION="${KAPSL_VERSION}" KAPSL_INSTALL_DIR=/usr/local/bin \
-          KAPSL_ACCELERATOR=cuda \
-          sh -s -- --version "${KAPSL_VERSION}" --install-dir /usr/local/bin \
-          --accelerator cuda; do \
-        if [ "${attempt}" -ge 20 ]; then exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        sleep 15; \
-    done; \
+    KAPSL_VERSION="${KAPSL_VERSION}" \
+        sh /tmp/install-release-assets.sh cuda; \
+    rm /tmp/install-release-assets.sh; \
     kapsl --version; \
     test -f /usr/local/bin/kapsl-provider-cuda12.json; \
     test -f /usr/local/bin/libonnxruntime_providers_cuda.so; \

--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -25,18 +25,12 @@ RUN echo "/opt/kapsl/tensorrt-package/tensorrt_libs" > /etc/ld.so.conf.d/kapsl-t
     && test -e /opt/kapsl/tensorrt-package/tensorrt_libs/libnvonnxparser.so.10
 
 ARG KAPSL_VERSION
+COPY docker/install-release-assets.sh /tmp/install-release-assets.sh
 RUN set -eux; \
     test -n "${KAPSL_VERSION}"; \
-    attempt=1; \
-    until curl -fsSL https://downloads.kapsl.net/install.sh \
-        | KAPSL_VERSION="${KAPSL_VERSION}" KAPSL_INSTALL_DIR=/usr/local/bin \
-          KAPSL_ACCELERATOR=tensorrt \
-          sh -s -- --version "${KAPSL_VERSION}" --install-dir /usr/local/bin \
-          --accelerator tensorrt; do \
-        if [ "${attempt}" -ge 20 ]; then exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        sleep 15; \
-    done; \
+    KAPSL_VERSION="${KAPSL_VERSION}" \
+        sh /tmp/install-release-assets.sh tensorrt; \
+    rm /tmp/install-release-assets.sh; \
     kapsl --version; \
     test -f /usr/local/bin/kapsl-provider-cuda12.json; \
     test -f /usr/local/bin/kapsl-provider-tensorrt10.json; \

--- a/docker/install-release-assets.sh
+++ b/docker/install-release-assets.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -eu
+
+: "${KAPSL_VERSION:?KAPSL_VERSION is required}"
+
+accelerator="${1:-cpu}"
+install_dir="${KAPSL_INSTALL_DIR:-/usr/local/bin}"
+release_base="${KAPSL_RELEASE_BASE_URL:-https://github.com/kapsl-runtime/kapsl-engine/releases/download/v${KAPSL_VERSION}}"
+
+case "$(uname -m)" in
+    x86_64 | amd64)
+        platform="linux-x86_64"
+        ;;
+    aarch64 | arm64)
+        platform="linux-aarch64"
+        ;;
+    *)
+        echo "Unsupported container architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+case "$accelerator" in
+    cpu) ;;
+    cuda | tensorrt)
+        if [ "$platform" != "linux-x86_64" ]; then
+            echo "${accelerator} images are supported only on Linux x86_64." >&2
+            exit 1
+        fi
+        ;;
+    *)
+        echo "Unsupported accelerator: ${accelerator}" >&2
+        exit 1
+        ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+download() {
+    url="$1"
+    destination="$2"
+    curl -fL \
+        --connect-timeout 30 \
+        --retry 10 \
+        --retry-all-errors \
+        --retry-delay 5 \
+        "$url" \
+        -o "$destination"
+}
+
+download_verified_asset() {
+    asset_name="$1"
+    asset_path="${tmp_dir}/${asset_name}"
+    checksum_path="${asset_path}.sha256"
+
+    download "${release_base}/${asset_name}" "$asset_path"
+    download "${release_base}/${asset_name}.sha256" "$checksum_path"
+    expected_checksum="$(awk '{print $1}' "$checksum_path")"
+    actual_checksum="$(sha256sum "$asset_path" | awk '{print $1}')"
+    if [ "$actual_checksum" != "$expected_checksum" ]; then
+        echo "Checksum mismatch for ${asset_name}" >&2
+        exit 1
+    fi
+}
+
+extract_asset() {
+    asset_name="$1"
+    download_verified_asset "$asset_name"
+    tar -xzf "${tmp_dir}/${asset_name}" -C "$install_dir"
+}
+
+mkdir -p "$install_dir"
+
+runtime_asset="kapsl-${KAPSL_VERSION}-${platform}.tar.gz"
+extract_asset "$runtime_asset"
+
+case "$accelerator" in
+    cuda | tensorrt)
+        extract_asset "kapsl-provider-cuda12-${KAPSL_VERSION}-${platform}.tar.gz"
+        ;;
+esac
+
+if [ "$accelerator" = "tensorrt" ]; then
+    extract_asset "kapsl-provider-tensorrt10-${KAPSL_VERSION}-${platform}.tar.gz"
+fi
+
+chmod +x "${install_dir}/kapsl"

--- a/docker/resolve-release-version.sh
+++ b/docker/resolve-release-version.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+set -eu
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+cargo_version="$(grep -m1 '^version = ' kapsl-runtime/crates/kapsl-cli/Cargo.toml | cut -d '"' -f2)"
+ref_type="${GITHUB_REF_TYPE:-}"
+ref_name="${GITHUB_REF_NAME:-}"
+dispatch_release_version="${DISPATCH_RELEASE_VERSION:-}"
+dispatch_update_channel_tags="${DISPATCH_UPDATE_CHANNEL_TAGS:-false}"
+
+if [ "${ref_type}" = "tag" ]; then
+    release_version="${ref_name#v}"
+    update_channel_tags=true
+elif [ -n "${dispatch_release_version}" ]; then
+    release_version="${dispatch_release_version#v}"
+    update_channel_tags="${dispatch_update_channel_tags}"
+else
+    : "${GITHUB_SHA:?GITHUB_SHA is required for development images}"
+    short_sha="$(printf '%.8s' "${GITHUB_SHA}")"
+    echo "version=dev-${cargo_version}-${short_sha}" >> "${GITHUB_OUTPUT}"
+    echo "runtime_version=${cargo_version}" >> "${GITHUB_OUTPUT}"
+    echo "channel=development" >> "${GITHUB_OUTPUT}"
+    echo "update_channel_tags=false" >> "${GITHUB_OUTPUT}"
+    echo "wait_for_assets=false" >> "${GITHUB_OUTPUT}"
+    exit 0
+fi
+
+case "${release_version}" in
+    [0-9]*) ;;
+    *)
+        echo "Release version must start with a number: ${release_version}" >&2
+        exit 1
+        ;;
+esac
+case "${release_version}" in
+    *[!0-9A-Za-z._-]*)
+        echo "Release version contains unsupported characters: ${release_version}" >&2
+        exit 1
+        ;;
+esac
+
+case "${update_channel_tags}" in
+    true | false) ;;
+    *)
+        echo "Channel tag option must be true or false: ${update_channel_tags}" >&2
+        exit 1
+        ;;
+esac
+
+channel=stable
+case "${release_version}" in
+    *-beta*) channel=beta ;;
+    *-*) channel=prerelease ;;
+esac
+
+echo "version=${release_version}" >> "${GITHUB_OUTPUT}"
+echo "runtime_version=${release_version}" >> "${GITHUB_OUTPUT}"
+echo "channel=${channel}" >> "${GITHUB_OUTPUT}"
+echo "update_channel_tags=${update_channel_tags}" >> "${GITHUB_OUTPUT}"
+echo "wait_for_assets=true" >> "${GITHUB_OUTPUT}"

--- a/docker/test-release-scripts.sh
+++ b/docker/test-release-scripts.sh
@@ -1,0 +1,158 @@
+#!/bin/sh
+set -eu
+
+version="9.9.9"
+test_root="$(mktemp -d)"
+release_dir="${test_root}/release"
+payload_dir="${test_root}/payload"
+server_log="${test_root}/http-server.log"
+server_pid=""
+base_url="http://127.0.0.1:18080"
+
+cleanup() {
+    if [ -n "${server_pid}" ]; then
+        kill "${server_pid}" 2>/dev/null || true
+        wait "${server_pid}" 2>/dev/null || true
+    fi
+    rm -rf "${test_root}"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "${release_dir}" "${payload_dir}"
+cat > "${payload_dir}/kapsl" <<'EOF'
+#!/bin/sh
+echo "kapsl release-script test"
+EOF
+chmod +x "${payload_dir}/kapsl"
+
+assert_output() {
+    expected_line="$1"
+    output_file="$2"
+    if ! grep -qx "${expected_line}" "${output_file}"; then
+        echo "Missing expected resolver output '${expected_line}' in ${output_file}:" >&2
+        cat "${output_file}" >&2
+        exit 1
+    fi
+}
+
+tag_output="${test_root}/tag-output"
+GITHUB_OUTPUT="${tag_output}" \
+GITHUB_REF_TYPE=tag \
+GITHUB_REF_NAME=v1.2.3 \
+GITHUB_SHA=1234567890abcdef \
+    docker/resolve-release-version.sh
+assert_output "version=1.2.3" "${tag_output}"
+assert_output "channel=stable" "${tag_output}"
+assert_output "update_channel_tags=true" "${tag_output}"
+assert_output "wait_for_assets=true" "${tag_output}"
+
+dispatch_output="${test_root}/dispatch-output"
+GITHUB_OUTPUT="${dispatch_output}" \
+GITHUB_REF_TYPE=branch \
+GITHUB_REF_NAME=main \
+GITHUB_SHA=1234567890abcdef \
+DISPATCH_RELEASE_VERSION=v1.2.3-beta.1 \
+DISPATCH_UPDATE_CHANNEL_TAGS=false \
+    docker/resolve-release-version.sh
+assert_output "version=1.2.3-beta.1" "${dispatch_output}"
+assert_output "channel=beta" "${dispatch_output}"
+assert_output "update_channel_tags=false" "${dispatch_output}"
+assert_output "wait_for_assets=true" "${dispatch_output}"
+
+development_output="${test_root}/development-output"
+cargo_version="$(grep -m1 '^version = ' kapsl-runtime/crates/kapsl-cli/Cargo.toml | cut -d '"' -f2)"
+GITHUB_OUTPUT="${development_output}" \
+GITHUB_REF_TYPE=branch \
+GITHUB_REF_NAME=main \
+GITHUB_SHA=1234567890abcdef \
+    docker/resolve-release-version.sh
+assert_output "version=dev-${cargo_version}-12345678" "${development_output}"
+assert_output "runtime_version=${cargo_version}" "${development_output}"
+assert_output "channel=development" "${development_output}"
+assert_output "wait_for_assets=false" "${development_output}"
+
+if GITHUB_OUTPUT="${test_root}/invalid-output" \
+    GITHUB_REF_TYPE=branch \
+    GITHUB_REF_NAME=main \
+    GITHUB_SHA=1234567890abcdef \
+    DISPATCH_RELEASE_VERSION='1.2.3;invalid' \
+    docker/resolve-release-version.sh; then
+    echo "Version resolver unexpectedly accepted an unsafe release version." >&2
+    exit 1
+fi
+
+assets="
+kapsl-${version}-linux-x86_64.tar.gz
+kapsl-${version}-linux-aarch64.tar.gz
+kapsl-provider-cuda12-${version}-linux-x86_64.tar.gz
+kapsl-provider-tensorrt10-${version}-linux-x86_64.tar.gz
+"
+
+for asset in ${assets}; do
+    tar -czf "${release_dir}/${asset}" -C "${payload_dir}" kapsl
+    sha256sum "${release_dir}/${asset}" > "${release_dir}/${asset}.sha256"
+done
+
+python3 -m http.server 18080 \
+    --bind 127.0.0.1 \
+    --directory "${release_dir}" \
+    >"${server_log}" 2>&1 &
+server_pid="$!"
+
+attempt=1
+while ! curl -fsSLI "${base_url}/kapsl-${version}-linux-x86_64.tar.gz" >/dev/null; do
+    if [ "${attempt}" -ge 20 ]; then
+        cat "${server_log}" >&2
+        echo "Timed out waiting for test HTTP server." >&2
+        exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+KAPSL_VERSION="${version}" \
+KAPSL_RELEASE_BASE_URL="${base_url}" \
+KAPSL_WAIT_ATTEMPTS=1 \
+KAPSL_WAIT_DELAY_SECONDS=0 \
+    docker/wait-for-release-assets.sh
+
+rm "${release_dir}/kapsl-provider-tensorrt10-${version}-linux-x86_64.tar.gz.sha256"
+if KAPSL_VERSION="${version}" \
+    KAPSL_RELEASE_BASE_URL="${base_url}" \
+    KAPSL_WAIT_ATTEMPTS=1 \
+    KAPSL_WAIT_DELAY_SECONDS=0 \
+    docker/wait-for-release-assets.sh; then
+    echo "Asset readiness check unexpectedly accepted an incomplete release." >&2
+    exit 1
+fi
+
+sha256sum \
+    "${release_dir}/kapsl-provider-tensorrt10-${version}-linux-x86_64.tar.gz" \
+    >"${release_dir}/kapsl-provider-tensorrt10-${version}-linux-x86_64.tar.gz.sha256"
+
+install_dir="${test_root}/install"
+KAPSL_VERSION="${version}" \
+KAPSL_RELEASE_BASE_URL="${base_url}" \
+KAPSL_INSTALL_DIR="${install_dir}" \
+    sh docker/install-release-assets.sh cpu
+"${install_dir}/kapsl"
+
+case "$(uname -m)" in
+    x86_64 | amd64) runtime_platform="linux-x86_64" ;;
+    aarch64 | arm64) runtime_platform="linux-aarch64" ;;
+    *)
+        echo "Unsupported test architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+printf 'corrupt' >> "${release_dir}/kapsl-${version}-${runtime_platform}.tar.gz"
+if KAPSL_VERSION="${version}" \
+    KAPSL_RELEASE_BASE_URL="${base_url}" \
+    KAPSL_INSTALL_DIR="${test_root}/corrupt-install" \
+    sh docker/install-release-assets.sh cpu; then
+    echo "Installer unexpectedly accepted a checksum mismatch." >&2
+    exit 1
+fi
+
+echo "Release asset scripts passed."

--- a/docker/wait-for-release-assets.sh
+++ b/docker/wait-for-release-assets.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+: "${KAPSL_VERSION:?KAPSL_VERSION is required}"
+
+release_base="${KAPSL_RELEASE_BASE_URL:-https://github.com/kapsl-runtime/kapsl-engine/releases/download/v${KAPSL_VERSION}}"
+max_attempts="${KAPSL_WAIT_ATTEMPTS:-180}"
+retry_delay="${KAPSL_WAIT_DELAY_SECONDS:-10}"
+
+case "${max_attempts}" in
+    *[!0-9]* | 0 | "")
+        echo "KAPSL_WAIT_ATTEMPTS must be a positive integer." >&2
+        exit 1
+        ;;
+esac
+
+case "${retry_delay}" in
+    *[!0-9]* | "")
+        echo "KAPSL_WAIT_DELAY_SECONDS must be a non-negative integer." >&2
+        exit 1
+        ;;
+esac
+
+assets="
+kapsl-${KAPSL_VERSION}-linux-x86_64.tar.gz
+kapsl-${KAPSL_VERSION}-linux-aarch64.tar.gz
+kapsl-provider-cuda12-${KAPSL_VERSION}-linux-x86_64.tar.gz
+kapsl-provider-tensorrt10-${KAPSL_VERSION}-linux-x86_64.tar.gz
+"
+
+attempt=1
+while [ "${attempt}" -le "${max_attempts}" ]; do
+    missing_assets=""
+
+    for asset in ${assets}; do
+        for required_file in "${asset}" "${asset}.sha256"; do
+            if ! curl -fsSLI --connect-timeout 30 "${release_base}/${required_file}" >/dev/null; then
+                missing_assets="${missing_assets} ${required_file}"
+            fi
+        done
+    done
+
+    if [ -z "${missing_assets}" ]; then
+        echo "All runtime and provider release assets are available for ${KAPSL_VERSION}."
+        exit 0
+    fi
+
+    echo "Release assets are not complete (attempt ${attempt}/${max_attempts}):${missing_assets}"
+    if [ "${attempt}" -lt "${max_attempts}" ]; then
+        sleep "${retry_delay}"
+    fi
+    attempt=$((attempt + 1))
+done
+
+echo "Timed out waiting for complete release assets for ${KAPSL_VERSION}." >&2
+exit 1


### PR DESCRIPTION
## Summary
- Split CPU/CUDA/TensorRT docker images cleanly by accelerator, with retrying in-image installs since the docker-image and runtime-installer release workflows are separate tag-triggered jobs that can finish in either order.
- Build the released linux-x86_64 binary on `ubuntu-22.04` instead of `ubuntu-latest`: GitHub moved `ubuntu-latest` to 24.04 (glibc 2.39), which broke v0.1.19's installer on Ubuntu 22.04 and other still-supported distros with older glibc (`GLIBC_2.38/2.39 not found`).
- Already merged into `main` via #93; this brings `develop` up to date with the same fix.

## Test plan
- [x] Reproduced the original bug on a fresh Ubuntu 22.04 GPU box (vast.ai): v0.1.19 installer binary failed with `GLIBC_2.38/2.39 not found`.
- [x] Triggered the Release Runtime Installers workflow on this branch, downloaded the resulting linux-x86_64 binary, confirmed max required glibc symbol dropped from 2.39 to 2.34.
- [x] Ran the new binary on a fresh Ubuntu 22.04 box: `kapsl --version` succeeds, `kapsl run` loads a model and serves a healthy `/api/health`.
- [x] Verified installer + docker images (CPU/CUDA) on macOS, fresh Linux/x86_64 GPU, and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)