### PR TITLE
fix(build): resolve the ONNX provider bridge from beside the binary

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/build.rs
+++ b/kapsl-runtime/crates/kapsl-cli/build.rs
@@ -7,6 +7,17 @@ fn main() {
         cc::Build::new()
             .file("compat_glibc.c")
             .compile("compat_glibc");
+
+        // ONNX Runtime loads its provider bridge with a bare-name dlopen(), so
+        // the loader searches this binary's own DT_RUNPATH for it. ORT is
+        // linked into this executable, which makes the executable the calling
+        // object, and $ORIGIN then resolves to wherever the binary was
+        // installed. Without it the sidecar libraries that ship beside the
+        // binary are invisible unless the directory happens to be a system
+        // library path, and every accelerator silently degrades to CPU.
+        // Windows needs no equivalent: its search order already includes the
+        // directory the executable was loaded from.
+        println!("cargo:rustc-link-arg-bins=-Wl,-rpath,$ORIGIN");
     }
 
     // On Windows, provide a posix_memalign shim for llama-cpp-sys-2


### PR DESCRIPTION
## Why this exists

#104 fixed the Docker images and #105 fixed the `.deb`, both by registering
`/usr/local/bin` with `ldconfig`. Neither reaches `install.sh`, which installs
to `$HOME/.local/bin` — and an unprivileged user **cannot** add that to the
loader path with `ldconfig` at all. So tarball and script installs still had no
way to register an accelerator, and every one of them degraded to CPU while
reporting that it had selected CUDA.

## The mechanism

ONNX Runtime loads `libonnxruntime_providers_shared.so` with a bare-name
`dlopen()`. For that call the loader searches the **calling object's**
`DT_RUNPATH`. ORT is linked into the `kapsl` executable, so the executable is
the calling object, and `$ORIGIN` resolves to wherever it was installed.

That makes the sidecar libraries beside the binary resolvable from any install
location, with no root and no environment variables — which is the property
`ldconfig` cannot give a per-user install.

## Verification

In `ubuntu:24.04`, against the real `libonnxruntime_providers_shared.so`, with
an **empty** loader cache and `LD_LIBRARY_PATH` unset:

```
control: no rpath, lib beside the binary
  DLOPEN FAILED: ... cannot open shared object file

with -Wl,-rpath,$ORIGIN
  RUNPATH  Library runpath: [$ORIGIN]
  DLOPEN OK

same binary, unrelated cwd
  DLOPEN OK
  ldconfig cache entries: 0
  LD_LIBRARY_PATH=[unset]
```

## Scope

`rustc-link-arg-bins` keeps this on the package's binaries — it does not leak
into tests, build scripts, or the pyo3 cdylib. Linux only; Windows already
searches the executable's own directory.

## Relationship to the other two PRs

This does not make them redundant. `ldconfig` registration still helps anything
that loads the libraries through a path other than the `kapsl` executable, and
the Docker assertion catches packaging regressions at build time. Belt and
braces on the channel that matters most.

Stacked behind #105 for the 0.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)