### PR TITLE
Install Hub extensions from the Kapsl CLI

### DIFF
--- a/docs/kapsl-cli-quickstart.md
+++ b/docs/kapsl-cli-quickstart.md
@@ -201,10 +201,21 @@ curl http://127.0.0.1:9095/api/models \
 
 If auth is disabled, API is loopback-only by default.
 
-## Extensions (via Runtime API)
+## Extensions
 
-`kapsl` CLI does not have dedicated extension subcommands.  
-Use the runtime API endpoints for extension lifecycle operations.
+Install an extension from Kapsl Hub into a running local engine:
+
+```bash
+kapsl extension install connector.echo
+```
+
+If runtime API authentication is enabled:
+
+```bash
+kapsl extension install connector.echo --auth-token "$KAPSL_API_TOKEN"
+```
+
+The runtime API remains available for the rest of the extension lifecycle.
 
 List installed extensions:
 

--- a/docs/kapsl-cli-user-guide.md
+++ b/docs/kapsl-cli-user-guide.md
@@ -416,10 +416,21 @@ curl http://127.0.0.1:9095/api/models \
 
 If auth is disabled, API access is loopback-only by default.
 
-## Extensions (via Runtime API)
+## Extensions
 
-`kapsl` CLI does not expose dedicated extension subcommands today.
-Use runtime API endpoints for extension lifecycle tasks.
+Install an extension from Kapsl Hub into a running local engine:
+
+```bash
+kapsl extension install connector.echo
+```
+
+If runtime API authentication is enabled:
+
+```bash
+kapsl extension install connector.echo --auth-token "$KAPSL_API_TOKEN"
+```
+
+Use runtime API endpoints for the rest of the extension lifecycle tasks.
 
 List installed extensions:
 

--- a/kapsl-runtime/FULL_DOCUMENTATION.md
+++ b/kapsl-runtime/FULL_DOCUMENTATION.md
@@ -86,6 +86,7 @@ Defaults:
 - `kapsl push ...`
 - `kapsl pull ...`
 - `kapsl login ...`
+- `kapsl extension install ...`
 - `kapsl control ...`
 - `kapsl --model ...` (legacy compatibility for `run`)
 
@@ -222,7 +223,19 @@ Flags:
 
 Credentials are stored in `~/.kapsl/tokens.json` (path overridable via `KAPSL_REMOTE_TOKEN_STORE_PATH`).
 
-### 4.5 Control Command
+### 4.5 Extension Command
+
+Install a marketplace extension into a running local engine:
+
+```bash
+kapsl extension install connector.s3
+```
+
+Use `--http-url`, `--http-host`, or `--http-port` to select another engine endpoint.
+If runtime authentication is enabled, pass its writer or admin token with `--auth-token`.
+Use `--marketplace-url` to override the Kapsl Hub marketplace endpoint.
+
+### 4.6 Control Command
 
 `kapsl control` runs a multi-runtime control loop that orchestrates cross-runtime weight distribution and scaling policy based on observed pressure and GPU utilization.
 

--- a/kapsl-runtime/crates/kapsl-cli/src/app/cli.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/app/cli.rs
@@ -144,6 +144,8 @@ pub(crate) enum KapslCommand {
     Pull(PullCommandArgs),
     /// Log in to a remote registry and save credentials locally
     Login(LoginCommandArgs),
+    /// Manage extensions in a running Kapsl Engine
+    Extension(ExtensionCommandArgs),
     /// Install optional hardware acceleration support
     Provider(ProviderCommandArgs),
     /// Hot-load a model into an already-running runtime (no restart required)
@@ -686,6 +688,50 @@ pub(crate) struct AddModelCommandArgs {
     pub(crate) tp_degree: usize,
 
     /// HTTP request timeout (ms) for the load call — large models may take longer to respond
+    #[arg(long, default_value_t = 30000, value_name = "MS")]
+    pub(crate) timeout_ms: u64,
+}
+
+#[derive(clap::Args, Debug)]
+pub(crate) struct ExtensionCommandArgs {
+    #[command(subcommand)]
+    pub(crate) command: ExtensionSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum ExtensionSubcommand {
+    /// Download and install an extension from Kapsl Hub
+    Install(ExtensionInstallCommandArgs),
+}
+
+#[derive(clap::Args, Debug)]
+#[command(next_help_heading = "Extension Install Options")]
+pub(crate) struct ExtensionInstallCommandArgs {
+    /// Marketplace extension ID (for example connector.s3)
+    #[arg(value_name = "EXTENSION_ID")]
+    pub(crate) extension_id: String,
+
+    /// HTTP port of the running runtime's API server
+    #[arg(long, default_value_t = 9095, value_name = "PORT")]
+    pub(crate) http_port: u16,
+
+    /// Hostname or IP of the running runtime's API server
+    #[arg(long, default_value = "127.0.0.1", value_name = "HOST")]
+    pub(crate) http_host: String,
+
+    /// Full base URL of the running runtime (overrides --http-host / --http-port)
+    #[arg(long, value_name = "URL")]
+    pub(crate) http_url: Option<String>,
+
+    /// Bearer token if the runtime has API authentication enabled
+    #[arg(long, value_name = "TOKEN")]
+    pub(crate) auth_token: Option<String>,
+
+    /// Override the Kapsl Hub marketplace endpoint
+    #[arg(long, value_name = "URL")]
+    pub(crate) marketplace_url: Option<String>,
+
+    /// HTTP request timeout (ms)
     #[arg(long, default_value_t = 30000, value_name = "MS")]
     pub(crate) timeout_ms: u64,
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/features/extensions.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/features/extensions.rs
@@ -199,3 +199,119 @@ pub(crate) fn install_extension_from_marketplace(
     let _ = fs::remove_dir_all(&temp_dir);
     install_result
 }
+
+pub(crate) fn execute_extension_command(args: ExtensionCommandArgs) -> Result<(), DynError> {
+    match args.command {
+        ExtensionSubcommand::Install(args) => execute_extension_install_command(args),
+    }
+}
+
+fn execute_extension_install_command(args: ExtensionInstallCommandArgs) -> Result<(), DynError> {
+    let extension_id = args.extension_id.trim();
+    if !is_valid_extension_id(extension_id) {
+        return Err(dyn_error_from_message(format!(
+            "Invalid extension ID `{}`. Use letters, numbers, dots, underscores, or hyphens.",
+            args.extension_id
+        )));
+    }
+
+    let base_url = match &args.http_url {
+        Some(url) => url.trim_end_matches('/').to_string(),
+        None => format!("http://{}:{}", args.http_host, args.http_port),
+    };
+    let install_url = format!("{}/api/extensions/install", base_url);
+    let timeout = std::time::Duration::from_millis(args.timeout_ms.max(1));
+    let agent_config = ureq::Agent::config_builder()
+        .timeout_global(Some(timeout))
+        .timeout_per_call(Some(timeout))
+        .build();
+    let agent: ureq::Agent = agent_config.into();
+
+    let mut payload = serde_json::json!({ "extension_id": extension_id });
+    if let Some(marketplace_url) = args.marketplace_url.as_deref() {
+        let marketplace_url = marketplace_url.trim();
+        if !marketplace_url.is_empty() {
+            payload["marketplace_url"] = serde_json::Value::String(marketplace_url.to_string());
+        }
+    }
+    let payload = serde_json::to_string(&payload)
+        .map_err(|e| dyn_error_from_message(format!("Failed to serialize request: {}", e)))?;
+
+    let mut request = agent
+        .post(&install_url)
+        .header("Content-Type", "application/json");
+    if let Some(token) = args.auth_token.as_deref() {
+        let token = token.trim();
+        if !token.is_empty() {
+            request = request.header("Authorization", &format!("Bearer {}", token));
+        }
+    }
+
+    let mut response = request.send(payload).map_err(|error| {
+        dyn_error_from_message(format!(
+            "Kapsl Engine could not install `{}` via {}: {}",
+            extension_id,
+            install_url,
+            format_remote_http_error(error)
+        ))
+    })?;
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .unwrap_or_else(|_| String::new());
+    let installed = serde_json::from_str::<serde_json::Value>(&body).unwrap_or_default();
+    let manifest = installed
+        .get("extension")
+        .and_then(|extension| extension.get("manifest"));
+    let display_name = manifest
+        .and_then(|manifest| manifest.get("name"))
+        .and_then(|name| name.as_str())
+        .unwrap_or(extension_id);
+    let version = manifest
+        .and_then(|manifest| manifest.get("version"))
+        .and_then(|version| version.as_str());
+
+    let a = Ansi::new();
+    eprintln!();
+    eprintln!(
+        "  {}  {}{}",
+        a.green("✓"),
+        a.bold(display_name),
+        version
+            .map(|version| format!(" {}", a.dim(&format!("v{}", version))))
+            .unwrap_or_default()
+    );
+    eprintln!("     {}", a.dim("Installed in the running Kapsl Engine"));
+    eprintln!();
+    Ok(())
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn extension_install_command_parses_hub_extension_id() {
+        let cli = Cli::try_parse_from([
+            "kapsl",
+            "extension",
+            "install",
+            "connector.s3",
+            "--http-port",
+            "9195",
+        ])
+        .expect("parse extension install command");
+
+        assert!(matches!(
+            cli.command,
+            Some(KapslCommand::Extension(ExtensionCommandArgs {
+                command: ExtensionSubcommand::Install(ExtensionInstallCommandArgs {
+                    extension_id,
+                    http_port: 9195,
+                    ..
+                })
+            })) if extension_id == "connector.s3"
+        ));
+    }
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/main.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/main.rs
@@ -98,6 +98,7 @@ async fn main() -> Result<(), DynError> {
         Some(KapslCommand::Push(args)) => return execute_push_command(args),
         Some(KapslCommand::Pull(args)) => return execute_pull_command(args),
         Some(KapslCommand::Login(args)) => return execute_login_command(args),
+        Some(KapslCommand::Extension(args)) => return execute_extension_command(args),
         Some(KapslCommand::Provider(args)) => return execute_provider_command(args),
         Some(KapslCommand::AddModel(args)) => return execute_add_model_command(args),
         Some(KapslCommand::Run(_)) | None => {}


### PR DESCRIPTION
## Summary
- add kapsl extension install for installing marketplace extensions into a running engine
- support local engine URL, authentication token, marketplace override, and timeout options
- document the Kapsl Hub extension workflow

## Validation
- cargo test --manifest-path kapsl-runtime/Cargo.toml -p kapsl extension_install_command_parses_hub_extension_id
- cargo build --manifest-path kapsl-runtime/Cargo.toml -p kapsl
- rustfmt checks for changed Rust sources
- git diff --check