### PR TITLE
build: bump runtime version to 0.1.20

### DIFF
--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -26,11 +26,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-22.04 (not ubuntu-latest) so the linux-x86_64 binary links
-        # against glibc 2.35 instead of 24.04's 2.39 — ubuntu-latest moved to
-        # 24.04 and the resulting binary refused to run on 22.04 and other
-        # still-supported distros with older glibc.
-        os: [ubuntu-22.04, ubuntu-24.04-arm, macos-latest, windows-latest]
+        # Build both Linux binaries on 22.04 runners so they link against
+        # glibc 2.35 rather than 24.04's 2.39. A 2.39-linked binary refuses to
+        # start on 22.04 and other still-supported distros with older glibc.
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -26,10 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build both Linux binaries on 22.04 runners so they link against
-        # glibc 2.35 rather than 24.04's 2.39. A 2.39-linked binary refuses to
-        # start on 22.04 and other still-supported distros with older glibc.
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-latest, windows-latest]
+        # ubuntu-22.04 (not ubuntu-latest) so the linux-x86_64 binary links
+        # against glibc 2.35 instead of 24.04's 2.39 — ubuntu-latest moved to
+        # 24.04 and the resulting binary refused to run on 22.04 and other
+        # still-supported distros with older glibc.
+        os: [ubuntu-22.04, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
## Summary
- Bumps the runtime CLI version to 0.1.20 to cut a release carrying the ubuntu-22.04 glibc-compatibility fix from #93.
- v0.1.19's linux-x86_64 installer binary was built on `ubuntu-latest` (Ubuntu 24.04, glibc 2.39) and refused to run on Ubuntu 22.04 and other still-supported distros. #93 (merged) fixed the CI runner; this bump is required to actually publish a fixed build, since v0.1.19's R2 assets are immutable and won't be overwritten by re-running CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)