### PR TITLE
chore(release): bump the runtime to 0.2.0

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.1.21"
+version = "0.2.0"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
Version bump for the 0.2.0 release.

`0.2.0` rather than a patch because #102 adds an OpenAI-compatible `/v1`
surface — a new API contract, not a fix to an existing one.

## What 0.2.0 carries

| PR | fixes |
|---|---|
| #101 | lru 0.16 (RUSTSEC-2026-0002) |
| #102 | OpenAI-compatible `/v1` surface |
| #103 | sdk pin, drops redundant model copies |
| #104 | CUDA/TensorRT images: register the provider dir with `ldconfig` |
| #105 | `.deb`: ship `ld.so.conf.d` + `postinst`/`postrm` |
| #106 | binary: `-Wl,-rpath,$ORIGIN`, covers every install path |

Before #104–#106 every GPU install registered no execution provider and
served every request from the CPU while reporting that it had selected CUDA.

## Verified on an NVIDIA L4 (driver 595.71.05)

Against the CI-built binary from `f9f472c`:

```
RUNPATH of shipped binary: [$ORIGIN]        # literal, survived cargo→rustc→ld

unprivileged ~/.local/bin, no ldconfig anywhere, LD_LIBRARY_PATH unset
  ort::ep errors=0  registered=5  vram=332 MiB

system .deb install (postinst ran ldconfig, cache=1)
  ort::ep errors=0  registered=5  vram=316 MiB
```

End-to-end through the new endpoint, real model on the GPU:

```
LLM using CUDA on device 0
VRAM held: 1480 MiB
POST /v1/chat/completions -> 200
{"choices":[{"message":{"content":"Three primary colors are red, blue, and yellow."}}],
 "usage":{"completion_tokens":12,"prompt_tokens":7,"total_tokens":19}}
```

The `install.sh` case in the first block was unreachable by `ldconfig` at all —
an unprivileged user cannot register a loader path — which is why #106 exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)