### PR TITLE
chore(deps): bump kapsl-sdk pin to drop redundant model copies

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "kapsl-backends"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "kapsl-core"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "flate2",
  "fs2",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "kapsl-engine-api"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "kapsl-hal"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "cudarc",
  "half",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "kapsl-ipc"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "kapsl-kernels"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "cudarc",
  "half",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "kapsl-llm"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2187,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "kapsl-loader"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "half",
  "kapsl-hal",
@@ -2202,7 +2202,7 @@ dependencies = [
 [[package]]
 name = "kapsl-monitor"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2216,7 +2216,7 @@ dependencies = [
 [[package]]
 name = "kapsl-quantization"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "anyhow",
  "half",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag-sdk"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "futures",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "kapsl-scheduler"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "kapsl-shm"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2303,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "kapsl-transport"
 version = "0.1.1"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2395,7 +2395,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 [[package]]
 name = "llama-cpp-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -2408,7 +2408,7 @@ dependencies = [
 [[package]]
 name = "llama-cpp-sys-2"
 version = "0.1.146"
-source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=f8462e170cc539b9aa0ff08d309f9e5d507d908a#f8462e170cc539b9aa0ff08d309f9e5d507d908a"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=0e74d8505d11469f569e5087a2b0d2ce6b50da93#0e74d8505d11469f569e5087a2b0d2ce6b50da93"
 dependencies = [
  "bindgen",
  "cc",

--- a/kapsl-runtime/Cargo.toml
+++ b/kapsl-runtime/Cargo.toml
@@ -10,17 +10,17 @@ resolver = "2"
 
 [patch.crates-io]
 esaxx-rs = { path = "patches/esaxx-rs" }
-kapsl-backends = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-core = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-engine-api = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-hal = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-ipc = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-llm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-monitor = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-rag = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-rag-sdk = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-scheduler = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-shm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-kapsl-transport = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-llama-cpp-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
-llama-cpp-sys-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "f8462e170cc539b9aa0ff08d309f9e5d507d908a" }
+kapsl-backends = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-core = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-engine-api = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-hal = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-ipc = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-llm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-monitor = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-rag = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-rag-sdk = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-scheduler = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-shm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+kapsl-transport = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+llama-cpp-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }
+llama-cpp-sys-2 = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "0e74d8505d11469f569e5087a2b0d2ce6b50da93" }


### PR DESCRIPTION
## Why

Third step of the deepseek runtime failure traced in penasys#44 → kapsl-sdk#85.

A runtime keeps the model on disk three times — the pulled `.aimod`, the archive extracted beside it, and a second copy of every extracted file in the model cache. On Cloud Run the writable layer is RAM, so all three are charged against the instance's memory: a 989 MB package measured at ~6 GB resident, and a 2.6 GB one is SIGKILLed part way through `Loading model packages`.

kapsl-sdk#85 populates the cache by hard link where the filesystem allows it (`fs::copy` remains the `EXDEV` fallback), and adds an opt-in `KAPSL_DISCARD_PACKAGE_AFTER_LOAD` that deletes the `.aimod` once its contents are cached. This bump is what carries that into the engine.

## Scope — please read before merging

**This is more than the loader fix.** The old pin `f8462e17` was not a develop commit: it was the *unsquashed branch head* of kapsl-sdk#81, whose squashed twin `a5bb8a2` is on develop. So `git log f8462e17..0e74d850` spans five commits:

| commit | change |
| --- | --- |
| `0e74d85` | loader: stop keeping the model on disk three times (#85) |
| `4a1bdee` | audio: support NeMo preprocessing inputs (#84) |
| `779595d` | link NCCL when ggml's CUDA build enables it (#83) |
| `a5bb8a2` | multi-turn chat rendering — squashed form of what was already pinned (#81) |
| `a15b681` | llm: preserve generated token boundaries (#82) |

`779595d` in particular is the NCCL link fix, so this is also the bump that carries it into the CUDA build. If you want the loader fix in isolation that needs a different rev — a cherry-pick branch on the SDK — rather than this bump.

## Verification

`cargo check --workspace` clean against the new rev (54s, default features, no CUDA). All 14 patch entries in `kapsl-runtime/Cargo.toml` moved together, plus `Cargo.lock`.

Not verified here: anything needing a GPU, and the CUDA feature build — this machine has neither.

## What still has to happen for prod to see it

`release-docker-images.yml` fires only on `workflow_dispatch` or a `v*` tag, never on merge, so publishing `ghcr.io/kapsl-runtime/kapsl-engine:latest` is a deliberate step. penasys' deploy then mirrors GHCR into Artifact Registry — and note it pins the *GPU* image to `0.1.20-cuda` while CPU tracks `:latest`, so GPU runtimes will lag unless that tag moves too. Only after that does penasys set `KAPSL_DISCARD_PACKAGE_AFTER_LOAD=1` and re-measure before lowering `ModelMemoryMultiplier` from 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)