### PR TITLE
feat(install): ship unified CUDA runtime

### DIFF
--- a/.github/scripts/package-linux-cuda-runtime.sh
+++ b/.github/scripts/package-linux-cuda-runtime.sh
@@ -14,6 +14,15 @@ if [ ! -x "$binary" ]; then
   exit 1
 fi
 
+cuda_provider="ort-cuda-libs/libonnxruntime_providers_cuda.so"
+shared_provider="ort-core-libs/libonnxruntime_providers_shared.so"
+for required_sidecar in "$cuda_provider" "$shared_provider"; do
+  if [ ! -f "$required_sidecar" ]; then
+    echo "Missing ONNX Runtime CUDA bundle sidecar: $required_sidecar" >&2
+    exit 1
+  fi
+done
+
 # Read the dynamic dependencies once. Piping readelf straight into `grep -q`
 # races against pipefail: grep exits on the first match, readelf takes SIGPIPE,
 # and the pipeline reports 141 even though the library is present. It only
@@ -35,29 +44,51 @@ bundle_name="kapsl-${KAPSL_VERSION}-linux-x86_64-cuda12"
 bundle_root="${RUNNER_TEMP}/${bundle_name}"
 mkdir -p dist "$bundle_root"
 install -m 755 "$binary" "$bundle_root/kapsl"
+cp -L ort-core-libs/* "$bundle_root/"
+cp -L ort-cuda-libs/* "$bundle_root/"
 
-if [ -d ort-core-libs ]; then
-  cp -L ort-core-libs/* "$bundle_root/" 2>/dev/null || true
+nvidia_license="${KAPSL_NVIDIA_LICENSE_FILE:-/NGC-DL-CONTAINER-LICENSE}"
+if [ ! -f "$nvidia_license" ]; then
+  echo "Missing NVIDIA redistribution license: $nvidia_license" >&2
+  exit 1
+fi
+cp "$nvidia_license" "$bundle_root/NVIDIA-CONTAINER-LICENSE"
+
+# cuDNN 9 loads its split libraries at runtime rather than declaring all of
+# them as ELF dependencies, so ldd cannot discover the complete family from
+# libcudnn.so.9 alone. Treat every runtime component as a dependency root.
+mapfile -t cudnn_libs < <(
+  find /usr \( -type f -o -type l \) 2>/dev/null \
+    | grep '/libcudnn[^/]*\.so\.9$' \
+    | sort -u
+)
+if [ "${#cudnn_libs[@]}" -eq 0 ]; then
+  echo "The CUDA bundle cannot find cuDNN 9; use a cuDNN release image." >&2
+  exit 1
 fi
 
-# Everything the binary needs that a bare GPU host will not already have has to
-# travel with it, next to the binary, where the $ORIGIN RUNPATH already looks.
+# Everything the GGUF CUDA binary and ONNX CUDA provider need that a bare GPU
+# host will not already have has to travel with them, next to the binary, where
+# the $ORIGIN RUNPATH already looks.
 #
-# libcuda.so.1 is deliberately excluded: it ships with the NVIDIA driver and
-# has to match it, so bundling a copy would break the host. The base C/C++
-# runtime is assumed present, exactly as for the portable build. What is left
-# is the CUDA-stack libraries this devel build image happens to carry but a
-# driver-only host does not — libnccl.so.2 today, linked because ggml turns on
-# GGML_CUDA_NCCL whenever CMake finds NCCL. That one is why a driver check
-# alone never proved the binary could actually start: it installed fine and
-# then exited 127 on every run.
-resolved_deps="$(ldd "$binary")"
+# libcuda.so.1 and libnvidia-* are deliberately excluded: they ship with the
+# NVIDIA driver and have to match it, so bundling copies would break the host.
+# The base C/C++ runtime is assumed present, exactly as for the portable build.
+# The release image supplies the remaining CUDA, cuDNN, and NCCL libraries, making this one
+# archive the Linux equivalent of a self-contained Triton GPU image.
+resolved_deps="$({
+  ldd "$binary"
+  ldd "$cuda_provider"
+  for cudnn_lib in "${cudnn_libs[@]}"; do
+    ldd "$cudnn_lib"
+  done
+})"
 bundled_libs=()
 unresolved_libs=()
-while read -r dep; do
+while IFS= read -r dep; do
   [ -n "$dep" ] || continue
   case "$dep" in
-    libcuda.so.* | libc.so.* | libm.so.* | libdl.so.* | librt.so.* | \
+    libcuda.so.* | libnvidia-*.so.* | libc.so.* | libm.so.* | libdl.so.* | librt.so.* | \
       libpthread.so.* | libgcc_s.so.* | libstdc++.so.* | ld-linux*)
       continue
       ;;
@@ -71,9 +102,16 @@ while read -r dep; do
     continue
   fi
 
-  cp -L "$resolved" "$bundle_root/"
+  # Preserve the requested SONAME even when the resolved file is a more
+  # specific version; that is the name the loader will look for at runtime.
+  cp -L "$resolved" "$bundle_root/$dep"
   bundled_libs+=("$dep")
-done <<< "$needed_libs"
+done < <(
+  {
+    printf '%s\n' "$needed_libs"
+    printf '%s\n' "$resolved_deps" | sed -n 's/^[[:space:]]*\([^[:space:]]*\)[[:space:]]*=>.*/\1/p'
+  } | sort -u
+)
 
 if [ "${#unresolved_libs[@]}" -gt 0 ]; then
   echo "Cannot resolve these dependencies to bundle: ${unresolved_libs[*]}" >&2
@@ -81,14 +119,82 @@ if [ "${#unresolved_libs[@]}" -gt 0 ]; then
   exit 1
 fi
 
-# Shipping libcuda would pin users to this image's driver version.
-if [ -e "$bundle_root/libcuda.so.1" ]; then
-  echo "libcuda.so.1 must not be bundled; it belongs to the host driver." >&2
+# Shipping driver libraries would pin users to this image's driver version.
+driver_library="$(find "$bundle_root" -maxdepth 1 -type f \
+  \( -name 'libcuda.so*' -o -name 'libnvidia-*.so*' \) -print -quit)"
+if [ -n "$driver_library" ]; then
+  echo "NVIDIA driver libraries must not be bundled; they belong to the host." >&2
   exit 1
 fi
 
 if [ "${#bundled_libs[@]}" -gt 0 ]; then
   echo "Bundled host-missing libraries: ${bundled_libs[*]}"
+fi
+
+# Ship every cuDNN runtime component under its loader-visible SONAME.
+for cudnn_lib in "${cudnn_libs[@]}"; do
+  cudnn_name="$(basename "$cudnn_lib")"
+  cp -L "$cudnn_lib" "$bundle_root/$cudnn_name"
+done
+
+if [ ! -f "$bundle_root/libcudnn.so.9" ]; then
+  echo "The CUDA bundle is missing libcudnn.so.9; use a cuDNN release image." >&2
+  exit 1
+fi
+
+# ORT's published CUDA provider carries a build-machine RUNPATH, while a bare
+# install puts all libraries beside kapsl. Normalize every bundled ELF to look
+# in its own directory so the archive works outside a container or ldconfig
+# setup as well.
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "patchelf is required to make the CUDA archive relocatable." >&2
+  exit 1
+fi
+while IFS= read -r elf_file; do
+  patchelf --set-rpath '$ORIGIN' "$elf_file"
+done < <(find "$bundle_root" -maxdepth 1 -type f \( -name kapsl -o -name 'lib*.so*' \) | sort)
+
+# This marker activates the ONNX CUDA execution provider. Keeping it in the
+# same archive as the CUDA-compiled binary is what guarantees that one install
+# accelerates both ONNX and GGUF models.
+provider_files=""
+while IFS= read -r provider_file; do
+  escaped="$(basename "$provider_file" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  if [ -n "$provider_files" ]; then
+    provider_files="${provider_files},"
+  fi
+  provider_files="${provider_files}\"${escaped}\""
+done < <(find "$bundle_root" -maxdepth 1 -type f ! -name kapsl | sort)
+
+cat > "$bundle_root/kapsl-provider-cuda12.json" <<EOF
+{
+  "schema_version": 1,
+  "provider": "cuda",
+  "provider_version": "12",
+  "runtime_version": "${KAPSL_VERSION}",
+  "platform": "linux-x86_64",
+  "requires": [],
+  "files": [${provider_files}],
+  "system_requirements": "A compatible NVIDIA driver must be installed."
+}
+EOF
+
+for required_bundle_file in \
+  kapsl \
+  kapsl-provider-cuda12.json \
+  libonnxruntime_providers_cuda.so \
+  libonnxruntime_providers_shared.so \
+  libcudnn.so.9; do
+  if [ ! -f "$bundle_root/$required_bundle_file" ]; then
+    echo "Incomplete CUDA bundle: missing $required_bundle_file" >&2
+    exit 1
+  fi
+done
+
+cuda_provider_runpath="$(patchelf --print-rpath "$bundle_root/libonnxruntime_providers_cuda.so")"
+if [ "$cuda_provider_runpath" != '$ORIGIN' ]; then
+  echo "CUDA provider is not relocatable: RUNPATH=${cuda_provider_runpath}" >&2
+  exit 1
 fi
 
 tar_path="dist/${bundle_name}.tar.gz"

--- a/.github/scripts/test-install-script.sh
+++ b/.github/scripts/test-install-script.sh
@@ -1,22 +1,13 @@
 #!/bin/sh
-# Exercises install.sh against a local fixture release.
-#
-# The interesting behavior is all on the failure paths: which runtime actually
-# lands, and whether the closing summary describes it honestly. Three separate
-# bugs have shipped here — a stale "GPU-accelerated" message over a CPU-only
-# install, a missing -cuda12 asset skipping the portable bundle, and a CUDA
-# binary that installs cleanly and then cannot load — so each case below
-# asserts the binary *and* the message, not just a zero exit.
-#
-# Runs unmodified on a Linux x86_64 runner, which is the only platform where
-# install.sh reaches the CUDA path.
+# Exercise the public installers against a local fixture release.
 set -eu
 
 version="9.9.9"
 test_root="$(mktemp -d)"
 release_dir="${test_root}/release"
 asset_dir="${release_dir}/runtime/v${version}"
-fake_bin_dir="${test_root}/fake-bin"
+beta_asset_dir="${release_dir}/runtime/beta/v${version}"
+fake_bin="${test_root}/bin"
 server_log="${test_root}/http-server.log"
 server_pid=""
 base_url="http://127.0.0.1:18081"
@@ -31,52 +22,54 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
-    echo "This test must run on Linux x86_64; install.sh gates the CUDA path on it." >&2
-    exit 1
-fi
+mkdir -p "${asset_dir}" "${beta_asset_dir}" "${fake_bin}"
 
-mkdir -p "${asset_dir}" "${fake_bin_dir}"
+# Keep the test runnable on developer Macs while exercising the production
+# Linux x86_64 selection path byte-for-byte.
+cat > "${fake_bin}/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+    -s) echo Linux ;;
+    -m) echo x86_64 ;;
+    *) echo Linux ;;
+esac
+EOF
+chmod +x "${fake_bin}/uname"
 
 # --- fixture payloads -------------------------------------------------------
 make_bundle() {
     bundle_asset="$1"
     marker="$2"
+    accelerator="$3"
     payload="${test_root}/payload-${marker}"
+    rm -rf "${payload}"
     mkdir -p "${payload}"
     cat > "${payload}/kapsl" <<EOF
 #!/bin/sh
 echo "${marker}"
 EOF
     chmod +x "${payload}/kapsl"
-    # Stands in for the ONNX Runtime core libraries the real bundles carry;
-    # its presence is how we tell a bundle install from the bare executable.
-    echo "sidecar" > "${payload}/libonnxruntime.so.1"
+    echo "core sidecar" > "${payload}/libonnxruntime.so.1"
+    if [ "${accelerator}" = "cuda" ]; then
+        echo '{}' > "${payload}/kapsl-provider-cuda12.json"
+        echo "cuda provider" > "${payload}/libonnxruntime_providers_cuda.so"
+        echo "cudnn" > "${payload}/libcudnn.so.9"
+    fi
     tar -czf "${asset_dir}/${bundle_asset}" -C "${payload}" .
 }
 
-make_bundle "kapsl-${version}-linux-x86_64.tar.gz" "portable"
-make_bundle "kapsl-${version}-linux-x86_64-cuda12.tar.gz" "cuda12"
-
-# A CUDA bundle that installs cleanly and then refuses to load, which is what a
-# host missing libnccl.so.2 actually looks like.
-broken_payload="${test_root}/payload-broken"
-mkdir -p "${broken_payload}"
-cat > "${broken_payload}/kapsl" <<'EOF'
-#!/bin/sh
-echo "kapsl: error while loading shared libraries: libnccl.so.2: cannot open shared object file" >&2
-exit 127
-EOF
-chmod +x "${broken_payload}/kapsl"
-echo "sidecar" > "${broken_payload}/libonnxruntime.so.1"
-tar -czf "${test_root}/cuda12-broken.tar.gz" -C "${broken_payload}" .
+portable_asset="kapsl-${version}-linux-x86_64.tar.gz"
+cuda_asset="kapsl-${version}-linux-x86_64-cuda12.tar.gz"
+make_bundle "${portable_asset}" "portable" cpu
+make_bundle "${cuda_asset}" "cuda12" cuda
 
 for provider in cuda12 tensorrt10; do
-    # Distinct from the runtime bundle payloads: a provider pack that also
-    # carried a kapsl binary would overwrite the one under test.
     provider_payload="${test_root}/payload-provider-${provider}"
     mkdir -p "${provider_payload}"
     echo '{}' > "${provider_payload}/kapsl-provider-${provider}.json"
+    if [ "${provider}" = "cuda12" ]; then
+        echo "legacy cuda provider" > "${provider_payload}/libonnxruntime_providers_cuda.so"
+    fi
     tar -czf "${asset_dir}/kapsl-provider-${provider}-${version}-linux-x86_64.tar.gz" \
         -C "${provider_payload}" .
 done
@@ -86,14 +79,10 @@ cat > "${asset_dir}/kapsl-${version}-linux-x86_64" <<'EOF'
 echo "single-exe"
 EOF
 
-cat > "${fake_bin_dir}/nvidia-smi" <<'EOF'
-#!/bin/sh
-if [ "$1" = "-L" ]; then
-    echo "GPU 0: Fixture GPU (UUID: GPU-00000000)"
-fi
-exit 0
-EOF
-chmod +x "${fake_bin_dir}/nvidia-smi"
+# install-cuda.sh fetches the general installer from the same origin.
+cp install.sh "${release_dir}/install.sh"
+cp install.sh "${release_dir}/install-beta-base.sh"
+cp "${asset_dir}/${cuda_asset}" "${beta_asset_dir}/${cuda_asset}"
 
 # --- fixture server ---------------------------------------------------------
 python3 -m http.server 18081 \
@@ -103,7 +92,7 @@ python3 -m http.server 18081 \
 server_pid="$!"
 
 attempt=1
-while ! curl -fsSLI "${base_url}/runtime/v${version}/kapsl-${version}-linux-x86_64.tar.gz" >/dev/null; do
+while ! curl -fsSLI "${base_url}/runtime/v${version}/${portable_asset}" >/dev/null; do
     if [ "${attempt}" -ge 20 ]; then
         cat "${server_log}" >&2
         echo "Timed out waiting for the fixture HTTP server." >&2
@@ -114,12 +103,10 @@ while ! curl -fsSLI "${base_url}/runtime/v${version}/kapsl-${version}-linux-x86_
 done
 
 # --- harness ----------------------------------------------------------------
-# run_install <name> <driver:yes|no> <accelerator|-> ; sets install_dir/log
+# run_install <name> <accelerator|->; sets install_dir/log_file/install_status.
 run_install() {
     case_name="$1"
-    with_driver="$2"
-    accelerator="$3"
-
+    accelerator="$2"
     install_dir="${test_root}/install-${case_name}"
     log_file="${test_root}/log-${case_name}"
     rm -rf "${install_dir}"
@@ -129,11 +116,27 @@ run_install() {
         set -- "$@" --accelerator "${accelerator}"
     fi
 
-    if [ "${with_driver}" = "yes" ]; then
-        PATH="${fake_bin_dir}:${PATH}" sh install.sh "$@" >"${log_file}" 2>&1 || true
-    else
-        sh install.sh "$@" >"${log_file}" 2>&1 || true
-    fi
+    set +e
+    PATH="${fake_bin}:${PATH}" sh install.sh "$@" >"${log_file}" 2>&1
+    install_status=$?
+    set -e
+}
+
+run_cuda_wrapper() {
+    case_name="$1"
+    wrapper="$2"
+    install_dir="${test_root}/install-${case_name}"
+    log_file="${test_root}/log-${case_name}"
+    rm -rf "${install_dir}"
+
+    set +e
+    KAPSL_BASE_URL="${base_url}" \
+    KAPSL_VERSION="${version}" \
+    KAPSL_INSTALL_DIR="${install_dir}" \
+    PATH="${fake_bin}:${PATH}" \
+        sh "${wrapper}" >"${log_file}" 2>&1
+    install_status=$?
+    set -e
 }
 
 fail() {
@@ -142,6 +145,13 @@ fail() {
         sed 's/^/        /' "${log_file}" >&2
     fi
     failures=$((failures + 1))
+}
+
+expect_status() {
+    expected="$1"
+    if [ "${install_status}" -ne "${expected}" ]; then
+        fail "installer exited ${install_status}; expected ${expected}"
+    fi
 }
 
 expect_binary() {
@@ -174,72 +184,90 @@ expect_file() {
     fi
 }
 
-gpu_claim="GGUF models: GPU-accelerated"
-cpu_claim="GGUF models: CPU only"
-
 # --- cases ------------------------------------------------------------------
-echo "case: driver present installs the CUDA runtime"
-run_install "cuda-driver" yes cuda
+echo "case: CUDA installs one merged GGUF + ONNX bundle"
+run_install "cuda" cuda
+expect_status 0
 expect_binary "cuda12"
 expect_file "kapsl-provider-cuda12.json"
-expect_log "${gpu_claim}"
+expect_file "libonnxruntime_providers_cuda.so"
+expect_file "libcudnn.so.9"
+expect_log "GGUF models: CUDA compiled"
+expect_log "ONNX models: CUDA execution provider installed"
+reject_log "legacy split"
 
-echo "case: no driver falls back and says so"
-run_install "cuda-nodriver" no cuda
-expect_binary "portable"
-expect_file "kapsl-provider-cuda12.json"
-expect_log "no working NVIDIA driver detected"
-expect_log "${cpu_claim}"
-reject_log "${gpu_claim}"
-
-echo "case: tensorrt also gets the CUDA runtime and both packs"
-run_install "tensorrt-driver" yes tensorrt
+echo "case: direct CUDA wrapper selects the same merged bundle"
+run_cuda_wrapper "cuda-wrapper" install-cuda.sh
+expect_status 0
 expect_binary "cuda12"
 expect_file "kapsl-provider-cuda12.json"
+expect_file "libonnxruntime_providers_cuda.so"
+
+echo "case: beta CUDA wrapper selects the merged beta bundle"
+run_cuda_wrapper "beta-cuda-wrapper" install-beta-cuda.sh
+expect_status 0
+expect_binary "cuda12"
+expect_file "kapsl-provider-cuda12.json"
+expect_file "libonnxruntime_providers_cuda.so"
+
+echo "case: TensorRT adds only its provider to the merged CUDA bundle"
+run_install "tensorrt" tensorrt
+expect_status 0
+expect_binary "cuda12"
+expect_file "kapsl-provider-cuda12.json"
+expect_file "libonnxruntime_providers_cuda.so"
 expect_file "kapsl-provider-tensorrt10.json"
-expect_log "${gpu_claim}"
+reject_log "legacy split"
 
-echo "case: cpu accelerator is untouched by the CUDA path"
-run_install "cpu" yes cpu
+echo "case: CPU and the default install remain portable"
+run_install "cpu" cpu
+expect_status 0
 expect_binary "portable"
-reject_log "${gpu_claim}"
-reject_log "nvidia"
-
-echo "case: default install is untouched by the CUDA path"
-run_install "default" yes -
+reject_log "CUDA compiled"
+run_install "default" -
+expect_status 0
 expect_binary "portable"
-reject_log "${gpu_claim}"
+reject_log "CUDA compiled"
 
-# A CUDA binary that cannot load must not be left in place, and must not be
-# reported as GPU-accelerated.
-echo "case: unusable CUDA runtime falls back to the portable bundle"
-cp "${asset_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz" "${test_root}/cuda12-good.tar.gz"
-cp "${test_root}/cuda12-broken.tar.gz" "${asset_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz"
-run_install "cuda-unusable" yes cuda
-expect_binary "portable"
-expect_log "libnccl.so.2"
-expect_log "${cpu_claim}"
-reject_log "${gpu_claim}"
-cp "${test_root}/cuda12-good.tar.gz" "${asset_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz"
+echo "case: an older split CUDA release remains installable"
+cp "${asset_dir}/${cuda_asset}" "${test_root}/merged-cuda.tar.gz"
+make_bundle "${cuda_asset}" "legacy-cuda12" cpu
+run_install "legacy-cuda" cuda
+expect_status 0
+expect_binary "legacy-cuda12"
+expect_file "kapsl-provider-cuda12.json"
+expect_file "libonnxruntime_providers_cuda.so"
+expect_log "legacy split ONNX CUDA provider pack"
+cp "${test_root}/merged-cuda.tar.gz" "${asset_dir}/${cuda_asset}"
 
-# Releases older than the -cuda12 artifact must still get the portable bundle,
-# with its sidecars, rather than dropping to the bare executable.
-echo "case: missing CUDA asset degrades to the portable bundle"
-mv "${asset_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz" "${test_root}/held-cuda12.tar.gz"
-run_install "cuda-missing" yes cuda
-expect_binary "portable"
-expect_file "libonnxruntime.so.1"
-expect_log "${cpu_claim}"
-reject_log "${gpu_claim}"
+echo "case: missing CUDA bundle fails instead of silently installing CPU"
+mv "${asset_dir}/${cuda_asset}" "${test_root}/held-cuda.tar.gz"
+run_install "cuda-missing" cuda
+if [ "${install_status}" -eq 0 ]; then
+    fail "missing CUDA bundle unexpectedly succeeded"
+fi
+expect_log "no CPU runtime was substituted"
+if [ -e "${install_dir}/kapsl" ]; then
+    fail "missing CUDA bundle installed a runtime"
+fi
+mv "${test_root}/held-cuda.tar.gz" "${asset_dir}/${cuda_asset}"
 
-echo "case: no bundles at all still installs the bare executable"
-mv "${asset_dir}/kapsl-${version}-linux-x86_64.tar.gz" "${test_root}/held-portable.tar.gz"
-run_install "no-bundles" yes cuda
+echo "case: corrupt CUDA bundle fails instead of silently installing CPU"
+cp "${asset_dir}/${cuda_asset}" "${test_root}/valid-cuda.tar.gz"
+printf 'corrupt' > "${asset_dir}/${cuda_asset}"
+run_install "cuda-corrupt" cuda
+if [ "${install_status}" -eq 0 ]; then
+    fail "corrupt CUDA bundle unexpectedly succeeded"
+fi
+expect_log "no CPU runtime was substituted"
+cp "${test_root}/valid-cuda.tar.gz" "${asset_dir}/${cuda_asset}"
+
+echo "case: old CPU release without a bundle uses the bare executable"
+mv "${asset_dir}/${portable_asset}" "${test_root}/held-portable.tar.gz"
+run_install "cpu-no-bundle" cpu
+expect_status 0
 expect_binary "single-exe"
-expect_log "${cpu_claim}"
-reject_log "${gpu_claim}"
-mv "${test_root}/held-cuda12.tar.gz" "${asset_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz"
-mv "${test_root}/held-portable.tar.gz" "${asset_dir}/kapsl-${version}-linux-x86_64.tar.gz"
+mv "${test_root}/held-portable.tar.gz" "${asset_dir}/${portable_asset}"
 
 if [ "${failures}" -ne 0 ]; then
     echo "${failures} install.sh case(s) failed." >&2

--- a/.github/scripts/test-package-linux-cuda-runtime.sh
+++ b/.github/scripts/test-package-linux-cuda-runtime.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+test_root="$(mktemp -d)"
+work_dir="${test_root}/work"
+fake_bin="${test_root}/bin"
+fake_lib="${test_root}/lib"
+runner_temp="${test_root}/runner"
+nvidia_license="${test_root}/NGC-DL-CONTAINER-LICENSE"
+
+cleanup() {
+  rm -rf "$test_root"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p \
+  "$work_dir/.github/scripts" \
+  "$work_dir/kapsl-runtime/target/release" \
+  "$work_dir/ort-core-libs" \
+  "$work_dir/ort-cuda-libs" \
+  "$fake_bin" \
+  "$fake_lib" \
+  "$runner_temp"
+printf 'NVIDIA fixture license\n' > "$nvidia_license"
+
+cp "$repo_root/.github/scripts/package-linux-cuda-runtime.sh" \
+  "$work_dir/.github/scripts/package-linux-cuda-runtime.sh"
+
+for file in \
+  libonnxruntime.so.1 \
+  libonnxruntime_providers_shared.so; do
+  printf '%s\n' "$file" > "$work_dir/ort-core-libs/$file"
+done
+printf 'cuda provider\n' > "$work_dir/ort-cuda-libs/libonnxruntime_providers_cuda.so"
+
+cat > "$work_dir/kapsl-runtime/target/release/kapsl" <<'EOF'
+#!/bin/sh
+echo kapsl
+EOF
+chmod +x "$work_dir/kapsl-runtime/target/release/kapsl"
+
+for file in \
+  libnccl.so.2 \
+  libcublasLt.so.12 \
+  libcublas.so.12 \
+  libcurand.so.10 \
+  libcufft.so.11 \
+  libcudart.so.12 \
+  libcudnn.so.9 \
+  libcudnn_ops.so.9 \
+  libnvrtc.so.12; do
+  printf '%s\n' "$file" > "$fake_lib/$file"
+done
+
+cat > "$fake_bin/readelf" <<'EOF'
+#!/bin/sh
+cat <<'OUTPUT'
+ 0x0000000000000001 (NEEDED)             Shared library: [libcuda.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libnccl.so.2]
+OUTPUT
+EOF
+
+cat > "$fake_bin/ldd" <<EOF
+#!/bin/sh
+case "\$(basename "\$1")" in
+  kapsl)
+    echo 'libcuda.so.1 => not found'
+    echo 'libnccl.so.2 => $fake_lib/libnccl.so.2 (0x1)'
+    ;;
+  libonnxruntime_providers_cuda.so)
+    echo 'libcublasLt.so.12 => $fake_lib/libcublasLt.so.12 (0x1)'
+    echo 'libcublas.so.12 => $fake_lib/libcublas.so.12 (0x1)'
+    echo 'libcurand.so.10 => $fake_lib/libcurand.so.10 (0x1)'
+    echo 'libcufft.so.11 => $fake_lib/libcufft.so.11 (0x1)'
+    echo 'libcudart.so.12 => $fake_lib/libcudart.so.12 (0x1)'
+    echo 'libcudnn.so.9 => $fake_lib/libcudnn.so.9 (0x1)'
+    ;;
+  libcudnn*.so.9)
+    echo 'libnvrtc.so.12 => $fake_lib/libnvrtc.so.12 (0x1)'
+    ;;
+esac
+echo 'libc.so.6 => /lib/libc.so.6 (0x1)'
+EOF
+
+cat > "$fake_bin/find" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = /usr ]; then
+  echo '$fake_lib/libcudnn.so.9'
+  echo '$fake_lib/libcudnn_ops.so.9'
+  exit 0
+fi
+exec /usr/bin/find "\$@"
+EOF
+
+cat > "$fake_bin/patchelf" <<'EOF'
+#!/bin/sh
+case "$1" in
+  --set-rpath) exit 0 ;;
+  --print-rpath) echo '$ORIGIN' ;;
+  *) exit 1 ;;
+esac
+EOF
+
+chmod +x "$fake_bin/readelf" "$fake_bin/ldd" "$fake_bin/find" "$fake_bin/patchelf"
+
+(
+  cd "$work_dir"
+  PATH="$fake_bin:$PATH" \
+  RUNNER_OS=Linux \
+  RUNNER_ARCH=X64 \
+  RUNNER_TEMP="$runner_temp" \
+  KAPSL_VERSION=9.9.9 \
+  KAPSL_NVIDIA_LICENSE_FILE="$nvidia_license" \
+    bash .github/scripts/package-linux-cuda-runtime.sh
+)
+
+archive="$work_dir/dist/kapsl-9.9.9-linux-x86_64-cuda12.tar.gz"
+test -f "$archive"
+contents="$(tar -tzf "$archive")"
+
+for required in \
+  kapsl \
+  kapsl-provider-cuda12.json \
+  NVIDIA-CONTAINER-LICENSE \
+  libonnxruntime_providers_cuda.so \
+  libonnxruntime_providers_shared.so \
+  libnccl.so.2 \
+  libcublas.so.12 \
+  libcudnn.so.9 \
+  libcudnn_ops.so.9 \
+  libnvrtc.so.12; do
+  if ! printf '%s\n' "$contents" | grep -qx "./$required"; then
+    echo "CUDA archive is missing $required" >&2
+    exit 1
+  fi
+done
+
+if printf '%s\n' "$contents" | grep -Eq 'libcuda\.so|libnvidia-.*\.so'; then
+  echo "CUDA archive must not include the host driver library." >&2
+  exit 1
+fi
+
+marker="$(tar -xOzf "$archive" ./kapsl-provider-cuda12.json)"
+printf '%s\n' "$marker" | grep -q '"provider": "cuda"'
+printf '%s\n' "$marker" | grep -q 'libonnxruntime_providers_cuda.so'
+
+echo "Merged Linux CUDA package passed."

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -291,7 +291,9 @@ jobs:
     name: Build CUDA runtime (linux-x86_64)
     runs-on: ubuntu-22.04
     container:
-      image: nvidia/cuda:12.6.3-devel-ubuntu22.04
+      # Match the stable release: this image supplies the CUDA/cuDNN libraries
+      # folded into the one GGUF + ONNX accelerator archive.
+      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
     env:
       CARGO_BUILD_JOBS: "2"
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
@@ -302,7 +304,7 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            binutils build-essential ca-certificates clang cmake curl git libclang-dev libssl-dev pkg-config
+            binutils build-essential ca-certificates clang cmake curl git libclang-dev libssl-dev patchelf pkg-config
           rm -rf /var/lib/apt/lists/*
 
       - name: Checkout
@@ -324,7 +326,7 @@ jobs:
       - name: Build kapsl with statically compiled GGUF CUDA
         run: cargo build --manifest-path kapsl-runtime/Cargo.toml -p kapsl --release --features cuda
 
-      - name: Collect ONNX Runtime core sidecars
+      - name: Collect ONNX Runtime sidecars
         shell: bash
         run: .github/scripts/collect-ort-sidecars.sh
 
@@ -458,6 +460,12 @@ jobs:
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
+          aws s3 cp install.sh \
+            s3://kapsl-installer/install-beta-base.sh \
+            --content-type "text/plain" \
+            --no-progress \
+            --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+
           for script in install-beta.ps1 install-beta-cuda.ps1 install-beta-tensorrt.ps1; do
             aws s3 cp "$script" \
               "s3://kapsl-installer/$script" \
@@ -465,3 +473,9 @@ jobs:
               --no-progress \
               --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
           done
+
+          aws s3 cp install-beta-cuda.sh \
+            s3://kapsl-installer/install-beta-cuda.sh \
+            --content-type "text/plain" \
+            --no-progress \
+            --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - "install.sh"
+      - "install-cuda.sh"
+      - "install-beta-cuda.sh"
       - ".github/scripts/test-install-script.sh"
       - ".github/scripts/package-linux-cuda-runtime.sh"
+      - ".github/scripts/test-package-linux-cuda-runtime.sh"
       - ".github/workflows/installer-smoke.yml"
   workflow_dispatch:
 
@@ -25,7 +28,14 @@ jobs:
       - name: Check shell syntax
         run: |
           sh -n install.sh
+          sh -n install-cuda.sh
+          sh -n install-beta-cuda.sh
           sh -n .github/scripts/test-install-script.sh
+          bash -n .github/scripts/package-linux-cuda-runtime.sh
+          bash -n .github/scripts/test-package-linux-cuda-runtime.sh
 
-      - name: Test accelerator selection and fallbacks
+      - name: Test merged accelerator selection and compatibility
         run: .github/scripts/test-install-script.sh
+
+      - name: Test merged CUDA archive contents
+        run: .github/scripts/test-package-linux-cuda-runtime.sh

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -360,7 +360,10 @@ jobs:
     name: Build CUDA runtime (linux-x86_64)
     runs-on: ubuntu-22.04
     container:
-      image: nvidia/cuda:12.6.3-devel-ubuntu22.04
+      # The CUDA archive carries the complete GGUF + ONNX GPU runtime, like a
+      # Triton GPU image. Use the cuDNN build image so the packager can collect
+      # every user-space library; only the NVIDIA driver stays host-provided.
+      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
     env:
       CARGO_BUILD_JOBS: "2"
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
@@ -371,7 +374,7 @@ jobs:
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            binutils build-essential ca-certificates clang cmake curl git libclang-dev libssl-dev pkg-config
+            binutils build-essential ca-certificates clang cmake curl git libclang-dev libssl-dev patchelf pkg-config
           rm -rf /var/lib/apt/lists/*
 
       - name: Checkout
@@ -399,7 +402,7 @@ jobs:
       - name: Build kapsl with statically compiled GGUF CUDA
         run: cargo build --manifest-path kapsl-runtime/Cargo.toml -p kapsl --release --features cuda
 
-      - name: Collect ONNX Runtime core sidecars
+      - name: Collect ONNX Runtime sidecars
         shell: bash
         run: .github/scripts/collect-ort-sidecars.sh
 
@@ -526,17 +529,19 @@ jobs:
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
-      - name: Upload install.sh to R2 (stable URL)
+      - name: Upload Linux installer scripts to R2 (stable URLs)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          aws s3 cp install.sh \
-            s3://kapsl-installer/install.sh \
-            --content-type "text/plain" \
-            --no-progress \
-            --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+          for script in install.sh install-cuda.sh; do
+            aws s3 cp "$script" \
+              "s3://kapsl-installer/$script" \
+              --content-type "text/plain" \
+              --no-progress \
+              --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+          done
 
       - name: Upload Windows installer scripts to R2 (stable URLs)
         env:

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,5 +1,5 @@
 # Kapsl Runtime — CUDA image
-# CUDA 12 + cuDNN runtime with the matching Kapsl CUDA provider pack.
+# CUDA 12 + cuDNN runtime with one Kapsl GGUF + ONNX CUDA bundle.
 
 FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     binutils curl ca-certificates ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the pre-built runtime and CUDA provider pack from the matching GitHub
+# Install the pre-built GGUF + ONNX CUDA runtime from the matching GitHub
 # Release, pinned to KAPSL_VERSION so this layer cache-busts per release.
 #
 # The provider pack unpacks next to the binary, but ONNX Runtime reaches

--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -1,5 +1,5 @@
 # Kapsl Runtime — TensorRT image
-# CUDA 12 + cuDNN + TensorRT 10 with matching Kapsl provider packs.
+# CUDA 12 + cuDNN + TensorRT 10 with a merged Kapsl CUDA runtime and TensorRT add-on.
 
 FROM python:3.12-slim AS tensorrt-libs
 

--- a/docker/install-release-assets.sh
+++ b/docker/install-release-assets.sh
@@ -77,18 +77,12 @@ case "$accelerator" in
         runtime_asset="kapsl-${KAPSL_VERSION}-${platform}.tar.gz"
         ;;
     cuda | tensorrt)
-        # GGUF CUDA is statically compiled into this runtime. ONNX accelerator
-        # providers remain separate packs installed below.
+        # One self-contained archive supplies both the CUDA-compiled GGUF
+        # runtime and the ONNX CUDA provider, matching the GPU image model.
         runtime_asset="kapsl-${KAPSL_VERSION}-${platform}-cuda12.tar.gz"
         ;;
 esac
 extract_asset "$runtime_asset"
-
-case "$accelerator" in
-    cuda | tensorrt)
-        extract_asset "kapsl-provider-cuda12-${KAPSL_VERSION}-${platform}.tar.gz"
-        ;;
-esac
 
 if [ "$accelerator" = "tensorrt" ]; then
     extract_asset "kapsl-provider-tensorrt10-${KAPSL_VERSION}-${platform}.tar.gz"

--- a/docker/test-release-scripts.sh
+++ b/docker/test-release-scripts.sh
@@ -37,6 +37,8 @@ cat > "${cuda_payload_dir}/kapsl" <<'EOF'
 echo "kapsl cuda release-script test"
 EOF
 chmod +x "${cuda_payload_dir}/kapsl"
+echo '{}' > "${cuda_payload_dir}/kapsl-provider-cuda12.json"
+echo 'cuda provider' > "${cuda_payload_dir}/libonnxruntime_providers_cuda.so"
 echo '{}' > "${cuda_provider_payload_dir}/kapsl-provider-cuda12.json"
 echo '{}' > "${tensorrt_provider_payload_dir}/kapsl-provider-tensorrt10.json"
 
@@ -146,6 +148,13 @@ sha256sum \
     "${release_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz" \
     >"${release_dir}/kapsl-${version}-linux-x86_64-cuda12.tar.gz.sha256"
 
+# The normal CUDA/Docker path is one archive. Remove the legacy standalone
+# provider pack after the readiness test to prove neither CUDA nor TensorRT
+# installation downloads it.
+rm \
+    "${release_dir}/kapsl-provider-cuda12-${version}-linux-x86_64.tar.gz" \
+    "${release_dir}/kapsl-provider-cuda12-${version}-linux-x86_64.tar.gz.sha256"
+
 install_dir="${test_root}/install"
 KAPSL_VERSION="${version}" \
 KAPSL_RELEASE_BASE_URL="${base_url}" \
@@ -168,6 +177,7 @@ case "$(uname -m)" in
             exit 1
         fi
         test -f "${cuda_install_dir}/kapsl-provider-cuda12.json"
+        test -f "${cuda_install_dir}/libonnxruntime_providers_cuda.so"
 
         tensorrt_install_dir="${test_root}/install-tensorrt"
         KAPSL_VERSION="${version}" \
@@ -179,6 +189,7 @@ case "$(uname -m)" in
             exit 1
         fi
         test -f "${tensorrt_install_dir}/kapsl-provider-cuda12.json"
+        test -f "${tensorrt_install_dir}/libonnxruntime_providers_cuda.so"
         test -f "${tensorrt_install_dir}/kapsl-provider-tensorrt10.json"
         ;;
 esac

--- a/install-beta-cuda.sh
+++ b/install-beta-cuda.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# One-command Linux x86_64 CUDA installer for the beta channel.
+set -e
+
+base_url="${KAPSL_BASE_URL:-https://downloads.kapsl.net}"
+
+if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "${base_url}/install-beta-base.sh" | KAPSL_ACCELERATOR=cuda KAPSL_CHANNEL=beta sh -s -- "$@"
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "${base_url}/install-beta-base.sh" | KAPSL_ACCELERATOR=cuda KAPSL_CHANNEL=beta sh -s -- "$@"
+else
+    echo "curl or wget is required" >&2
+    exit 1
+fi

--- a/install-cuda.sh
+++ b/install-cuda.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# One-command Linux x86_64 CUDA installer.
+set -e
+
+base_url="${KAPSL_BASE_URL:-https://downloads.kapsl.net}"
+
+if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "${base_url}/install.sh" | KAPSL_ACCELERATOR=cuda sh -s -- "$@"
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO- "${base_url}/install.sh" | KAPSL_ACCELERATOR=cuda sh -s -- "$@"
+else
+    echo "curl or wget is required" >&2
+    exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env sh
 # Kapsl CLI installer
 # Usage: curl -fsSL https://downloads.kapsl.net/install.sh | sh
-# CUDA: curl -fsSL https://downloads.kapsl.net/install.sh | sh -s -- --accelerator cuda
+# CUDA: curl -fsSL https://downloads.kapsl.net/install-cuda.sh | sh
 set -e
 
 BASE_URL="${KAPSL_BASE_URL:-https://downloads.kapsl.net}"
 BIN_NAME="kapsl"
 INSTALL_DIR="${KAPSL_INSTALL_DIR:-$HOME/.local/bin}"
 ACCELERATOR="${KAPSL_ACCELERATOR:-cpu}"
-CHANNEL="stable"
+CHANNEL="${KAPSL_CHANNEL:-stable}"
 VERSION="${KAPSL_VERSION:-}"
 
 usage() {
@@ -21,7 +21,7 @@ Usage:
 
 Examples:
   curl -fsSL https://downloads.kapsl.net/install.sh | sh
-  curl -fsSL https://downloads.kapsl.net/install.sh | sh -s -- --accelerator cuda
+  curl -fsSL https://downloads.kapsl.net/install-cuda.sh | sh
   curl -fsSL https://downloads.kapsl.net/install.sh | sh -s -- --accelerator tensorrt
 EOF
 }
@@ -158,21 +158,7 @@ install_bundle() {
 
     cp -R "$(dirname "$bundle_bin")/." "$INSTALL_DIR/"
     chmod +x "${INSTALL_DIR}/${BIN_NAME}"
-}
-
-# A working driver is necessary but not sufficient for the CUDA build: it also
-# carries DT_NEEDED entries the driver does not provide (libnccl.so.2 among
-# them, which ships in the CUDA container images but is a separate package on
-# a bare host), so it can install cleanly and still fail to load. Prove the
-# binary starts before committing to it, and surface the loader's own error —
-# it names the missing library, which is the one thing that tells the user how
-# to get the GPU back.
-runtime_starts() {
-    start_error="$("${INSTALL_DIR}/${BIN_NAME}" --version 2>&1 >/dev/null)" && return 0
-    if [ -n "$start_error" ]; then
-        echo "  ${start_error}" >&2
-    fi
-    return 1
+    INSTALLED_BUNDLE_DIR="$(dirname "$bundle_bin")"
 }
 
 install_provider_pack() {
@@ -206,33 +192,33 @@ case "$ACCELERATOR" in
         ;;
 esac
 
+case "$ACCELERATOR" in
+    cuda | cuda12 | tensorrt | tensorrt10)
+        if [ "$PLATFORM" != "linux-x86_64" ]; then
+            echo "The ${ACCELERATOR} runtime is currently available only for Linux x86_64." >&2
+            exit 1
+        fi
+        ;;
+esac
+
 if [ -z "$VERSION" ]; then
     printf "Fetching latest version... "
     VERSION="$(latest_version)"
     echo "$VERSION"
 fi
 
-# GGUF/llama.cpp only gets GPU support if the binary was compiled with
-# --features cuda, and that build links libcuda.so.1 directly (not dlopen'd),
-# so it cannot exec at all on a host with no NVIDIA driver loaded. Only reach
-# for it when the driver is confirmed working; otherwise keep installing the
-# portable build so `kapsl` still runs, and say so.
-USE_CUDA_RUNTIME=0
 case "$ACCELERATOR" in
+    cpu)
+        BUNDLE_FILE="${BIN_NAME}-${VERSION}-${PLATFORM}.tar.gz"
+        ;;
     cuda | cuda12 | tensorrt | tensorrt10)
-        if [ "$PLATFORM" = "linux-x86_64" ]; then
-            if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
-                USE_CUDA_RUNTIME=1
-            else
-                echo "Warning: no working NVIDIA driver detected (nvidia-smi missing or failed)." >&2
-                echo "Installing the portable runtime instead; GGUF models will run on CPU until a driver is available. ONNX models still get the ${ACCELERATOR} provider pack." >&2
-            fi
-        fi
+        # One archive contains the CUDA-compiled GGUF runtime, the ONNX CUDA
+        # provider, and their user-space CUDA dependencies. Only the matching
+        # NVIDIA driver remains a host prerequisite.
+        BUNDLE_FILE="${BIN_NAME}-${VERSION}-${PLATFORM}-cuda12.tar.gz"
         ;;
 esac
 
-PORTABLE_BUNDLE_FILE="${BIN_NAME}-${VERSION}-${PLATFORM}.tar.gz"
-CUDA_BUNDLE_FILE="${BIN_NAME}-${VERSION}-${PLATFORM}-cuda12.tar.gz"
 BIN_FILE="${BIN_NAME}-${VERSION}-${PLATFORM}"
 DOWNLOAD_URL="${BASE_URL}/${RUNTIME_PATH}/v${VERSION}/${BIN_FILE}"
 
@@ -243,38 +229,29 @@ mkdir -p "$INSTALL_DIR"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-INSTALLED=0
-
-# Prefer the CUDA-compiled runtime when the driver check passed, but never let
-# a missing -cuda12 asset (older releases predate it) cost the user the ORT
-# sidecars that the portable bundle carries — degrade to it instead.
-if [ "$USE_CUDA_RUNTIME" = "1" ]; then
-    if install_bundle "$CUDA_BUNDLE_FILE" && runtime_starts; then
-        INSTALLED=1
-    else
-        echo "The CUDA runtime is unusable on this host; falling back to the portable runtime, so GGUF models will run on CPU." >&2
-        USE_CUDA_RUNTIME=0
+if ! install_bundle "$BUNDLE_FILE"; then
+    if [ "$ACCELERATOR" != "cpu" ]; then
+        echo "The requested ${ACCELERATOR} runtime is unavailable; no CPU runtime was substituted." >&2
+        exit 1
     fi
-fi
 
-if [ "$INSTALLED" = "0" ] && install_bundle "$PORTABLE_BUNDLE_FILE"; then
-    INSTALLED=1
-fi
-
-# Last resort: the bare executable, which ships without the ORT sidecars and is
-# never the CUDA build, so GGUF stays on the CPU whatever was requested.
-if [ "$INSTALLED" = "0" ]; then
+    # Old CPU releases may only have the bare executable. Accelerator installs
+    # deliberately do not use this fallback because it cannot run GGUF on CUDA.
     echo "Falling back to single executable." >&2
-    USE_CUDA_RUNTIME=0
-    TMP="${TMP_DIR}/${BIN_FILE}"
-    download "$DOWNLOAD_URL" "$TMP"
-    chmod +x "$TMP"
-    mv "$TMP" "${INSTALL_DIR}/${BIN_NAME}"
+    tmp="${TMP_DIR}/${BIN_FILE}"
+    download "$DOWNLOAD_URL" "$tmp"
+    chmod +x "$tmp"
+    mv "$tmp" "${INSTALL_DIR}/${BIN_NAME}"
 fi
 
 case "$ACCELERATOR" in
     cuda | cuda12 | tensorrt | tensorrt10)
-        install_provider_pack "cuda" "12"
+        # Compatibility for pre-merged releases: new CUDA archives already
+        # contain this marker and need no second download.
+        if [ ! -f "${INSTALLED_BUNDLE_DIR}/kapsl-provider-cuda12.json" ]; then
+            echo "Installing legacy split ONNX CUDA provider pack..."
+            install_provider_pack "cuda" "12"
+        fi
         ;;
 esac
 case "$ACCELERATOR" in
@@ -298,11 +275,8 @@ esac
 echo ""
 if [ "$ACCELERATOR" != "cpu" ]; then
     echo "Installed accelerator profile: ${ACCELERATOR}"
-    echo "Linux accelerator packs require compatible NVIDIA system runtime libraries."
-    if [ "$USE_CUDA_RUNTIME" = "1" ]; then
-        echo "GGUF models: GPU-accelerated (CUDA compiled into this runtime build)."
-    else
-        echo "GGUF models: CPU only for this install (ONNX models still get the ${ACCELERATOR} provider pack)."
-    fi
+    echo "GGUF models: CUDA compiled into this runtime build."
+    echo "ONNX models: CUDA execution provider installed."
+    echo "A compatible NVIDIA driver is required."
 fi
 echo "Run 'kapsl --help' to get started."

--- a/kapsl-runtime/docs/deployment.md
+++ b/kapsl-runtime/docs/deployment.md
@@ -8,14 +8,16 @@
 - GPU drivers and SDKs only if using a non-CPU backend:
   - A compatible NVIDIA display driver on Windows; the provider packs include
     the required CUDA 12, cuDNN 9, and TensorRT 10 user-space runtime libraries
-  - Compatible system CUDA/TensorRT runtime libraries on Linux
+  - A compatible NVIDIA driver on Linux; the CUDA installer includes the CUDA
+    12, cuDNN 9, and NCCL user-space libraries. Bare-metal TensorRT installs
+    additionally require compatible TensorRT 10 system libraries
   - Xcode command line tools for Metal (macOS)
 
 ## Runtime and accelerator packages
 
 The default installer contains the portable Kapsl runtime and ONNX Runtime core
-libraries. NVIDIA libraries are published separately so CPU, DirectML, and Apple
-Silicon installations stay small.
+libraries. The Linux CUDA installer is a separate self-contained archive so CPU,
+DirectML, and Apple Silicon installations stay small.
 
 Install the default runtime:
 
@@ -23,12 +25,15 @@ Install the default runtime:
 curl -fsSL https://downloads.kapsl.net/install.sh | sh
 ```
 
-Install it with the CUDA 12 pack:
+Install the Linux x86_64 CUDA 12 runtime:
 
 ```bash
-curl -fsSL https://downloads.kapsl.net/install.sh |
-  sh -s -- --accelerator cuda
+curl -fsSL https://downloads.kapsl.net/install-cuda.sh | sh
 ```
+
+That single archive contains the CUDA-compiled GGUF runtime and the ONNX CUDA
+execution provider, plus their user-space CUDA dependencies. It requires only a
+compatible host NVIDIA driver, like a Triton GPU image.
 
 Install CUDA 12 and TensorRT 10 packs:
 
@@ -66,7 +71,11 @@ PowerShell. A saved copy of the general installer also accepts explicit paramete
 .\install.ps1 -Accelerator tensorrt
 ```
 
-The latest beta has equivalent Windows entry points:
+The latest beta has equivalent entry points:
+
+```bash
+curl -fsSL https://downloads.kapsl.net/install-beta-cuda.sh | sh
+```
 
 ```powershell
 irm https://downloads.kapsl.net/install-beta.ps1 | iex
@@ -75,9 +84,10 @@ irm https://downloads.kapsl.net/install-beta-tensorrt.ps1 | iex
 ```
 
 Windows provider packs contain the calculated NVIDIA DLL dependency closure.
-Linux packs contain the ONNX Runtime provider sidecars and require compatible
-NVIDIA driver and system runtime libraries. macOS uses system Metal/CoreML
-frameworks and does not require an accelerator pack.
+The standalone Linux provider packs remain available for existing portable
+installations and require compatible NVIDIA system runtime libraries. The merged
+Linux CUDA installer does not require that extra provider step. macOS uses system
+Metal/CoreML frameworks and does not require an accelerator pack.
 
 ## Docker images
 
@@ -87,10 +97,10 @@ Docker images follow the same modular split:
 # Small, multi-architecture CPU image; also published as :latest
 docker pull ghcr.io/kapsl-runtime/kapsl-engine:latest-cpu
 
-# Linux amd64 with CUDA 12, cuDNN, and the Kapsl CUDA provider pack
+# Linux amd64 with the merged GGUF + ONNX CUDA 12 runtime
 docker pull ghcr.io/kapsl-runtime/kapsl-engine:latest-cuda
 
-# Linux amd64 with CUDA 12, cuDNN, TensorRT 10, and both provider packs
+# Linux amd64 with the merged CUDA runtime and TensorRT 10 add-on
 docker pull ghcr.io/kapsl-runtime/kapsl-engine:latest-tensorrt
 ```
 


### PR DESCRIPTION
## Summary
- package one Linux x86_64 CUDA archive for both GGUF and ONNX
- include CUDA, cuDNN, NCCL dependencies and relocatable ORIGIN runpaths
- add simple stable and beta CUDA installer wrappers with no silent CPU substitution
- make Docker consume the same merged archive and retain legacy split-release compatibility

## Verification
- installer stable/beta fixture matrix
- merged archive dependency/content fixture
- release-asset installer tests
- shell syntax, workflow YAML parsing, and diff checks