### PR TITLE
fix(deps): bump kapsl-sdk pin to pull in lru 0.16 (RUSTSEC-2026-0002)

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -1492,6 +1492,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2048,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "kapsl-backends"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2078,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "kapsl-core"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "flate2",
  "fs2",
@@ -2098,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "kapsl-engine-api"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2110,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "kapsl-hal"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "cudarc",
  "half",
@@ -2124,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "kapsl-ipc"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2142,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "kapsl-kernels"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "cudarc",
  "half",
@@ -2155,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "kapsl-llm"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2185,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "kapsl-loader"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "half",
  "kapsl-hal",
@@ -2200,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "kapsl-monitor"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2214,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "kapsl-quantization"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "anyhow",
  "half",
@@ -2229,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2249,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag-sdk"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -2261,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "kapsl-scheduler"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2280,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "kapsl-shm"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2301,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "kapsl-transport"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2393,7 +2395,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2406,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=2e2e4d93fdaf54dcc2e85b39e78740d78454e18f#2e2e4d93fdaf54dcc2e85b39e78740d78454e18f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=28a15b4b32fd452ff170c68221792e6746e441a1#28a15b4b32fd452ff170c68221792e6746e441a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -2433,11 +2435,11 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]

--- a/kapsl-runtime/Cargo.toml
+++ b/kapsl-runtime/Cargo.toml
@@ -10,17 +10,17 @@ resolver = "2"
 
 [patch.crates-io]
 esaxx-rs = { path = "patches/esaxx-rs" }
-kapsl-backends = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-core = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-engine-api = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-hal = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-ipc = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-llm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-monitor = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-rag = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-rag-sdk = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-scheduler = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-shm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-kapsl-transport = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-llama-cpp-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
-llama-cpp-sys-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "2e2e4d93fdaf54dcc2e85b39e78740d78454e18f" }
+kapsl-backends = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-core = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-engine-api = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-hal = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-ipc = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-llm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-monitor = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-rag = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-rag-sdk = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-scheduler = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-shm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+kapsl-transport = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+llama-cpp-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }
+llama-cpp-sys-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "28a15b4b32fd452ff170c68221792e6746e441a1" }


### PR DESCRIPTION
Clears Dependabot alert [#9](https://github.com/kapsl-runtime/kapsl-engine/security/dependabot/9) — the only open alert on this repo.

## What

Bumps every `kapsl-*` / `llama-cpp-*` `[patch.crates-io]` rev from `2e2e4d9` → `28a15b4` (kapsl-sdk `develop`, the merge of kapsl-runtime/kapsl-sdk#80).

## Why

[RUSTSEC-2026-0002](https://rustsec.org/advisories/RUSTSEC-2026-0002.html) / [GHSA-rhfx-m35p-ff5j](https://github.com/advisories/GHSA-rhfx-m35p-ff5j) — `lru` `>=0.9.0, <0.16.3` has a soundness issue where `IterMut::next` / `next_back` briefly create an exclusive reference to the key, invalidating the shared pointer held by the internal `HashMap` and violating Stacked Borrows.

`lru` isn't a direct dependency here — it arrives transitively through `kapsl-backends`, so the actual fix landed in the SDK and reaches this repo through the pin.

## Blast radius

Deliberately minimal. The SDK tree diff between the old and new pinned revs is **exactly** the `lru` bump:

```
 Cargo.lock                       | 8 +++++---
 crates/kapsl-backends/Cargo.toml | 2 +-
```

and the resulting `Cargo.lock` change here is one package:

```
-lru 0.12.5
+lru 0.16.4
```

Everything else in the diff is the rev hash string across the 14 patch entries.

## Impact

Low, and not reachable in practice. `kapsl-backends`' single `lru` use site (`engine_pool.rs`) only touches `new` / `get` / `push` / `pop` / `len` / `is_empty` / `iter` — never `iter_mut`, so the unsound path was never exercised. Bumping so the advisory stops showing against the repo ahead of it going public.

## Testing

- SDK side (kapsl-runtime/kapsl-sdk#80): `cargo test -p kapsl-backends` — 109 passed / 0 failed, including the 5 `engine_pool` tests covering LRU eviction ordering and the eviction callback. Full CI green on ubuntu / macOS / windows.
- Here: lockfile re-resolved and verified locally; a full engine build needs CUDA, so **CI is the real check on this PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)