### PR TITLE
fix(packaging): register the provider directory from the Debian package

### DIFF
--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -132,11 +132,17 @@ jobs:
       - name: Package Debian installer (.deb)
         if: runner.os == 'Linux'
         run: |
-          mkdir -p dist pkgroot/DEBIAN pkgroot/usr/local/bin
+          mkdir -p dist pkgroot/DEBIAN pkgroot/usr/local/bin pkgroot/etc/ld.so.conf.d
           install -m 755 kapsl-runtime/target/release/kapsl pkgroot/usr/local/bin/kapsl
           if [ -d ort-core-libs ]; then
             cp -L ort-core-libs/* pkgroot/usr/local/bin/ 2>/dev/null || true
           fi
+
+          # ONNX Runtime dlopen()s libonnxruntime_providers_shared.so by bare
+          # name, and /usr/local/bin is not a loader search path. Without this
+          # the accelerator packs register no provider and the runtime serves
+          # every request from the CPU while holding the GPU.
+          echo "/usr/local/bin" > pkgroot/etc/ld.so.conf.d/kapsl-runtime.conf
 
           arch="$(dpkg --print-architecture)"
 
@@ -149,6 +155,17 @@ jobs:
             echo "Maintainer: Kapsl Team <support@kapsl.ai>"
             echo "Description: Kapsl runtime CLI and local inference server (beta)."
           } > pkgroot/DEBIAN/control
+
+          # The conf file only takes effect once the cache is rebuilt, and dpkg
+          # triggers ldconfig on its own only for standard library directories.
+          for script in postinst postrm; do
+            {
+              echo "#!/bin/sh"
+              echo "set -e"
+              echo "ldconfig"
+            } > "pkgroot/DEBIAN/${script}"
+            chmod 755 "pkgroot/DEBIAN/${script}"
+          done
 
           deb_path="dist/kapsl-runtime_${KAPSL_DEB_VERSION}_${arch}.deb"
           dpkg-deb --build pkgroot "${deb_path}"

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -150,11 +150,17 @@ jobs:
       - name: Package Debian installer (.deb)
         if: runner.os == 'Linux'
         run: |
-          mkdir -p dist pkgroot/DEBIAN pkgroot/usr/local/bin
+          mkdir -p dist pkgroot/DEBIAN pkgroot/usr/local/bin pkgroot/etc/ld.so.conf.d
           install -m 755 kapsl-runtime/target/release/kapsl pkgroot/usr/local/bin/kapsl
           if [ -d ort-core-libs ]; then
             cp -L ort-core-libs/* pkgroot/usr/local/bin/ 2>/dev/null || true
           fi
+
+          # ONNX Runtime dlopen()s libonnxruntime_providers_shared.so by bare
+          # name, and /usr/local/bin is not a loader search path. Without this
+          # the accelerator packs register no provider and the runtime serves
+          # every request from the CPU while holding the GPU.
+          echo "/usr/local/bin" > pkgroot/etc/ld.so.conf.d/kapsl-runtime.conf
 
           arch="$(dpkg --print-architecture)"
 
@@ -167,6 +173,17 @@ jobs:
             echo "Maintainer: Kapsl Team <support@kapsl.ai>"
             echo "Description: Kapsl runtime CLI and local inference server."
           } > pkgroot/DEBIAN/control
+
+          # The conf file only takes effect once the cache is rebuilt, and dpkg
+          # triggers ldconfig on its own only for standard library directories.
+          for script in postinst postrm; do
+            {
+              echo "#!/bin/sh"
+              echo "set -e"
+              echo "ldconfig"
+            } > "pkgroot/DEBIAN/${script}"
+            chmod 755 "pkgroot/DEBIAN/${script}"
+          done
 
           deb_path="dist/kapsl-runtime_${KAPSL_DEB_VERSION}_${arch}.deb"
           dpkg-deb --build pkgroot "${deb_path}"


### PR DESCRIPTION
## The gap

Found while verifying #104 on an L4. The Docker fix covered the images, but
the `.deb` packages have the identical defect. Unpacking the current beta debs:

```
kapsl-runtime        → /usr/local/bin/kapsl
                       /usr/local/bin/libonnxruntime_providers_shared.so
kapsl-runtime-cuda12 → /usr/local/bin/kapsl-provider-cuda12.json
                       /usr/local/bin/libonnxruntime_providers_cuda.so
```

`control.tar` holds only `./control` — no `postinst`, and no loader
configuration in the payload. ONNX Runtime resolves the bridge with a
bare-name `dlopen()`, `/usr/local/bin` is not a loader search path, so the
accelerator packs register nothing and the runtime serves every request from
the CPU while holding the GPU.

## Reproduced on hardware

Installed the beta debs on a rented **NVIDIA L4** (driver 595.71.05) — this is
develop's own binary, `0.1.21-beta.20260804.139c4588`:

```
deb-as-shipped        errors=5  registered=0  vram=(no process holds GPU memory)
with-ldconfig-fix     errors=0  registered=5  vram=kapsl, 344 MiB
control-fix-removed   errors=5  registered=0  vram=(no process holds GPU memory)
```

## The fix

Ship `/etc/ld.so.conf.d/kapsl-runtime.conf` in the package plus `postinst`
and `postrm` that run `ldconfig`. dpkg triggers `ldconfig` itself only for
standard library directories, so the conf file alone would sit inert.

Applied to both the release and beta installer workflows so the two stay in
step.

## Verification

Built the package with the new steps and installed it in `ubuntu:24.04`:

```
deb contents:  ./etc/ld.so.conf.d/kapsl-runtime.conf
               ./usr/local/bin/kapsl
               ./usr/local/bin/libonnxruntime_providers_shared.so
maintainer:    postinst, postrm

cache BEFORE install: 0
cache AFTER install:  1  →  /usr/local/bin/libonnxruntime_providers_shared.so
cache after removal:  0
```

## Known remaining gap

`install.sh` installs to `$HOME/.local/bin` and touches neither `ldconfig` nor
`LD_LIBRARY_PATH`, so tarball and script installs still can't resolve the
bridge — and an unprivileged user cannot fix that with `ldconfig` at all.

The systemic fix for every channel at once is linking the binary with
`-Wl,-rpath,$ORIGIN`: ORT is statically linked into `kapsl`, so the executable
is the calling object for that `dlopen`, and its `DT_RUNPATH` would be
searched. That changes the compiled artifact and needs its own build and GPU
retest, so I have deliberately left it out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)