### PR TITLE
feat: add unified runtime memory authority

### DIFF
--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: beta-runtime-installers
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -286,6 +290,7 @@ jobs:
           name: runtime-installers-${{ matrix.os }}
           path: dist/*
           if-no-files-found: error
+          retention-days: 1
 
   build-cuda-runtime:
     name: Build CUDA runtime (linux-x86_64)
@@ -341,6 +346,7 @@ jobs:
           path: dist/*
           if-no-files-found: error
           compression-level: 0
+          retention-days: 1
 
   publish-beta-release:
     needs: [build-runtime-installers, build-cuda-runtime]
@@ -440,10 +446,11 @@ jobs:
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
-          # Also overwrite the "latest-beta" pointer so clients can always find the newest beta
-          aws s3 cp release-assets/ \
+          # Keep the mutable latest directory as an exact mirror. Artifact names
+          # contain their version, so --delete prevents old betas accumulating here.
+          aws s3 sync release-assets/ \
             s3://kapsl-installer/runtime/beta/latest/ \
-            --recursive \
+            --delete \
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
@@ -479,3 +486,37 @@ jobs:
             --content-type "text/plain" \
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+
+      - name: Delete superseded beta installers from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          R2_ENDPOINT: https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+          CURRENT_BETA_VERSION: v${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          listing="$(aws s3 ls s3://kapsl-installer/runtime/beta/ \
+            --endpoint-url "$R2_ENDPOINT")"
+          mapfile -t versions < <(
+            printf '%s\n' "$listing" \
+              | awk '$NF ~ /^v.*\/$/ { sub(/\/$/, "", $NF); print $NF }'
+          )
+
+          deleted=0
+          for version in "${versions[@]}"; do
+            if [ "$version" = "$CURRENT_BETA_VERSION" ]; then
+              continue
+            fi
+
+            echo "Deleting superseded beta s3://kapsl-installer/runtime/beta/$version/"
+            aws s3 rm "s3://kapsl-installer/runtime/beta/$version/" \
+              --recursive \
+              --no-progress \
+              --endpoint-url "$R2_ENDPOINT"
+            deleted=$((deleted + 1))
+          done
+
+          echo "Deleted $deleted superseded beta version(s); retained $CURRENT_BETA_VERSION."

--- a/.github/workflows/cleanup-r2-installers.yml
+++ b/.github/workflows/cleanup-r2-installers.yml
@@ -2,14 +2,18 @@ name: Cleanup R2 Installers
 
 on:
   schedule:
-    # Run on the 1st of every month at 02:00 UTC
-    - cron: "0 2 1 * *"
+    # Run daily so abandoned beta uploads are removed promptly.
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       keep_latest:
         description: "Number of most recent versions to keep"
         required: false
         default: "3"
+      beta_retention_days:
+        description: "Delete superseded beta versions older than this many days"
+        required: false
+        default: "1"
 
 jobs:
   cleanup:
@@ -60,3 +64,76 @@ jobs:
           done
 
           echo "Done. Retained: $(echo "$versions" | tail -n "$KEEP_LATEST" | tr '\n' ' ')"
+
+      - name: Delete expired beta installer versions
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          R2_ENDPOINT: https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+          BETA_RETENTION_DAYS: ${{ github.event.inputs.beta_retention_days || '1' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! [[ "$BETA_RETENTION_DAYS" =~ ^[0-9]+$ ]]; then
+            echo "beta_retention_days must be a non-negative integer." >&2
+            exit 1
+          fi
+
+          latest_version="$(aws s3 cp \
+            s3://kapsl-installer/runtime/beta/latest.txt - \
+            --no-progress \
+            --endpoint-url "$R2_ENDPOINT" \
+            | tr -d '[:space:]')"
+          if ! [[ "$latest_version" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+            echo "Refusing to prune beta versions: latest.txt contains an invalid version." >&2
+            exit 1
+          fi
+          current_version="v${latest_version}"
+          cutoff_epoch="$(date -u -d "$BETA_RETENTION_DAYS days ago" +%s)"
+
+          objects="$(aws s3api list-objects-v2 \
+            --bucket kapsl-installer \
+            --prefix runtime/beta/v \
+            --query 'Contents[].[Key,LastModified]' \
+            --output text \
+            --endpoint-url "$R2_ENDPOINT")"
+
+          declare -A newest_object_by_version=()
+          while IFS=$'\t' read -r key last_modified; do
+            if [ -z "${key:-}" ] || [ "$key" = "None" ]; then
+              continue
+            fi
+
+            relative_key="${key#runtime/beta/}"
+            version="${relative_key%%/*}"
+            if [[ "$version" != v* ]] || [ "$relative_key" = "$version" ]; then
+              continue
+            fi
+
+            modified_epoch="$(date -u -d "$last_modified" +%s)"
+            previous_epoch="${newest_object_by_version[$version]:-0}"
+            if (( modified_epoch > previous_epoch )); then
+              newest_object_by_version[$version]="$modified_epoch"
+            fi
+          done <<< "$objects"
+
+          deleted=0
+          for version in "${!newest_object_by_version[@]}"; do
+            if [ "$version" = "$current_version" ]; then
+              continue
+            fi
+            if (( newest_object_by_version[$version] >= cutoff_epoch )); then
+              continue
+            fi
+
+            echo "Deleting expired beta s3://kapsl-installer/runtime/beta/$version/"
+            aws s3 rm "s3://kapsl-installer/runtime/beta/$version/" \
+              --recursive \
+              --no-progress \
+              --endpoint-url "$R2_ENDPOINT"
+            deleted=$((deleted + 1))
+          done
+
+          echo "Deleted $deleted beta version(s) older than $BETA_RETENTION_DAYS day(s); retained $current_version."

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2100,8 +2100,7 @@ dependencies = [
 [[package]]
 name = "kapsl-backends"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd252922cc188ea048d16c911eb0088d158ac41f79bdc642717a3ed9e6dfd4f"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2131,8 +2130,7 @@ dependencies = [
 [[package]]
 name = "kapsl-core"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a60839b1991bdb43743f38d0c485297b3c0269fd63b5e11ea5ae234c59893fa"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "flate2",
  "fs2",
@@ -2152,8 +2150,7 @@ dependencies = [
 [[package]]
 name = "kapsl-engine-api"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08733653a817b887d3730fca63b485e79e5b14323b6a8def1ab114801352a329"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2165,8 +2162,7 @@ dependencies = [
 [[package]]
 name = "kapsl-hal"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd167e22b300dffa066287b232f743b8373afc3b30cc1967ccc695e7f10a4f4"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "cudarc",
  "half",
@@ -2180,8 +2176,7 @@ dependencies = [
 [[package]]
 name = "kapsl-ipc"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75ae76089778278df4b1b7ce57c86cf82f108039b86f9d120774643976b4aa9"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2199,8 +2194,7 @@ dependencies = [
 [[package]]
 name = "kapsl-kernels"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21365b4b2a537f68770beb80b276a63e040ddd227c02d12d58321cbc89b30bc7"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "cudarc",
  "half",
@@ -2241,8 +2235,7 @@ dependencies = [
 [[package]]
 name = "kapsl-llm"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526eb4e05528f6c90fbd108aed7ecd551e3ef7cbd82867df15dcd3807d450789"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2272,8 +2265,7 @@ dependencies = [
 [[package]]
 name = "kapsl-loader"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cb361ad0afeb195ca43c173c9c6a5f5502fd682ba3f2610a01d178b09d7ad1"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "half",
  "kapsl-hal",
@@ -2288,8 +2280,7 @@ dependencies = [
 [[package]]
 name = "kapsl-monitor"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f494785bdb51f685f1abdb07e13d64de98c99dcc6c42a40676c47ddfca17503"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2303,8 +2294,7 @@ dependencies = [
 [[package]]
 name = "kapsl-quantization"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd758ee6e01d51370388089cf5d4395067e1ad5909ed3b48863838831a92c611"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "anyhow",
  "half",
@@ -2319,8 +2309,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef12070b6d071d20f711617aab5b2449a759c00081da89a3828c22363b50356b"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2340,8 +2329,7 @@ dependencies = [
 [[package]]
 name = "kapsl-rag-sdk"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bda5c5504f07d305983b2b4ec35b64217f6d68f73933e670e553df1e25253f1"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "futures",
@@ -2353,8 +2341,7 @@ dependencies = [
 [[package]]
 name = "kapsl-scheduler"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664e33edd94f090c244d78652b186a713c0ae87b96ebc9882dad9c8ddd932cc6"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2373,8 +2360,7 @@ dependencies = [
 [[package]]
 name = "kapsl-shm"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10439d3cefc893c73aabebbe55c649d57aaa78a3998d3a10d7e4851f5e092a9"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2395,8 +2381,7 @@ dependencies = [
 [[package]]
 name = "kapsl-transport"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2b2abd48f8d8aa226af24199e5d97ef02602fadb2a91eb678f410486634cc0"
+source = "git+https://github.com/kapsl-runtime/kapsl-sdk.git?rev=e02f03f445df66715a9130607ef7fd7b3448bf70#e02f03f445df66715a9130607ef7fd7b3448bf70"
 dependencies = [
  "async-trait",
  "bincode",

--- a/kapsl-runtime/FULL_DOCUMENTATION.md
+++ b/kapsl-runtime/FULL_DOCUMENTATION.md
@@ -693,14 +693,39 @@ CPU memory governance:
 
 - `KAPSL_CPU_MEMORY_LIMIT_MB`: optional process-wide system-memory ceiling in
   MiB. Kapsl uses the tightest of this value, detected host RAM, and the Linux
-  cgroup memory limit, then retains 20% as safety headroom. CPU LLM KV-cache
-  limits are derived from the resulting safe budget. Before each in-process CPU
-  model or replica loads, Kapsl also reserves an estimate for expanded weights
-  and execution workspace within the other half of the safe budget; admission
-  fails before allocation if aggregate reservations would exceed that partition.
-  Reservations are released on
-  unload. This is accounting only: Kapsl does not reserve a second physical CPU
-  arena.
+  cgroup memory limit, then retains 20% as safety headroom. CPU LLM KV-cache,
+  model/session, and active request-transient accounting are separate classes
+  under that one safe budget. KV keeps one half-budget; model/session and active
+  request-transient reservations share the complementary half, preventing a
+  full logical KV cache from overcommitting host memory. Reservations are
+  released with the model, replica, or request lease. Model loads are serialized
+  for a before/after process-RSS sample; reconciliation can raise (but never
+  lower) the conservative model reservation. This is accounting only: Kapsl
+  does not reserve a second physical CPU arena.
+
+Memory admission is coordinated by a backend-neutral authority. A `MemoryPlan`
+contains typed host, pinned-host, mapped-host, CUDA-device, or provider-domain
+claims, each attributed to a model ID, replica ID, allocation class, allocation
+source, and stable allocation ID. Model loading admits the complete plan
+transactionally, reconciles backend reports and observed CUDA/RSS deltas after
+load, and commits a single RAII `MemoryLease`; failure or unload releases all
+domains. Request input, staging, output, and workspace reports receive
+short-lived leases around synchronous, batched, and streaming inference. CUDA
+claims use the physical pool/budget manager, host claims use the CPU budget
+manager, and non-CUDA providers use accounting adapters. Physical allocations
+shared by replicas are charged once while each replica keeps its own ownership
+reference.
+
+When a CUDA pool is materialized, the native and `gguf-native` paths allocate
+weights, scratch/workspace, block tables, request buffers, and KV blocks from
+typed views over that pool. ONNX CUDA/TensorRT sessions use the pool through the
+ORT environment allocator. Compatible rank-4 autoregressive ONNX graphs also
+retain authoritative `present.*` KV OrtValues on CUDA and bind them directly as
+the next step's `past_key_values.*`; an unsupported graph, disabled/fallback
+allocator, isolated worker, or binding failure uses the host KV implementation.
+The llama.cpp-backed GGUF path remains explicit backend-managed CUDA memory for
+weights and compute scratch because GGML does not yet expose a Kapsl pool buffer
+adapter; its shared paged KV is still runtime-managed in the pool.
 
 ## 13. Runtime Pressure Management
 

--- a/kapsl-runtime/FULL_DOCUMENTATION.md
+++ b/kapsl-runtime/FULL_DOCUMENTATION.md
@@ -689,6 +689,14 @@ Model cache / disk-check env vars (read by `kapsl-core` loader):
 - `KAPSL_MODEL_CACHE_RESERVED_FREE_BYTES` / `KAPSL_MODEL_CACHE_RESERVED_FREE_MIB`: minimum free disk space that must remain after a model cache copy; the loader will evict LRU entries until the constraint is satisfied (or fail with `InsufficientDiskSpace`).
 - `KAPSL_PACKAGE_TMP_DIR`: override the temporary directory used when unpacking an `.aimod` archive.
 
+CPU memory governance:
+
+- `KAPSL_CPU_MEMORY_LIMIT_MB`: optional process-wide system-memory ceiling in
+  MiB. Kapsl uses the tightest of this value, detected host RAM, and the Linux
+  cgroup memory limit, then retains 20% as safety headroom. CPU LLM KV-cache
+  limits are derived from the resulting safe budget. This is admission and
+  capacity accounting; Kapsl does not reserve a second physical CPU arena.
+
 ## 13. Runtime Pressure Management
 
 The runtime monitors system resource utilization and adjusts inference behavior when under pressure. There are three pressure states:

--- a/kapsl-runtime/FULL_DOCUMENTATION.md
+++ b/kapsl-runtime/FULL_DOCUMENTATION.md
@@ -694,8 +694,13 @@ CPU memory governance:
 - `KAPSL_CPU_MEMORY_LIMIT_MB`: optional process-wide system-memory ceiling in
   MiB. Kapsl uses the tightest of this value, detected host RAM, and the Linux
   cgroup memory limit, then retains 20% as safety headroom. CPU LLM KV-cache
-  limits are derived from the resulting safe budget. This is admission and
-  capacity accounting; Kapsl does not reserve a second physical CPU arena.
+  limits are derived from the resulting safe budget. Before each in-process CPU
+  model or replica loads, Kapsl also reserves an estimate for expanded weights
+  and execution workspace within the other half of the safe budget; admission
+  fails before allocation if aggregate reservations would exceed that partition.
+  Reservations are released on
+  unload. This is accounting only: Kapsl does not reserve a second physical CPU
+  arena.
 
 ## 13. Runtime Pressure Management
 

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -30,18 +30,18 @@ gguf-cuda-shared-kv = ["gpu-device-pool", "kapsl-backends/gguf-cuda-shared-kv", 
 cc = "1"
 
 [dependencies]
-kapsl-core = "0.1.2"
-kapsl-hal = "0.1.2"
-kapsl-engine-api = "0.1.2"
-kapsl-backends = "0.1.2"
-kapsl-scheduler = "0.1.2"
-kapsl-ipc = "0.1.2"
-kapsl-monitor = "0.1.2"
-kapsl-transport = "0.1.2"
-kapsl-shm = "0.1.2"
-kapsl-llm = "0.1.2"
-kapsl-rag = "0.1.2"
-kapsl-rag-sdk = "0.1.2"
+kapsl-core = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-hal = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-engine-api = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-backends = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-scheduler = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-ipc = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-monitor = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-transport = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-shm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-llm = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-rag = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
+kapsl-rag-sdk = { git = "https://github.com/kapsl-runtime/kapsl-sdk.git", rev = "e02f03f445df66715a9130607ef7fd7b3448bf70" }
 warp = "0.3"
 prometheus = "0.14"
 parking_lot = "0.12"

--- a/kapsl-runtime/crates/kapsl-cli/src/app/constants.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/app/constants.rs
@@ -73,6 +73,10 @@ pub(crate) const CUDA_DEVICE_MEMORY_LIMIT_ENV: &str = "CUDA_DEVICE_MEMORY_LIMIT"
 /// kapsl alias for the per-device VRAM cap, in plain MiB, for non-HAMi
 /// deployments that still want cooperative self-limiting.
 pub(crate) const KAPSL_GPU_MEMORY_LIMIT_MB_ENV: &str = "KAPSL_GPU_MEMORY_LIMIT_MB";
+/// Cooperative process-wide system-memory ceiling, in MiB. The host-memory
+/// budget also observes container limits and keeps a safety reserve; this
+/// override is useful on bare-metal hosts where no cgroup boundary exists.
+pub(crate) const KAPSL_CPU_MEMORY_LIMIT_MB_ENV: &str = "KAPSL_CPU_MEMORY_LIMIT_MB";
 /// Internal worker override used to keep process-local CUDA arenas from each
 /// claiming the parent process's full configured pool.
 pub(crate) const GPU_DEVICE_POOL_DISABLED_ENV: &str = "KAPSL_GPU_DEVICE_POOL_DISABLED";

--- a/kapsl-runtime/crates/kapsl-cli/src/main.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/main.rs
@@ -18,7 +18,7 @@ use kapsl_engine_api::{
     EngineModelInfo, InferenceRequest, TensorDtype,
 };
 #[cfg(feature = "gpu-device-pool")]
-use kapsl_engine_api::{EngineStream, ExternalDeviceMemory, ExternalDeviceMemoryReport};
+use kapsl_engine_api::{ExternalDeviceMemory, ExternalDeviceMemoryReport};
 use kapsl_hal::device::DeviceInfo;
 use kapsl_ipc::{IpcServer, TcpServer};
 use kapsl_llm::block_manager::{new_shared_allocator, SharedBlockAllocator};

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/device_budget.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/device_budget.rs
@@ -1,3 +1,4 @@
+use super::memory::{MemoryAllocationClass, MemoryOwner};
 use std::collections::HashMap;
 
 pub(crate) const AUTO_POOL_ALIGNMENT_BYTES: usize = 2 * 1024 * 1024;
@@ -122,7 +123,8 @@ struct DeviceBudget {
 #[derive(Debug)]
 struct ExternalAllocation {
     bytes: usize,
-    refs: usize,
+    class: MemoryAllocationClass,
+    owners: HashMap<MemoryOwner, usize>,
     planned: bool,
 }
 
@@ -159,13 +161,22 @@ impl DeviceBudgetLedger {
         device_id: usize,
         allocation_id: &str,
         bytes: usize,
+        owner: MemoryOwner,
+        class: MemoryAllocationClass,
     ) -> Result<(DeviceBudgetSnapshot, bool), String> {
         let device = self
             .devices
             .get_mut(&device_id)
             .ok_or_else(|| format!("CUDA device {device_id} has no runtime memory authority"))?;
         if let Some(allocation) = device.allocations.get_mut(allocation_id) {
-            allocation.refs = allocation.refs.saturating_add(1);
+            if allocation.class != class {
+                return Err(format!(
+                    "CUDA device {device_id} external allocation `{allocation_id}` is already classified as {}, not {} for {}",
+                    allocation.class, class, owner
+                ));
+            }
+            let refs = allocation.owners.entry(owner).or_default();
+            *refs = refs.saturating_add(1);
             return Ok((snapshot(device), false));
         }
         let current = snapshot(device);
@@ -181,11 +192,14 @@ impl DeviceBudgetLedger {
                 device.budget_bytes
             ));
         }
+        let mut owners = HashMap::new();
+        owners.insert(owner, 1);
         device.allocations.insert(
             allocation_id.to_string(),
             ExternalAllocation {
                 bytes,
-                refs: 1,
+                class,
+                owners,
                 planned: true,
             },
         );
@@ -253,11 +267,22 @@ impl DeviceBudgetLedger {
         Ok(current)
     }
 
-    pub(crate) fn release_external(&mut self, device_id: usize, allocation_id: &str) {
+    pub(crate) fn release_external(
+        &mut self,
+        device_id: usize,
+        allocation_id: &str,
+        owner: MemoryOwner,
+    ) {
         if let Some(device) = self.devices.get_mut(&device_id) {
             let remove = if let Some(allocation) = device.allocations.get_mut(allocation_id) {
-                allocation.refs = allocation.refs.saturating_sub(1);
-                allocation.refs == 0
+                let remove_owner = allocation.owners.get_mut(&owner).is_some_and(|refs| {
+                    *refs = refs.saturating_sub(1);
+                    *refs == 0
+                });
+                if remove_owner {
+                    allocation.owners.remove(&owner);
+                }
+                allocation.owners.is_empty()
             } else {
                 false
             };
@@ -298,6 +323,30 @@ mod tests {
 
     const DEVICE: usize = 3;
     const GIB: usize = 1024 * 1024 * 1024;
+    const OWNER: MemoryOwner = MemoryOwner::new(7, 0);
+
+    fn reserve(
+        ledger: &mut DeviceBudgetLedger,
+        allocation_id: &str,
+        bytes: usize,
+    ) -> Result<(DeviceBudgetSnapshot, bool), String> {
+        reserve_for(ledger, allocation_id, bytes, OWNER)
+    }
+
+    fn reserve_for(
+        ledger: &mut DeviceBudgetLedger,
+        allocation_id: &str,
+        bytes: usize,
+        owner: MemoryOwner,
+    ) -> Result<(DeviceBudgetSnapshot, bool), String> {
+        ledger.reserve_external(
+            DEVICE,
+            allocation_id,
+            bytes,
+            owner,
+            MemoryAllocationClass::PersistentWeights,
+        )
+    }
 
     fn ledger() -> DeviceBudgetLedger {
         let mut ledger = DeviceBudgetLedger::default();
@@ -416,20 +465,19 @@ mod tests {
     #[test]
     fn pool_and_external_reservations_share_one_budget() {
         let mut ledger = ledger();
-        let (snapshot, owns_charge) = ledger
-            .reserve_external(DEVICE, "weights-a", 12 * GIB)
-            .expect("exact fit should be admitted");
+        let (snapshot, owns_charge) =
+            reserve(&mut ledger, "weights-a", 12 * GIB).expect("exact fit should be admitted");
         assert!(owns_charge);
         assert_eq!(snapshot.used_bytes(), 20 * GIB);
         assert_eq!(snapshot.available_bytes(), 0);
-        assert!(ledger.reserve_external(DEVICE, "weights-b", 1).is_err());
+        assert!(reserve(&mut ledger, "weights-b", 1).is_err());
     }
 
     #[test]
     fn deferred_pool_charge_accounts_for_existing_external_bytes() {
         let mut ledger = DeviceBudgetLedger::default();
         ledger.insert_device(DEVICE, 20 * GIB, 0).unwrap();
-        ledger.reserve_external(DEVICE, "weights", 6 * GIB).unwrap();
+        reserve(&mut ledger, "weights", 6 * GIB).unwrap();
 
         let snapshot = ledger.set_pooled_bytes(DEVICE, 12 * GIB).unwrap();
         assert_eq!(snapshot.pooled_bytes, 12 * GIB);
@@ -445,9 +493,7 @@ mod tests {
     #[test]
     fn reconciliation_releases_overestimated_headroom() {
         let mut ledger = ledger();
-        ledger
-            .reserve_external(DEVICE, "weights", 8 * GIB)
-            .expect("planned load");
+        reserve(&mut ledger, "weights", 8 * GIB).expect("planned load");
         let snapshot = ledger
             .reconcile_external(DEVICE, "weights", 5 * GIB)
             .expect("actual load");
@@ -459,9 +505,7 @@ mod tests {
     #[test]
     fn over_budget_actual_is_retained_until_failed_load_cleans_up() {
         let mut ledger = ledger();
-        ledger
-            .reserve_external(DEVICE, "weights", 8 * GIB)
-            .expect("planned load");
+        reserve(&mut ledger, "weights", 8 * GIB).expect("planned load");
         assert!(ledger
             .reconcile_external(DEVICE, "weights", 13 * GIB)
             .is_err());
@@ -469,63 +513,68 @@ mod tests {
             ledger.snapshot(DEVICE).expect("device").external_bytes,
             13 * GIB
         );
-        assert!(ledger.reserve_external(DEVICE, "other", 1).is_err());
+        assert!(reserve(&mut ledger, "other", 1).is_err());
 
-        ledger.release_external(DEVICE, "weights");
+        ledger.release_external(DEVICE, "weights", OWNER);
         assert_eq!(ledger.snapshot(DEVICE).expect("device").external_bytes, 0);
     }
 
     #[test]
     fn shared_allocation_is_charged_once_and_reference_counted() {
         let mut ledger = ledger();
-        let (_, first_owns_charge) = ledger
-            .reserve_external(DEVICE, "shared-weights", 7 * GIB)
-            .expect("first replica");
+        let first_owner = MemoryOwner::new(7, 0);
+        let second_owner = MemoryOwner::new(7, 1);
+        let (_, first_owns_charge) =
+            reserve_for(&mut ledger, "shared-weights", 7 * GIB, first_owner)
+                .expect("first replica");
         ledger
             .reconcile_external(DEVICE, "shared-weights", 6 * GIB)
             .expect("actual weights");
-        let (snapshot, second_owns_charge) = ledger
-            .reserve_external(DEVICE, "shared-weights", 7 * GIB)
-            .expect("second replica");
+        let (snapshot, second_owns_charge) =
+            reserve_for(&mut ledger, "shared-weights", 7 * GIB, second_owner)
+                .expect("second replica");
         assert!(first_owns_charge);
         assert!(!second_owns_charge);
         assert_eq!(snapshot.external_bytes, 6 * GIB);
 
-        ledger.release_external(DEVICE, "shared-weights");
+        let allocation = ledger.devices[&DEVICE]
+            .allocations
+            .get("shared-weights")
+            .unwrap();
+        assert_eq!(allocation.class, MemoryAllocationClass::PersistentWeights);
+        assert!(allocation.owners.contains_key(&first_owner));
+        assert!(allocation.owners.contains_key(&second_owner));
+
+        ledger.release_external(DEVICE, "shared-weights", first_owner);
         assert_eq!(
             ledger.snapshot(DEVICE).expect("device").external_bytes,
             6 * GIB
         );
-        ledger.release_external(DEVICE, "shared-weights");
+        ledger.release_external(DEVICE, "shared-weights", second_owner);
         assert_eq!(ledger.snapshot(DEVICE).expect("device").external_bytes, 0);
     }
 
     #[test]
     fn swap_peak_requires_room_for_active_and_target_weights() {
         let mut ledger = ledger();
-        ledger
-            .reserve_external(DEVICE, "active-weights", 7 * GIB)
-            .expect("active model plan");
+        reserve(&mut ledger, "active-weights", 7 * GIB).expect("active model plan");
         ledger
             .reconcile_external(DEVICE, "active-weights", 7 * GIB)
             .expect("active model actual");
 
-        assert!(ledger
-            .reserve_external(DEVICE, "swap-peak-1", 6 * GIB)
-            .is_err());
+        assert!(reserve(&mut ledger, "swap-peak-1", 6 * GIB).is_err());
         let snapshot = ledger.snapshot(DEVICE).expect("device");
         assert_eq!(snapshot.external_bytes, 7 * GIB);
         assert_eq!(snapshot.planned_external_bytes, 0);
 
-        let (snapshot, owns_charge) = ledger
-            .reserve_external(DEVICE, "swap-peak-2", 5 * GIB)
+        let (snapshot, owns_charge) = reserve(&mut ledger, "swap-peak-2", 5 * GIB)
             .expect("active plus target is an exact fit");
         assert!(owns_charge);
         assert_eq!(snapshot.external_bytes, 7 * GIB);
         assert_eq!(snapshot.planned_external_bytes, 5 * GIB);
         assert_eq!(snapshot.available_bytes(), 0);
 
-        ledger.release_external(DEVICE, "swap-peak-2");
+        ledger.release_external(DEVICE, "swap-peak-2", OWNER);
         assert_eq!(
             ledger.snapshot(DEVICE).expect("device").available_bytes(),
             5 * GIB

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/device_memory.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/device_memory.rs
@@ -3,7 +3,7 @@ use super::device_budget::{
 };
 use super::*;
 use cudarc::driver::{result as cuda_result, CudaDevice};
-use kapsl_hal::gpu_arena::{GpuDevicePool, PoolOwner};
+use kapsl_hal::gpu_arena::{GpuDevicePool, PoolAllocationClass, PoolBackend, PoolOwner};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -115,6 +115,7 @@ impl DeviceMemoryBootstrapPlan {
 #[derive(Debug)]
 struct ExternalReservation {
     allocation_id: String,
+    memory_owner: MemoryOwner,
     owns_charge: bool,
 }
 
@@ -122,7 +123,7 @@ struct ExternalReservation {
 ///
 /// Backends receive cloned elastic-pool handles where available, while this
 /// manager retains the global device budget and accounts allocations that
-/// cannot yet live in that pool (notably GGUF/native weights).
+/// cannot yet live in that pool (notably llama.cpp weights and compute scratch).
 pub(crate) struct DeviceMemoryManager {
     devices: HashMap<usize, DeviceAuthority>,
     pools: Mutex<HashMap<usize, Arc<GpuDevicePool>>>,
@@ -565,6 +566,71 @@ impl DeviceMemoryManager {
         self.pools.lock().unwrap().contains_key(&device_id)
     }
 
+    /// Admit one request-lifetime CUDA claim without taking the model-load
+    /// sampling lock. Pool-managed rows are already bounded by the admitted
+    /// workload quota. Backend-managed rows receive a unique ledger ID so
+    /// concurrent requests are charged additively rather than mistaken for a
+    /// shared persistent allocation.
+    pub(crate) fn admit_transient(
+        self: &Arc<Self>,
+        claim: &MemoryClaim,
+    ) -> Result<Option<DeviceMemoryTransientLease>, String> {
+        let MemoryDomain::Cuda { device_id } = claim.domain else {
+            return Err(format!(
+                "device memory manager cannot admit a {} claim",
+                claim.domain
+            ));
+        };
+        if claim.bytes == 0 {
+            return Ok(None);
+        }
+        if matches!(claim.source, MemoryClaimSource::Runtime { .. }) {
+            if !self.has_pool(device_id) {
+                return Err(format!(
+                    "runtime-managed CUDA claim for {} targets device {} without a physical pool",
+                    claim.owner, device_id
+                ));
+            }
+            return Ok(None);
+        }
+
+        let reported_id = match &claim.source {
+            MemoryClaimSource::External { allocation_id } => allocation_id.as_str(),
+            MemoryClaimSource::Runtime { .. } => unreachable!("handled above"),
+        };
+        let allocation_id = format!(
+            "request:{}:{}:{}:{}:{}",
+            claim.owner.model_id,
+            claim.owner.replica_id,
+            device_id,
+            self.next_fallback_allocation
+                .fetch_add(1, Ordering::Relaxed),
+            reported_id
+        );
+        let snapshot = {
+            let mut budget = self.budget.lock().unwrap();
+            let (snapshot, owns_charge) = budget.reserve_external(
+                device_id,
+                &allocation_id,
+                claim.bytes,
+                claim.owner,
+                claim.class,
+            )?;
+            debug_assert!(owns_charge, "request allocation IDs are unique");
+            snapshot
+        };
+        self.publish_metrics(device_id, snapshot);
+        Ok(Some(DeviceMemoryTransientLease {
+            manager: Arc::clone(self),
+            device_id,
+            reservation: ExternalReservation {
+                allocation_id,
+                memory_owner: claim.owner,
+                owns_charge: true,
+            },
+        }))
+    }
+
     /// Reserve this workload's planned external weight bytes and protect its
     /// configured elastic-pool guarantee during model load. Loads are
     /// serialized per device so the before/after CUDA samples can be attributed
@@ -573,7 +639,7 @@ impl DeviceMemoryManager {
     pub(crate) async fn begin_admission(
         self: &Arc<Self>,
         device_id: usize,
-        model_id: u32,
+        memory_owner: MemoryOwner,
         kind: EngineKind,
         planned_report: &ExternalDeviceMemoryReport,
     ) -> Result<Option<DeviceMemoryAdmission>, String> {
@@ -581,7 +647,7 @@ impl DeviceMemoryManager {
             return Ok(None);
         };
         let load_guard = Arc::clone(&authority.load_lock).lock_owned().await;
-        let owner = owner_for(kind, model_id);
+        let pool_owner = pool_owner_for(kind, memory_owner);
         let mut planned_allocations: Vec<_> = planned_report
             .allocations
             .iter()
@@ -610,17 +676,24 @@ impl DeviceMemoryManager {
                     device_id,
                     &allocation.allocation_id,
                     allocation.bytes,
+                    memory_owner,
+                    classify_external_allocation(&allocation.allocation_id),
                 ) {
                     Ok((snapshot, owns_charge)) => {
                         current = snapshot;
                         reservations.push(ExternalReservation {
                             allocation_id: allocation.allocation_id.clone(),
+                            memory_owner,
                             owns_charge,
                         });
                     }
                     Err(error) => {
                         for reservation in &reservations {
-                            budget.release_external(device_id, &reservation.allocation_id);
+                            budget.release_external(
+                                device_id,
+                                &reservation.allocation_id,
+                                reservation.memory_owner,
+                            );
                         }
                         return Err(error);
                     }
@@ -629,7 +702,7 @@ impl DeviceMemoryManager {
             current
         };
         self.publish_metrics(device_id, snapshot);
-        if let Err(error) = self.admit_pool(device_id, owner) {
+        if let Err(error) = self.admit_pool(device_id, pool_owner) {
             self.release_external_reservations(device_id, &reservations);
             return Err(error);
         }
@@ -637,7 +710,7 @@ impl DeviceMemoryManager {
             Ok(bytes) => bytes,
             Err(error) => {
                 self.release_external_reservations(device_id, &reservations);
-                self.release_pool_one(device_id, owner);
+                self.release_pool_one(device_id, pool_owner);
                 return Err(error);
             }
         };
@@ -646,8 +719,9 @@ impl DeviceMemoryManager {
             .map(|allocation| allocation.bytes)
             .sum::<usize>();
         log::info!(
-            "[device-memory] admitted {:?} on CUDA device {}: planned_external_weights={} global_used={} global_available={} bytes",
-            owner,
+            "[device-memory] admitted {} ({:?}) on CUDA device {}: planned_external={} global_used={} global_available={} bytes",
+            memory_owner,
+            pool_owner,
             device_id,
             planned_external_bytes,
             snapshot.used_bytes(),
@@ -656,7 +730,8 @@ impl DeviceMemoryManager {
         Ok(Some(DeviceMemoryAdmission {
             manager: Arc::clone(self),
             device_id,
-            owner,
+            memory_owner,
+            pool_owner,
             reservations,
             free_before_load,
             _load_guard: Some(load_guard),
@@ -673,7 +748,7 @@ impl DeviceMemoryManager {
     pub(crate) async fn begin_swap_admission(
         self: &Arc<Self>,
         device_id: usize,
-        model_id: u32,
+        memory_owner: MemoryOwner,
         planned_report: &ExternalDeviceMemoryReport,
     ) -> Result<Option<DeviceMemorySwapAdmission>, String> {
         let Some(authority) = self.devices.get(&device_id) else {
@@ -699,23 +774,36 @@ impl DeviceMemoryManager {
                 format!("CUDA device {device_id} has no runtime memory authority")
             })?;
             for (index, allocation) in planned_allocations.iter().enumerate() {
-                let allocation_id =
-                    format!("runtime-swap-peak:{model_id}:{device_id}:{swap_id}:{index}");
-                match budget.reserve_external(device_id, &allocation_id, allocation.bytes) {
+                let allocation_id = format!(
+                    "runtime-swap-peak:{}:{}:{device_id}:{swap_id}:{index}",
+                    memory_owner.model_id, memory_owner.replica_id
+                );
+                match budget.reserve_external(
+                    device_id,
+                    &allocation_id,
+                    allocation.bytes,
+                    memory_owner,
+                    classify_external_allocation(&allocation.allocation_id),
+                ) {
                     Ok((snapshot, owns_charge)) => {
                         debug_assert!(owns_charge);
                         current = snapshot;
                         reservations.push(ExternalReservation {
                             allocation_id,
+                            memory_owner,
                             owns_charge,
                         });
                     }
                     Err(error) => {
                         for reservation in &reservations {
-                            budget.release_external(device_id, &reservation.allocation_id);
+                            budget.release_external(
+                                device_id,
+                                &reservation.allocation_id,
+                                reservation.memory_owner,
+                            );
                         }
                         return Err(format!(
-                            "hot-swap memory admission for model {model_id} failed: {error}"
+                            "hot-swap memory admission for {memory_owner} failed: {error}"
                         ));
                     }
                 }
@@ -724,8 +812,8 @@ impl DeviceMemoryManager {
         };
         self.publish_metrics(device_id, snapshot);
         log::info!(
-            "[device-memory] admitted hot-swap peak for model {} on CUDA device {}: target_external={} global_used={} global_available={} bytes",
-            model_id,
+            "[device-memory] admitted hot-swap peak for {} on CUDA device {}: target_external={} global_used={} global_available={} bytes",
+            memory_owner,
             device_id,
             planned_allocations
                 .iter()
@@ -819,7 +907,11 @@ impl DeviceMemoryManager {
         let snapshot = {
             let mut budget = self.budget.lock().unwrap();
             for reservation in reservations {
-                budget.release_external(device_id, &reservation.allocation_id);
+                budget.release_external(
+                    device_id,
+                    &reservation.allocation_id,
+                    reservation.memory_owner,
+                );
             }
             budget.snapshot(device_id)
         };
@@ -895,7 +987,7 @@ impl DeviceMemoryManager {
             .lock()
             .unwrap()
             .get(&device_id)
-            .map(|pool| pool.owner_usage_bytes(owner))
+            .map(|pool| pool.workload_usage_bytes(owner))
             .unwrap_or(0);
         log::info!(
             "[device-memory] deferring {:?} admission release on CUDA device {} until {} live bytes are freed",
@@ -916,7 +1008,7 @@ impl DeviceMemoryManager {
                 .lock()
                 .unwrap()
                 .get(&device_id)
-                .map(|pool| pool.owner_usage_bytes(owner))
+                .map(|pool| pool.workload_usage_bytes(owner))
                 .unwrap_or(0);
             log::warn!(
                 "[device-memory] timed out releasing {:?} admission on CUDA device {}; {} bytes remain live",
@@ -941,7 +1033,7 @@ impl DeviceMemoryManager {
             refs.remove(&key);
             return true;
         };
-        if pool.owner_usage_bytes(owner) != 0 {
+        if pool.workload_usage_bytes(owner) != 0 {
             return false;
         }
         match pool.set_owner_admitted(owner, false) {
@@ -1020,7 +1112,8 @@ impl DeviceMemoryManager {
 pub(crate) struct DeviceMemoryAdmission {
     manager: Arc<DeviceMemoryManager>,
     device_id: usize,
-    owner: PoolOwner,
+    memory_owner: MemoryOwner,
+    pool_owner: PoolOwner,
     reservations: Vec<ExternalReservation>,
     free_before_load: usize,
     _load_guard: Option<OwnedMutexGuard<()>>,
@@ -1070,9 +1163,12 @@ impl DeviceMemoryAdmission {
                 self.device_id,
                 &allocation_id,
                 0,
+                self.memory_owner,
+                classify_external_allocation(&allocation_id),
             )?;
             self.reservations.push(ExternalReservation {
                 allocation_id: allocation_id.clone(),
+                memory_owner: self.memory_owner,
                 owns_charge,
             });
             if owns_charge {
@@ -1096,10 +1192,13 @@ impl DeviceMemoryAdmission {
                 self.device_id,
                 &allocation_id,
                 0,
+                self.memory_owner,
+                MemoryAllocationClass::ExternallyOwned,
             )?;
             debug_assert!(owns_charge);
             self.reservations.push(ExternalReservation {
                 allocation_id: allocation_id.clone(),
+                memory_owner: self.memory_owner,
                 owns_charge,
             });
             self.manager
@@ -1119,7 +1218,8 @@ impl DeviceMemoryAdmission {
         DeviceMemoryLease {
             manager: Arc::clone(&self.manager),
             device_id: self.device_id,
-            owner: self.owner,
+            memory_owner: self.memory_owner,
+            pool_owner: self.pool_owner,
             reservations: std::mem::take(&mut self.reservations),
         }
     }
@@ -1129,7 +1229,7 @@ impl Drop for DeviceMemoryAdmission {
     fn drop(&mut self) {
         if !self.committed {
             self.manager
-                .release_one(self.device_id, self.owner, &self.reservations);
+                .release_one(self.device_id, self.pool_owner, &self.reservations);
         }
     }
 }
@@ -1155,11 +1255,30 @@ impl Drop for DeviceMemorySwapAdmission {
 pub(crate) struct DeviceMemoryLease {
     manager: Arc<DeviceMemoryManager>,
     device_id: usize,
-    owner: PoolOwner,
+    memory_owner: MemoryOwner,
+    pool_owner: PoolOwner,
     reservations: Vec<ExternalReservation>,
 }
 
+/// Request-lifetime reservation for CUDA memory allocated outside the pool.
+pub(crate) struct DeviceMemoryTransientLease {
+    manager: Arc<DeviceMemoryManager>,
+    device_id: usize,
+    reservation: ExternalReservation,
+}
+
+impl Drop for DeviceMemoryTransientLease {
+    fn drop(&mut self) {
+        self.manager
+            .release_external_reservations(self.device_id, std::slice::from_ref(&self.reservation));
+    }
+}
+
 impl DeviceMemoryLease {
+    pub(crate) fn owner(&self) -> MemoryOwner {
+        self.memory_owner
+    }
+
     pub(crate) fn reconcile_report(
         &mut self,
         report: &ExternalDeviceMemoryReport,
@@ -1189,25 +1308,51 @@ impl DeviceMemoryLease {
 impl Drop for DeviceMemoryLease {
     fn drop(&mut self) {
         self.manager
-            .release_one(self.device_id, self.owner, &self.reservations);
+            .release_one(self.device_id, self.pool_owner, &self.reservations);
     }
 }
 
-fn owner_for(kind: EngineKind, model_id: u32) -> PoolOwner {
+fn pool_owner_for(kind: EngineKind, owner: MemoryOwner) -> PoolOwner {
     if kind.is_gguf() {
-        PoolOwner::GgufKv { model_id }
+        PoolOwner::gguf(
+            owner.model_id,
+            owner.replica_id,
+            PoolAllocationClass::PersistentWeights,
+        )
     } else if kind == EngineKind::Native {
-        PoolOwner::NativeKv { model_id }
+        PoolOwner::native(
+            owner.model_id,
+            owner.replica_id,
+            PoolAllocationClass::PersistentWeights,
+        )
     } else {
-        PoolOwner::Onnx
+        PoolOwner::onnx(
+            owner.model_id,
+            owner.replica_id,
+            PoolAllocationClass::PersistentWeights,
+        )
     }
 }
 
 fn pool_owner_metric_label(owner: PoolOwner) -> String {
-    match owner {
-        PoolOwner::Onnx => "onnx".to_string(),
-        PoolOwner::GgufKv { model_id } => format!("gguf_kv:{model_id}"),
-        PoolOwner::NativeKv { model_id } => format!("native_kv:{model_id}"),
+    let backend = match owner.backend() {
+        PoolBackend::Onnx => "onnx",
+        PoolBackend::Gguf => "gguf",
+        PoolBackend::Native => "native",
+    };
+    let class = match owner.class() {
+        PoolAllocationClass::PersistentWeights => "persistent-weights",
+        PoolAllocationClass::KvCache => "kv-cache",
+        PoolAllocationClass::TransientWorkspace => "transient-workspace",
+        PoolAllocationClass::BlockTable => "block-table",
+        PoolAllocationClass::RequestTransient => "request-transient",
+        PoolAllocationClass::ExternallyOwned => "externally-owned",
+    };
+    match (owner.model_id(), owner.replica_id()) {
+        (Some(model_id), Some(replica_id)) => {
+            format!("{backend}:{model_id}:{replica_id}:{class}")
+        }
+        _ => format!("{backend}:unattributed:{class}"),
     }
 }
 
@@ -1246,10 +1391,10 @@ fn configured_quota(
     owner: PoolOwner,
     device_id: usize,
 ) -> Result<(usize, usize), String> {
-    let (guaranteed_name, max_name) = match owner {
-        PoolOwner::Onnx => (GPU_ONNX_GUARANTEED_BYTES_ENV, GPU_ONNX_MAX_BYTES_ENV),
-        PoolOwner::GgufKv { .. } => (GPU_GGUF_GUARANTEED_BYTES_ENV, GPU_GGUF_MAX_BYTES_ENV),
-        PoolOwner::NativeKv { .. } => (GPU_NATIVE_GUARANTEED_BYTES_ENV, GPU_NATIVE_MAX_BYTES_ENV),
+    let (guaranteed_name, max_name) = match owner.backend() {
+        PoolBackend::Onnx => (GPU_ONNX_GUARANTEED_BYTES_ENV, GPU_ONNX_MAX_BYTES_ENV),
+        PoolBackend::Gguf => (GPU_GGUF_GUARANTEED_BYTES_ENV, GPU_GGUF_MAX_BYTES_ENV),
+        PoolBackend::Native => (GPU_NATIVE_GUARANTEED_BYTES_ENV, GPU_NATIVE_MAX_BYTES_ENV),
     };
     let max = configured_bytes(max_name, device_id)?.unwrap_or(pool.capacity_bytes());
     // Protect a useful share for each admitted backend by default. Four-way
@@ -1581,14 +1726,24 @@ mod tests {
 
     #[test]
     fn pool_owner_metric_labels_are_stable_and_include_model_identity() {
-        assert_eq!(pool_owner_metric_label(PoolOwner::Onnx), "onnx");
         assert_eq!(
-            pool_owner_metric_label(PoolOwner::GgufKv { model_id: 42 }),
-            "gguf_kv:42"
+            pool_owner_metric_label(PoolOwner::onnx(
+                11,
+                2,
+                PoolAllocationClass::TransientWorkspace
+            )),
+            "onnx:11:2:transient-workspace"
         );
         assert_eq!(
-            pool_owner_metric_label(PoolOwner::NativeKv { model_id: 7 }),
-            "native_kv:7"
+            pool_owner_metric_label(PoolOwner::gguf(42, 3, PoolAllocationClass::KvCache)),
+            "gguf:42:3:kv-cache"
+        );
+        assert_eq!(
+            pool_owner_metric_label(PoolOwner::unattributed(
+                PoolBackend::Native,
+                PoolAllocationClass::ExternallyOwned
+            )),
+            "native:unattributed:externally-owned"
         );
     }
 
@@ -1603,7 +1758,7 @@ mod tests {
             largest_free_range_bytes: 500,
             fragmentation_ratio: 1.0 / 6.0,
             owners: vec![kapsl_hal::gpu_arena::PoolOwnerSnapshot {
-                owner: PoolOwner::GgufKv { model_id: 9 },
+                owner: PoolOwner::gguf(9, 4, PoolAllocationClass::KvCache),
                 usage_bytes: 400,
                 guaranteed_bytes: 300,
                 max_bytes: 800,
@@ -1619,7 +1774,7 @@ mod tests {
         assert_eq!(metrics.largest_free_range_bytes, 500);
         assert_eq!(metrics.fragmentation_ratio, 1.0 / 6.0);
         assert_eq!(metrics.owners.len(), 1);
-        assert_eq!(metrics.owners[0].owner, "gguf_kv:9");
+        assert_eq!(metrics.owners[0].owner, "gguf:9:4:kv-cache");
         assert_eq!(metrics.owners[0].usage_bytes, 400);
         assert_eq!(metrics.owners[0].guaranteed_bytes, 300);
         assert_eq!(metrics.owners[0].max_bytes, 800);

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/host_memory.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/host_memory.rs
@@ -1,7 +1,10 @@
 use crate::app::constants::KAPSL_CPU_MEMORY_LIMIT_MB_ENV;
+use crate::runtime::memory::{MemoryAllocationClass, MemoryClaim, MemoryDomain, MemoryOwner};
 use parking_lot::Mutex;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
+use sysinfo::{Pid, System};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
 const MIB: usize = 1024 * 1024;
 const DEFAULT_HEADROOM_PERCENT: usize = 20;
@@ -16,83 +19,269 @@ pub(crate) struct HostMemoryBudget {
 
 pub(crate) struct HostMemoryManager {
     budget: HostMemoryBudget,
-    cpu_device_ids: HashSet<usize>,
-    reserved_bytes: Mutex<usize>,
+    reservations: Mutex<HostReservations>,
+    load_lock: Arc<AsyncMutex<()>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct HostReservationOwner {
+    owner: MemoryOwner,
+    class: MemoryAllocationClass,
+}
+
+#[derive(Default)]
+struct HostReservations {
+    by_owner: HashMap<HostReservationOwner, usize>,
+}
+
+impl HostReservations {
+    fn total_bytes(&self) -> usize {
+        self.by_owner
+            .values()
+            .copied()
+            .fold(0usize, usize::saturating_add)
+    }
+
+    fn class_group_bytes(&self, class: MemoryAllocationClass) -> usize {
+        self.by_owner
+            .iter()
+            .filter(|(key, _)| budget_group(key.class) == budget_group(class))
+            .map(|(_, bytes)| *bytes)
+            .fold(0usize, usize::saturating_add)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostBudgetGroup {
+    Model,
+    Kv,
+}
+
+fn budget_group(class: MemoryAllocationClass) -> HostBudgetGroup {
+    match class {
+        MemoryAllocationClass::KvCache => HostBudgetGroup::Kv,
+        MemoryAllocationClass::PersistentWeights
+        | MemoryAllocationClass::ModelSession
+        | MemoryAllocationClass::TransientWorkspace
+        | MemoryAllocationClass::BlockTable
+        | MemoryAllocationClass::RequestTransient
+        | MemoryAllocationClass::ExternallyOwned => HostBudgetGroup::Model,
+    }
 }
 
 impl HostMemoryManager {
     pub(crate) fn new(device_info: &kapsl_hal::device::DeviceInfo) -> Arc<Self> {
         Arc::new(Self {
             budget: HostMemoryBudget::detect(device_info.total_memory),
-            cpu_device_ids: device_info
-                .devices
-                .iter()
-                .filter(|device| device.backend.to_string().eq_ignore_ascii_case("cpu"))
-                .map(|device| device.id)
-                .collect(),
-            reserved_bytes: Mutex::new(0),
+            reservations: Mutex::new(HostReservations::default()),
+            load_lock: Arc::new(AsyncMutex::new(())),
         })
+    }
+
+    pub(crate) fn budget(&self) -> HostMemoryBudget {
+        self.budget
     }
 
     pub(crate) fn admit(
         self: &Arc<Self>,
-        device_ids: &[usize],
-        model_id: u32,
-        requested_bytes: usize,
+        claim: &MemoryClaim,
     ) -> Result<Option<HostMemoryLease>, String> {
-        if requested_bytes == 0
-            || !device_ids
-                .iter()
-                .any(|device_id| self.cpu_device_ids.contains(device_id))
-        {
-            return Ok(None);
-        }
-        // The KV coordinator may consume half of the same safe host budget.
-        // Keep model/session reservations inside the complementary half so the
-        // two independently allocated classes cannot jointly exceed it.
-        let admission_budget = self.budget.safe_bytes / 2;
-        let mut reserved = self.reserved_bytes.lock();
-        let projected = reserved.saturating_add(requested_bytes);
-        if projected > admission_budget {
+        if !matches!(
+            claim.domain,
+            MemoryDomain::Host | MemoryDomain::HostPinned { .. } | MemoryDomain::HostMapped { .. }
+        ) {
             return Err(format!(
-                "CPU memory admission rejected for model {model_id}: requested={requested_bytes} reserved={} projected={projected} model_budget={admission_budget} host_safe_budget={} bytes",
-                *reserved, self.budget.safe_bytes,
+                "host memory manager cannot admit a {} claim",
+                claim.domain
             ));
         }
-        *reserved = projected;
+        if claim.bytes == 0 {
+            return Ok(None);
+        }
+        // KV retains its historical half-budget. Model/session and active
+        // request-transient memory share the complementary half, so a full KV
+        // cache can never push aggregate admitted memory above the safe budget.
+        let class_budget = self.budget.class_limit(claim.class);
+        let mut reservations = self.reservations.lock();
+        let class_reserved = reservations.class_group_bytes(claim.class);
+        let class_projected = class_reserved.saturating_add(claim.bytes);
+        let global_projected = reservations.total_bytes().saturating_add(claim.bytes);
+        if class_projected > class_budget || global_projected > self.budget.safe_bytes {
+            return Err(format!(
+                "host memory admission rejected for {} class={}: requested={} class_reserved={} class_projected={} class_budget={} global_projected={} host_safe_budget={} bytes",
+                claim.owner,
+                claim.class,
+                claim.bytes,
+                class_reserved,
+                class_projected,
+                class_budget,
+                global_projected,
+                self.budget.safe_bytes,
+            ));
+        }
+        let key = HostReservationOwner {
+            owner: claim.owner,
+            class: claim.class,
+        };
+        let owned = reservations.by_owner.entry(key).or_default();
+        *owned = owned.saturating_add(claim.bytes);
         log::info!(
-            "[host-memory] admitted model {}: reserved={} global_reserved={} model_budget={} host_safe_budget={} bytes",
-            model_id,
-            requested_bytes,
-            projected,
-            admission_budget,
+            "[host-memory] admitted {} class={}: reserved={} class_reserved={} global_reserved={} class_budget={} host_safe_budget={} bytes",
+            claim.owner,
+            claim.class,
+            claim.bytes,
+            class_projected,
+            global_projected,
+            class_budget,
             self.budget.safe_bytes
         );
         Ok(Some(HostMemoryLease {
             manager: Arc::clone(self),
-            bytes: requested_bytes,
+            key,
+            bytes: claim.bytes,
         }))
     }
 
     #[cfg(test)]
-    fn reserved_bytes(&self) -> usize {
-        *self.reserved_bytes.lock()
+    pub(crate) fn reserved_bytes(&self) -> usize {
+        self.reservations.lock().total_bytes()
+    }
+
+    /// Serialize host model loads so a before/after process-RSS delta can be
+    /// attributed to one load transaction. Existing inference may still move
+    /// RSS while the sample is open, so reconciliation only raises the planned
+    /// reservation; it never weakens a conservative estimate.
+    pub(crate) async fn begin_load_reconciliation(self: &Arc<Self>) -> HostMemoryLoadAdmission {
+        let guard = Arc::clone(&self.load_lock).lock_owned().await;
+        HostMemoryLoadAdmission {
+            manager: Arc::clone(self),
+            rss_before: process_rss_bytes(),
+            _guard: Some(guard),
+        }
+    }
+
+    fn resize_lease(&self, lease: &mut HostMemoryLease, target_bytes: usize) -> Result<(), String> {
+        if lease.bytes == target_bytes {
+            return Ok(());
+        }
+        let mut reservations = self.reservations.lock();
+        let class_reserved = reservations.class_group_bytes(lease.key.class);
+        let global_reserved = reservations.total_bytes();
+        let class_projected = class_reserved
+            .saturating_sub(lease.bytes)
+            .saturating_add(target_bytes);
+        let global_projected = global_reserved
+            .saturating_sub(lease.bytes)
+            .saturating_add(target_bytes);
+        let class_budget = self.budget.class_limit(lease.key.class);
+        if class_projected > class_budget || global_projected > self.budget.safe_bytes {
+            return Err(format!(
+                "host memory reconciliation rejected for {} class={}: planned={} observed_target={} class_projected={} class_budget={} global_projected={} host_safe_budget={} bytes",
+                lease.key.owner,
+                lease.key.class,
+                lease.bytes,
+                target_bytes,
+                class_projected,
+                class_budget,
+                global_projected,
+                self.budget.safe_bytes,
+            ));
+        }
+        let owned = reservations.by_owner.entry(lease.key).or_default();
+        *owned = owned
+            .saturating_sub(lease.bytes)
+            .saturating_add(target_bytes);
+        if *owned == 0 {
+            reservations.by_owner.remove(&lease.key);
+        }
+        lease.bytes = target_bytes;
+        Ok(())
     }
 }
 
 pub(crate) struct HostMemoryLease {
     manager: Arc<HostMemoryManager>,
+    key: HostReservationOwner,
     bytes: usize,
+}
+
+/// Before/after RSS attribution guard for one host model load.
+pub(crate) struct HostMemoryLoadAdmission {
+    manager: Arc<HostMemoryManager>,
+    rss_before: Option<usize>,
+    _guard: Option<OwnedMutexGuard<()>>,
+}
+
+impl HostMemoryLoadAdmission {
+    pub(crate) fn reconcile(&mut self, leases: &mut [HostMemoryLease]) -> Result<(), String> {
+        let planned_total = leases
+            .iter()
+            .filter(|lease| budget_group(lease.key.class) == HostBudgetGroup::Model)
+            .map(|lease| lease.bytes)
+            .fold(0usize, usize::saturating_add);
+        let observed_delta = self
+            .rss_before
+            .zip(process_rss_bytes())
+            .map(|(before, after)| after.saturating_sub(before));
+        let target_total = observed_delta.map_or(planned_total, |bytes| bytes.max(planned_total));
+
+        if target_total > planned_total {
+            let Some(index) = leases
+                .iter()
+                .position(|lease| budget_group(lease.key.class) == HostBudgetGroup::Model)
+            else {
+                self._guard.take();
+                return Err(format!(
+                    "observed {} bytes of host RSS growth without a model/session reservation",
+                    target_total - planned_total
+                ));
+            };
+            let target = leases[index]
+                .bytes
+                .saturating_add(target_total - planned_total);
+            self.manager.resize_lease(&mut leases[index], target)?;
+        }
+        log::info!(
+            "[host-memory] reconciled model load: planned={} observed_rss_delta={:?} retained={} bytes",
+            planned_total,
+            observed_delta,
+            target_total
+        );
+        self._guard.take();
+        Ok(())
+    }
+}
+
+fn process_rss_bytes() -> Option<usize> {
+    let mut system = System::new();
+    let pid = Pid::from_u32(std::process::id());
+    system.refresh_process(pid);
+    system.process(pid).map(|process| process.memory() as usize)
 }
 
 impl Drop for HostMemoryLease {
     fn drop(&mut self) {
-        let mut reserved = self.manager.reserved_bytes.lock();
-        *reserved = reserved.saturating_sub(self.bytes);
+        let mut reservations = self.manager.reservations.lock();
+        let remove = reservations
+            .by_owner
+            .get_mut(&self.key)
+            .is_some_and(|bytes| {
+                *bytes = bytes.saturating_sub(self.bytes);
+                *bytes == 0
+            });
+        if remove {
+            reservations.by_owner.remove(&self.key);
+        }
     }
 }
 
 impl HostMemoryBudget {
+    pub(crate) fn class_limit(self, _class: MemoryAllocationClass) -> usize {
+        // Each group may use up to half of safe memory, but all groups remain
+        // subject to the single global safe-memory cap.
+        self.safe_bytes / 2
+    }
+
     pub(crate) fn detect(system_total_kib: u64) -> Self {
         let physical = usize::try_from(system_total_kib)
             .unwrap_or(usize::MAX / 1024)
@@ -145,10 +334,11 @@ fn cgroup_memory_limit_bytes() -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::{HostMemoryBudget, HostMemoryManager};
+    use super::{HostMemoryBudget, HostMemoryManager, HostReservations};
+    use crate::runtime::memory::{MemoryAllocationClass, MemoryClaim, MemoryDomain, MemoryOwner};
     use parking_lot::Mutex;
-    use std::collections::HashSet;
     use std::sync::Arc;
+    use tokio::sync::Mutex as AsyncMutex;
 
     const GIB: usize = 1024 * 1024 * 1024;
 
@@ -179,27 +369,131 @@ mod tests {
                 limit_bytes: 10 * GIB,
                 safe_bytes: 8 * GIB,
             },
-            cpu_device_ids: HashSet::from([0]),
-            reserved_bytes: Mutex::new(0),
+            reservations: Mutex::new(HostReservations::default()),
+            load_lock: Arc::new(AsyncMutex::new(())),
         });
-        let lease = manager.admit(&[0], 7, 3 * GIB).unwrap().unwrap();
+        let first = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(7, 2),
+            MemoryAllocationClass::ModelSession,
+            3 * GIB,
+        );
+        let lease = manager.admit(&first).unwrap().unwrap();
         assert_eq!(manager.reserved_bytes(), 3 * GIB);
-        assert!(manager.admit(&[0], 8, 6 * GIB).is_err());
+        let too_large = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(8, 0),
+            MemoryAllocationClass::PersistentWeights,
+            2 * GIB,
+        );
+        assert!(manager.admit(&too_large).is_err());
         drop(lease);
         assert_eq!(manager.reserved_bytes(), 0);
     }
 
     #[test]
-    fn non_cpu_devices_do_not_consume_host_admission_budget() {
+    fn rss_reconciliation_can_raise_but_not_overcommit_a_lease() {
         let manager = Arc::new(HostMemoryManager {
             budget: HostMemoryBudget {
                 limit_bytes: 10 * GIB,
                 safe_bytes: 8 * GIB,
             },
-            cpu_device_ids: HashSet::from([0]),
-            reserved_bytes: Mutex::new(0),
+            reservations: Mutex::new(HostReservations::default()),
+            load_lock: Arc::new(AsyncMutex::new(())),
         });
-        assert!(manager.admit(&[1], 7, GIB).unwrap().is_none());
+        let claim = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(7, 2),
+            MemoryAllocationClass::ModelSession,
+            2 * GIB,
+        );
+        let mut lease = manager.admit(&claim).unwrap().unwrap();
+        manager.resize_lease(&mut lease, 3 * GIB).unwrap();
+        assert_eq!(manager.reserved_bytes(), 3 * GIB);
+        assert!(manager.resize_lease(&mut lease, 5 * GIB).is_err());
+        assert_eq!(manager.reserved_bytes(), 3 * GIB);
+        drop(lease);
         assert_eq!(manager.reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn kv_and_model_classes_have_independent_half_budgets() {
+        let manager = Arc::new(HostMemoryManager {
+            budget: HostMemoryBudget {
+                limit_bytes: 10 * GIB,
+                safe_bytes: 8 * GIB,
+            },
+            reservations: Mutex::new(HostReservations::default()),
+            load_lock: Arc::new(AsyncMutex::new(())),
+        });
+        let model = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(7, 0),
+            MemoryAllocationClass::ModelSession,
+            4 * GIB,
+        );
+        let kv = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(7, 0),
+            MemoryAllocationClass::KvCache,
+            4 * GIB,
+        );
+        let model_lease = manager.admit(&model).unwrap().unwrap();
+        let kv_lease = manager.admit(&kv).unwrap().unwrap();
+        assert_eq!(manager.reserved_bytes(), 8 * GIB);
+        drop((model_lease, kv_lease));
+        assert_eq!(manager.reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn request_transient_shares_the_non_kv_half_budget() {
+        let manager = Arc::new(HostMemoryManager {
+            budget: HostMemoryBudget {
+                limit_bytes: 10 * GIB,
+                safe_bytes: 8 * GIB,
+            },
+            reservations: Mutex::new(HostReservations::default()),
+            load_lock: Arc::new(AsyncMutex::new(())),
+        });
+        let model = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(7, 0),
+            MemoryAllocationClass::ModelSession,
+            3 * GIB,
+        );
+        let request = MemoryClaim::runtime(
+            MemoryDomain::Host,
+            MemoryOwner::new(7, 0),
+            MemoryAllocationClass::RequestTransient,
+            GIB,
+        );
+        let model_lease = manager.admit(&model).unwrap().unwrap();
+        let request_lease = manager.admit(&request).unwrap().unwrap();
+        assert!(manager.admit(&request).is_err());
+        drop((model_lease, request_lease));
+        assert_eq!(manager.reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn non_host_domains_are_rejected() {
+        let manager = Arc::new(HostMemoryManager {
+            budget: HostMemoryBudget {
+                limit_bytes: 10 * GIB,
+                safe_bytes: 8 * GIB,
+            },
+            reservations: Mutex::new(HostReservations::default()),
+            load_lock: Arc::new(AsyncMutex::new(())),
+        });
+        let claim = MemoryClaim::runtime(
+            MemoryDomain::Cuda { device_id: 1 },
+            MemoryOwner::new(7, 0),
+            MemoryAllocationClass::ModelSession,
+            GIB,
+        );
+        let error = match manager.admit(&claim) {
+            Ok(_) => panic!("CUDA claim must not be admitted by the host manager"),
+            Err(error) => error,
+        };
+        assert!(error.contains("cannot admit"));
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/host_memory.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/host_memory.rs
@@ -1,0 +1,90 @@
+use crate::app::constants::KAPSL_CPU_MEMORY_LIMIT_MB_ENV;
+
+const MIB: usize = 1024 * 1024;
+const DEFAULT_HEADROOM_PERCENT: usize = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct HostMemoryBudget {
+    /// The tightest detected physical, container, or operator-provided limit.
+    pub(crate) limit_bytes: usize,
+    /// Memory available to runtime-owned model state after safety headroom.
+    pub(crate) safe_bytes: usize,
+}
+
+impl HostMemoryBudget {
+    pub(crate) fn detect(system_total_kib: u64) -> Self {
+        let physical = usize::try_from(system_total_kib)
+            .unwrap_or(usize::MAX / 1024)
+            .saturating_mul(1024);
+        let configured = std::env::var(KAPSL_CPU_MEMORY_LIMIT_MB_ENV)
+            .ok()
+            .and_then(|raw| raw.trim().parse::<usize>().ok())
+            .filter(|value| *value > 0)
+            .map(|mib| mib.saturating_mul(MIB));
+        let container = cgroup_memory_limit_bytes();
+        Self::from_limits(physical, configured, container)
+    }
+
+    fn from_limits(
+        physical_bytes: usize,
+        configured_bytes: Option<usize>,
+        container_bytes: Option<usize>,
+    ) -> Self {
+        let limit_bytes = [
+            Some(physical_bytes).filter(|value| *value > 0),
+            configured_bytes,
+            container_bytes,
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(0);
+        let safe_bytes = limit_bytes.saturating_mul(100 - DEFAULT_HEADROOM_PERCENT) / 100;
+        Self {
+            limit_bytes,
+            safe_bytes,
+        }
+    }
+}
+
+fn cgroup_memory_limit_bytes() -> Option<usize> {
+    // v2 first, then the common v1 path. `max` and implausibly large v1
+    // sentinel values mean unlimited and are deliberately ignored.
+    [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ]
+    .into_iter()
+    .filter_map(|path| std::fs::read_to_string(path).ok())
+    .filter_map(|raw| raw.trim().parse::<u64>().ok())
+    .filter(|limit| *limit > 0 && *limit < (1_u64 << 60))
+    .filter_map(|limit| usize::try_from(limit).ok())
+    .min()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HostMemoryBudget;
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    #[test]
+    fn keeps_twenty_percent_headroom() {
+        let budget = HostMemoryBudget::from_limits(16 * GIB, None, None);
+        assert_eq!(budget.limit_bytes, 16 * GIB);
+        assert_eq!(budget.safe_bytes, 16 * GIB * 4 / 5);
+    }
+
+    #[test]
+    fn tightest_limit_wins() {
+        let budget = HostMemoryBudget::from_limits(64 * GIB, Some(24 * GIB), Some(16 * GIB));
+        assert_eq!(budget.limit_bytes, 16 * GIB);
+        assert_eq!(budget.safe_bytes, 16 * GIB * 4 / 5);
+    }
+
+    #[test]
+    fn zero_physical_memory_can_fall_back_to_a_container_limit() {
+        let budget = HostMemoryBudget::from_limits(0, None, Some(8 * GIB));
+        assert_eq!(budget.limit_bytes, 8 * GIB);
+    }
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/host_memory.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/host_memory.rs
@@ -1,4 +1,7 @@
 use crate::app::constants::KAPSL_CPU_MEMORY_LIMIT_MB_ENV;
+use parking_lot::Mutex;
+use std::collections::HashSet;
+use std::sync::Arc;
 
 const MIB: usize = 1024 * 1024;
 const DEFAULT_HEADROOM_PERCENT: usize = 20;
@@ -9,6 +12,84 @@ pub(crate) struct HostMemoryBudget {
     pub(crate) limit_bytes: usize,
     /// Memory available to runtime-owned model state after safety headroom.
     pub(crate) safe_bytes: usize,
+}
+
+pub(crate) struct HostMemoryManager {
+    budget: HostMemoryBudget,
+    cpu_device_ids: HashSet<usize>,
+    reserved_bytes: Mutex<usize>,
+}
+
+impl HostMemoryManager {
+    pub(crate) fn new(device_info: &kapsl_hal::device::DeviceInfo) -> Arc<Self> {
+        Arc::new(Self {
+            budget: HostMemoryBudget::detect(device_info.total_memory),
+            cpu_device_ids: device_info
+                .devices
+                .iter()
+                .filter(|device| device.backend.to_string().eq_ignore_ascii_case("cpu"))
+                .map(|device| device.id)
+                .collect(),
+            reserved_bytes: Mutex::new(0),
+        })
+    }
+
+    pub(crate) fn admit(
+        self: &Arc<Self>,
+        device_ids: &[usize],
+        model_id: u32,
+        requested_bytes: usize,
+    ) -> Result<Option<HostMemoryLease>, String> {
+        if requested_bytes == 0
+            || !device_ids
+                .iter()
+                .any(|device_id| self.cpu_device_ids.contains(device_id))
+        {
+            return Ok(None);
+        }
+        // The KV coordinator may consume half of the same safe host budget.
+        // Keep model/session reservations inside the complementary half so the
+        // two independently allocated classes cannot jointly exceed it.
+        let admission_budget = self.budget.safe_bytes / 2;
+        let mut reserved = self.reserved_bytes.lock();
+        let projected = reserved.saturating_add(requested_bytes);
+        if projected > admission_budget {
+            return Err(format!(
+                "CPU memory admission rejected for model {model_id}: requested={requested_bytes} reserved={} projected={projected} model_budget={admission_budget} host_safe_budget={} bytes",
+                *reserved, self.budget.safe_bytes,
+            ));
+        }
+        *reserved = projected;
+        log::info!(
+            "[host-memory] admitted model {}: reserved={} global_reserved={} model_budget={} host_safe_budget={} bytes",
+            model_id,
+            requested_bytes,
+            projected,
+            admission_budget,
+            self.budget.safe_bytes
+        );
+        Ok(Some(HostMemoryLease {
+            manager: Arc::clone(self),
+            bytes: requested_bytes,
+        }))
+    }
+
+    #[cfg(test)]
+    fn reserved_bytes(&self) -> usize {
+        *self.reserved_bytes.lock()
+    }
+}
+
+pub(crate) struct HostMemoryLease {
+    manager: Arc<HostMemoryManager>,
+    bytes: usize,
+}
+
+impl Drop for HostMemoryLease {
+    fn drop(&mut self) {
+        let mut reserved = self.manager.reserved_bytes.lock();
+        *reserved = reserved.saturating_sub(self.bytes);
+    }
 }
 
 impl HostMemoryBudget {
@@ -64,7 +145,10 @@ fn cgroup_memory_limit_bytes() -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::HostMemoryBudget;
+    use super::{HostMemoryBudget, HostMemoryManager};
+    use parking_lot::Mutex;
+    use std::collections::HashSet;
+    use std::sync::Arc;
 
     const GIB: usize = 1024 * 1024 * 1024;
 
@@ -86,5 +170,36 @@ mod tests {
     fn zero_physical_memory_can_fall_back_to_a_container_limit() {
         let budget = HostMemoryBudget::from_limits(0, None, Some(8 * GIB));
         assert_eq!(budget.limit_bytes, 8 * GIB);
+    }
+
+    #[test]
+    fn admission_is_released_with_its_lease() {
+        let manager = Arc::new(HostMemoryManager {
+            budget: HostMemoryBudget {
+                limit_bytes: 10 * GIB,
+                safe_bytes: 8 * GIB,
+            },
+            cpu_device_ids: HashSet::from([0]),
+            reserved_bytes: Mutex::new(0),
+        });
+        let lease = manager.admit(&[0], 7, 3 * GIB).unwrap().unwrap();
+        assert_eq!(manager.reserved_bytes(), 3 * GIB);
+        assert!(manager.admit(&[0], 8, 6 * GIB).is_err());
+        drop(lease);
+        assert_eq!(manager.reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn non_cpu_devices_do_not_consume_host_admission_budget() {
+        let manager = Arc::new(HostMemoryManager {
+            budget: HostMemoryBudget {
+                limit_bytes: 10 * GIB,
+                safe_bytes: 8 * GIB,
+            },
+            cpu_device_ids: HashSet::from([0]),
+            reserved_bytes: Mutex::new(0),
+        });
+        assert!(manager.admit(&[1], 7, GIB).unwrap().is_none());
+        assert_eq!(manager.reserved_bytes(), 0);
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/memory.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/memory.rs
@@ -1,0 +1,1584 @@
+//! Backend-neutral memory admission and lifetime ownership.
+//!
+//! A [`MemoryPlan`] describes memory before a backend allocates it. The
+//! [`MemoryAuthority`] routes each claim to the manager for its domain, and a
+//! committed [`MemoryLease`] retains those reservations until the owning
+//! model/replica is unloaded. Provider domains are accounting adapters: they
+//! participate in ownership and lifetime now, without pretending that the
+//! runtime physically allocates their memory.
+
+use super::host_memory::{HostMemoryLease, HostMemoryLoadAdmission, HostMemoryManager};
+use kapsl_core::EngineKind;
+#[cfg(any(feature = "gpu-device-pool", test))]
+use kapsl_engine_api::{ExternalDeviceMemory, ExternalDeviceMemoryReport};
+use kapsl_engine_api::{
+    MemoryAllocationClass as BackendMemoryAllocationClass,
+    MemoryAllocationSource as BackendMemoryAllocationSource, MemoryDomain as BackendMemoryDomain,
+    MemoryReport as BackendMemoryReport,
+};
+use kapsl_hal::device::DeviceInfo;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+#[cfg(feature = "gpu-device-pool")]
+use super::device_memory::{
+    DeviceMemoryAdmission, DeviceMemoryBootstrapPlan, DeviceMemoryLease, DeviceMemoryManager,
+    DeviceMemorySwapAdmission, DeviceMemoryTransientLease,
+};
+
+/// An independently-budgeted memory domain.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum MemoryDomain {
+    Host,
+    HostPinned {
+        provider: String,
+        device_id: Option<usize>,
+    },
+    HostMapped {
+        provider: String,
+        device_id: Option<usize>,
+    },
+    Cuda {
+        device_id: usize,
+    },
+    /// A provider that is not managed by the host or CUDA allocators.
+    Provider {
+        provider: String,
+        device_id: Option<usize>,
+    },
+}
+
+impl fmt::Display for MemoryDomain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Host => formatter.write_str("host"),
+            Self::HostPinned {
+                provider,
+                device_id: Some(device_id),
+            } => write!(formatter, "host-pinned:{provider}:{device_id}"),
+            Self::HostPinned {
+                provider,
+                device_id: None,
+            } => write!(formatter, "host-pinned:{provider}"),
+            Self::HostMapped {
+                provider,
+                device_id: Some(device_id),
+            } => write!(formatter, "host-mapped:{provider}:{device_id}"),
+            Self::HostMapped {
+                provider,
+                device_id: None,
+            } => write!(formatter, "host-mapped:{provider}"),
+            Self::Cuda { device_id } => write!(formatter, "cuda:{device_id}"),
+            Self::Provider {
+                provider,
+                device_id: Some(device_id),
+            } => write!(formatter, "{provider}:{device_id}"),
+            Self::Provider {
+                provider,
+                device_id: None,
+            } => formatter.write_str(provider),
+        }
+    }
+}
+
+impl MemoryDomain {
+    fn from_backend(domain: &BackendMemoryDomain) -> Self {
+        match domain {
+            BackendMemoryDomain::Host => Self::Host,
+            BackendMemoryDomain::HostPinned {
+                provider,
+                device_id,
+            } => Self::HostPinned {
+                provider: provider.clone(),
+                device_id: *device_id,
+            },
+            BackendMemoryDomain::HostMapped {
+                provider,
+                device_id,
+            } => Self::HostMapped {
+                provider: provider.clone(),
+                device_id: *device_id,
+            },
+            BackendMemoryDomain::Cuda { device_id } => Self::Cuda {
+                device_id: *device_id,
+            },
+            BackendMemoryDomain::Provider {
+                provider,
+                device_id,
+            } => {
+                let provider = match provider.trim().to_ascii_lowercase().as_str() {
+                    // CoreML executes in the Metal device domain selected by
+                    // the runtime. Treat both names as one admission domain so
+                    // an explicit backend report is not discarded and replaced
+                    // by a legacy estimate.
+                    "coreml" | "metal" => "metal".to_string(),
+                    provider => provider.to_string(),
+                };
+                Self::Provider {
+                    provider,
+                    device_id: *device_id,
+                }
+            }
+        }
+    }
+
+    pub(crate) fn for_provider(provider: &str, device_id: usize) -> Self {
+        match provider.trim().to_ascii_lowercase().as_str() {
+            "cpu" => Self::Host,
+            "cuda" | "tensorrt" => Self::Cuda { device_id },
+            "coreml" | "metal" => Self::Provider {
+                provider: "metal".to_string(),
+                device_id: Some(device_id),
+            },
+            provider => Self::Provider {
+                provider: provider.to_string(),
+                device_id: Some(device_id),
+            },
+        }
+    }
+}
+
+/// Why an allocation exists. Budgets and metrics can aggregate these without
+/// knowing which backend produced them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum MemoryAllocationClass {
+    PersistentWeights,
+    ModelSession,
+    KvCache,
+    TransientWorkspace,
+    BlockTable,
+    RequestTransient,
+    ExternallyOwned,
+}
+
+impl MemoryAllocationClass {
+    fn from_backend(class: BackendMemoryAllocationClass) -> Self {
+        match class {
+            BackendMemoryAllocationClass::PersistentWeights => Self::PersistentWeights,
+            BackendMemoryAllocationClass::ModelSession => Self::ModelSession,
+            BackendMemoryAllocationClass::KvCache => Self::KvCache,
+            BackendMemoryAllocationClass::TransientWorkspace => Self::TransientWorkspace,
+            BackendMemoryAllocationClass::BlockTable => Self::BlockTable,
+            BackendMemoryAllocationClass::RequestTransient => Self::RequestTransient,
+            BackendMemoryAllocationClass::ExternallyOwned => Self::ExternallyOwned,
+        }
+    }
+}
+
+impl fmt::Display for MemoryAllocationClass {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PersistentWeights => "persistent-weights",
+            Self::ModelSession => "model-session",
+            Self::KvCache => "kv-cache",
+            Self::TransientWorkspace => "transient-workspace",
+            Self::BlockTable => "block-table",
+            Self::RequestTransient => "request-transient",
+            Self::ExternallyOwned => "externally-owned",
+        })
+    }
+}
+
+/// Stable workload identity carried through every admission adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct MemoryOwner {
+    pub(crate) model_id: u32,
+    pub(crate) replica_id: u32,
+}
+
+impl MemoryOwner {
+    pub(crate) const fn new(model_id: u32, replica_id: u32) -> Self {
+        Self {
+            model_id,
+            replica_id,
+        }
+    }
+}
+
+impl fmt::Display for MemoryOwner {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "model {} replica {}",
+            self.model_id, self.replica_id
+        )
+    }
+}
+
+/// Whether bytes are runtime-managed or only accounted by an adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MemoryClaimSource {
+    Runtime { allocation_id: Option<String> },
+    External { allocation_id: String },
+}
+
+/// One independently-owned claim in a memory plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemoryClaim {
+    pub(crate) domain: MemoryDomain,
+    pub(crate) owner: MemoryOwner,
+    pub(crate) class: MemoryAllocationClass,
+    pub(crate) bytes: usize,
+    pub(crate) source: MemoryClaimSource,
+}
+
+impl MemoryClaim {
+    pub(crate) fn runtime(
+        domain: MemoryDomain,
+        owner: MemoryOwner,
+        class: MemoryAllocationClass,
+        bytes: usize,
+    ) -> Self {
+        Self {
+            domain,
+            owner,
+            class,
+            bytes,
+            source: MemoryClaimSource::Runtime {
+                allocation_id: None,
+            },
+        }
+    }
+
+    pub(crate) fn runtime_allocation(
+        domain: MemoryDomain,
+        owner: MemoryOwner,
+        class: MemoryAllocationClass,
+        allocation_id: impl Into<String>,
+        bytes: usize,
+    ) -> Self {
+        Self {
+            domain,
+            owner,
+            class,
+            bytes,
+            source: MemoryClaimSource::Runtime {
+                allocation_id: Some(allocation_id.into()),
+            },
+        }
+    }
+
+    pub(crate) fn external(
+        domain: MemoryDomain,
+        owner: MemoryOwner,
+        class: MemoryAllocationClass,
+        allocation_id: impl Into<String>,
+        bytes: usize,
+    ) -> Self {
+        Self {
+            domain,
+            owner,
+            class,
+            bytes,
+            source: MemoryClaimSource::External {
+                allocation_id: allocation_id.into(),
+            },
+        }
+    }
+}
+
+/// Backend-neutral declaration of a workload's host and device memory.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct MemoryPlan {
+    claims: Vec<MemoryClaim>,
+}
+
+impl MemoryPlan {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn push(&mut self, claim: MemoryClaim) -> &mut Self {
+        self.claims.push(claim);
+        self
+    }
+
+    pub(crate) fn claims(&self) -> &[MemoryClaim] {
+        &self.claims
+    }
+
+    pub(crate) fn extend(&mut self, other: Self) -> &mut Self {
+        self.claims.extend(other.claims);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn request_transient(owner: MemoryOwner, bytes: usize) -> Self {
+        Self {
+            claims: vec![MemoryClaim::runtime(
+                MemoryDomain::Host,
+                owner,
+                MemoryAllocationClass::RequestTransient,
+                bytes,
+            )],
+        }
+    }
+
+    pub(crate) fn from_backend_report(owner: MemoryOwner, report: &BackendMemoryReport) -> Self {
+        let claims = report
+            .allocations
+            .iter()
+            .map(|allocation| {
+                let domain = MemoryDomain::from_backend(&allocation.domain);
+                let class = MemoryAllocationClass::from_backend(allocation.class);
+                match allocation.source {
+                    BackendMemoryAllocationSource::RuntimeManaged => {
+                        MemoryClaim::runtime_allocation(
+                            domain,
+                            owner,
+                            class,
+                            allocation.allocation_id.clone(),
+                            allocation.bytes,
+                        )
+                    }
+                    BackendMemoryAllocationSource::BackendManaged => MemoryClaim::external(
+                        domain,
+                        owner,
+                        class,
+                        allocation.allocation_id.clone(),
+                        allocation.bytes,
+                    ),
+                }
+            })
+            .collect();
+        Self { claims }
+    }
+
+    /// Request-time authority. Runtime-managed CUDA rows are enforced by the
+    /// admitted workload's pool quota at allocation time; backend-managed CUDA
+    /// rows receive a transient device-budget reservation. Host, pinned,
+    /// mapped, and provider rows are retained for the request lifetime.
+    pub(crate) fn request_from_backend_report(
+        owner: MemoryOwner,
+        report: &BackendMemoryReport,
+    ) -> Self {
+        let mut plan = Self::from_backend_report(owner, report);
+        plan.claims.retain(|claim| {
+            matches!(
+                claim.domain,
+                MemoryDomain::Host
+                    | MemoryDomain::HostPinned { .. }
+                    | MemoryDomain::HostMapped { .. }
+                    | MemoryDomain::Provider { .. }
+            ) || (cfg!(feature = "gpu-device-pool")
+                && matches!(claim.domain, MemoryDomain::Cuda { .. }))
+        });
+        plan
+    }
+
+    #[cfg(test)]
+    pub(crate) fn external_cuda_report(
+        owner: MemoryOwner,
+        report: &ExternalDeviceMemoryReport,
+    ) -> Self {
+        let mut plan = Self::new();
+        for allocation in &report.allocations {
+            plan.push(MemoryClaim::external(
+                MemoryDomain::Cuda {
+                    device_id: allocation.device_id,
+                },
+                owner,
+                classify_external_allocation(&allocation.allocation_id),
+                allocation.allocation_id.clone(),
+                allocation.bytes,
+            ));
+        }
+        plan
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    fn external_report_for_cuda(&self, device_id: usize) -> ExternalDeviceMemoryReport {
+        ExternalDeviceMemoryReport {
+            allocations: self
+                .claims
+                .iter()
+                .filter_map(|claim| match (&claim.domain, &claim.source) {
+                    (
+                        MemoryDomain::Cuda {
+                            device_id: candidate,
+                        },
+                        MemoryClaimSource::External { allocation_id },
+                    ) if *candidate == device_id => Some(ExternalDeviceMemory {
+                        allocation_id: allocation_id.clone(),
+                        device_id,
+                        bytes: claim.bytes,
+                    }),
+                    _ => None,
+                })
+                .collect(),
+        }
+    }
+
+    #[cfg(any(feature = "gpu-device-pool", test))]
+    fn cuda_device_ids(&self) -> Vec<usize> {
+        let mut device_ids: Vec<_> = self
+            .claims
+            .iter()
+            .filter_map(|claim| match claim.domain {
+                MemoryDomain::Cuda { device_id } => Some(device_id),
+                _ => None,
+            })
+            .collect();
+        device_ids.sort_unstable();
+        device_ids.dedup();
+        device_ids
+    }
+}
+
+#[cfg(any(feature = "gpu-device-pool", test))]
+pub(crate) fn classify_external_allocation(allocation_id: &str) -> MemoryAllocationClass {
+    let lowered = allocation_id.to_ascii_lowercase();
+    if lowered.contains("block-table") || lowered.contains("block_table") {
+        MemoryAllocationClass::BlockTable
+    } else if lowered.contains("scratch") || lowered.contains("workspace") {
+        MemoryAllocationClass::TransientWorkspace
+    } else if lowered.contains("kv") || lowered.contains("past") || lowered.contains("present") {
+        MemoryAllocationClass::KvCache
+    } else if lowered.contains("session") {
+        MemoryAllocationClass::ModelSession
+    } else if lowered.contains("weight")
+        || lowered.contains("model")
+        || lowered.contains("gguf")
+        || lowered.contains("native")
+    {
+        MemoryAllocationClass::PersistentWeights
+    } else {
+        MemoryAllocationClass::ExternallyOwned
+    }
+}
+
+#[cfg(feature = "gpu-device-pool")]
+fn external_cuda_report_from_backend(report: &BackendMemoryReport) -> ExternalDeviceMemoryReport {
+    ExternalDeviceMemoryReport {
+        allocations: report
+            .allocations
+            .iter()
+            .filter_map(|allocation| {
+                let BackendMemoryDomain::Cuda { device_id } = &allocation.domain else {
+                    return None;
+                };
+                if allocation.source != BackendMemoryAllocationSource::BackendManaged {
+                    return None;
+                }
+                Some(ExternalDeviceMemory {
+                    allocation_id: allocation.allocation_id.clone(),
+                    device_id: *device_id,
+                    bytes: allocation.bytes,
+                })
+            })
+            .collect(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ProviderAllocationKey {
+    domain: MemoryDomain,
+    allocation_id: String,
+}
+
+#[derive(Debug)]
+struct ProviderAllocation {
+    class: MemoryAllocationClass,
+    bytes: usize,
+    owners: HashMap<MemoryOwner, usize>,
+}
+
+#[derive(Default)]
+struct ProviderMemoryLedger {
+    allocations: Mutex<HashMap<ProviderAllocationKey, ProviderAllocation>>,
+    next_transient_allocation: std::sync::atomic::AtomicU64,
+}
+
+impl ProviderMemoryLedger {
+    fn reserve(
+        self: &Arc<Self>,
+        claim: &MemoryClaim,
+    ) -> Result<Option<ProviderMemoryLease>, String> {
+        let MemoryDomain::Provider { .. } = claim.domain else {
+            return Ok(None);
+        };
+        if claim.bytes == 0 {
+            return Ok(None);
+        }
+        let mut allocation_id = match &claim.source {
+            MemoryClaimSource::External { allocation_id } => allocation_id.clone(),
+            MemoryClaimSource::Runtime { allocation_id } => {
+                allocation_id.clone().unwrap_or_else(|| {
+                    format!(
+                        "runtime:{}:{}:{}",
+                        claim.owner.model_id, claim.owner.replica_id, claim.class
+                    )
+                })
+            }
+        };
+        if claim.class == MemoryAllocationClass::RequestTransient {
+            use std::sync::atomic::Ordering;
+            allocation_id = format!(
+                "{}:request:{}",
+                allocation_id,
+                self.next_transient_allocation
+                    .fetch_add(1, Ordering::Relaxed)
+            );
+        }
+        let key = ProviderAllocationKey {
+            domain: claim.domain.clone(),
+            allocation_id,
+        };
+        let mut allocations = self.allocations.lock();
+        if let Some(existing) = allocations.get_mut(&key) {
+            if existing.class != claim.class {
+                return Err(format!(
+                    "provider allocation `{}` in {} is already classified as {}, not {} for {}",
+                    key.allocation_id, key.domain, existing.class, claim.class, claim.owner
+                ));
+            }
+            let refs = existing.owners.entry(claim.owner).or_default();
+            *refs = refs.saturating_add(1);
+            existing.bytes = existing.bytes.max(claim.bytes);
+        } else {
+            let mut owners = HashMap::new();
+            owners.insert(claim.owner, 1);
+            allocations.insert(
+                key.clone(),
+                ProviderAllocation {
+                    class: claim.class,
+                    bytes: claim.bytes,
+                    owners,
+                },
+            );
+        }
+        Ok(Some(ProviderMemoryLease {
+            ledger: Arc::clone(self),
+            key,
+            owner: claim.owner,
+        }))
+    }
+
+    fn release(&self, key: &ProviderAllocationKey, owner: MemoryOwner) {
+        let mut allocations = self.allocations.lock();
+        let remove = allocations.get_mut(key).is_some_and(|allocation| {
+            let remove_owner = allocation.owners.get_mut(&owner).is_some_and(|refs| {
+                *refs = refs.saturating_sub(1);
+                *refs == 0
+            });
+            if remove_owner {
+                allocation.owners.remove(&owner);
+            }
+            allocation.owners.is_empty()
+        });
+        if remove {
+            allocations.remove(key);
+        }
+    }
+
+    #[cfg(test)]
+    fn allocation_count(&self) -> usize {
+        self.allocations.lock().len()
+    }
+}
+
+struct ProviderMemoryLease {
+    ledger: Arc<ProviderMemoryLedger>,
+    key: ProviderAllocationKey,
+    owner: MemoryOwner,
+}
+
+impl Drop for ProviderMemoryLease {
+    fn drop(&mut self) {
+        self.ledger.release(&self.key, self.owner);
+    }
+}
+
+/// Process-wide authority spanning host, CUDA, and provider adapter domains.
+pub(crate) struct MemoryAuthority {
+    host: Arc<HostMemoryManager>,
+    #[cfg(feature = "gpu-device-pool")]
+    cuda: Option<Arc<DeviceMemoryManager>>,
+    providers: Arc<ProviderMemoryLedger>,
+}
+
+impl MemoryAuthority {
+    #[cfg_attr(feature = "gpu-device-pool", allow(dead_code))]
+    pub(crate) fn new(device_info: &DeviceInfo) -> Result<Arc<Self>, String> {
+        #[cfg(feature = "gpu-device-pool")]
+        {
+            Self::new_with_cuda_plan(device_info, &DeviceMemoryBootstrapPlan::default())
+        }
+        #[cfg(not(feature = "gpu-device-pool"))]
+        {
+            Ok(Arc::new(Self {
+                host: HostMemoryManager::new(device_info),
+                providers: Arc::new(ProviderMemoryLedger::default()),
+            }))
+        }
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) fn new_with_cuda_plan(
+        device_info: &DeviceInfo,
+        bootstrap: &DeviceMemoryBootstrapPlan,
+    ) -> Result<Arc<Self>, String> {
+        Ok(Arc::new(Self {
+            host: HostMemoryManager::new(device_info),
+            cuda: DeviceMemoryManager::from_env_with_plan(device_info, bootstrap)?,
+            providers: Arc::new(ProviderMemoryLedger::default()),
+        }))
+    }
+
+    pub(crate) fn host_budget(&self) -> super::host_memory::HostMemoryBudget {
+        self.host.budget()
+    }
+
+    /// Build a load plan from the selected devices and the backend's external
+    /// allocation report. Empty CUDA reports describe pool-backed allocations;
+    /// non-CUDA providers are represented by accounting-only adapter claims.
+    #[cfg(test)]
+    pub(crate) fn model_load_plan(
+        &self,
+        domains: &[MemoryDomain],
+        owner: MemoryOwner,
+        session_bytes: usize,
+        workspace_bytes: usize,
+        external_report: &ExternalDeviceMemoryReport,
+    ) -> Result<MemoryPlan, String> {
+        if domains.is_empty() {
+            return Err(format!("memory plan for {owner} has no target domains"));
+        }
+        let mut plan = MemoryPlan::new();
+        let mut selected = Vec::new();
+        for domain in domains {
+            if !selected.contains(domain) {
+                selected.push(domain.clone());
+            }
+        }
+        let mut host_planned = false;
+
+        for domain in selected {
+            match &domain {
+                MemoryDomain::Host
+                | MemoryDomain::HostPinned { .. }
+                | MemoryDomain::HostMapped { .. } => {
+                    if host_planned {
+                        continue;
+                    }
+                    host_planned = true;
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::ModelSession,
+                        session_bytes,
+                    ));
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::TransientWorkspace,
+                        workspace_bytes,
+                    ));
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::KvCache,
+                        0,
+                    ));
+                }
+                MemoryDomain::Cuda { device_id } => {
+                    let external: Vec<_> = external_report
+                        .allocations
+                        .iter()
+                        .filter(|allocation| allocation.device_id == *device_id)
+                        .collect();
+                    if external.is_empty() {
+                        plan.push(MemoryClaim::runtime(
+                            domain.clone(),
+                            owner,
+                            MemoryAllocationClass::PersistentWeights,
+                            session_bytes,
+                        ));
+                        plan.push(MemoryClaim::runtime(
+                            domain.clone(),
+                            owner,
+                            MemoryAllocationClass::TransientWorkspace,
+                            workspace_bytes,
+                        ));
+                    } else {
+                        for allocation in external {
+                            plan.push(MemoryClaim::external(
+                                domain.clone(),
+                                owner,
+                                classify_external_allocation(&allocation.allocation_id),
+                                allocation.allocation_id.clone(),
+                                allocation.bytes,
+                            ));
+                        }
+                    }
+                    // Elastic KV has no fixed byte reservation at model-load
+                    // time, but still belongs to this model/replica lease.
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::KvCache,
+                        0,
+                    ));
+                }
+                MemoryDomain::Provider { .. } => {
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::PersistentWeights,
+                        session_bytes,
+                    ));
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::TransientWorkspace,
+                        workspace_bytes,
+                    ));
+                    plan.push(MemoryClaim::runtime(
+                        domain.clone(),
+                        owner,
+                        MemoryAllocationClass::KvCache,
+                        0,
+                    ));
+                }
+            }
+        }
+        Ok(plan)
+    }
+
+    /// Build a load plan from the backend-neutral report. Explicit backend
+    /// rows retain their domain, class, source, and stable allocation ID;
+    /// selected domains missing from a legacy report receive conservative
+    /// model/session and workspace estimates.
+    pub(crate) fn model_load_plan_with_report(
+        &self,
+        domains: &[MemoryDomain],
+        owner: MemoryOwner,
+        session_bytes: usize,
+        workspace_bytes: usize,
+        report: &BackendMemoryReport,
+    ) -> Result<MemoryPlan, String> {
+        if domains.is_empty() {
+            return Err(format!("memory plan for {owner} has no target domains"));
+        }
+        let mut selected = Vec::new();
+        for domain in domains {
+            if !selected.contains(domain) {
+                selected.push(domain.clone());
+            }
+        }
+        let mut plan = MemoryPlan::from_backend_report(owner, report);
+        plan.claims.retain(|claim| {
+            matches!(
+                claim.domain,
+                MemoryDomain::Host
+                    | MemoryDomain::HostPinned { .. }
+                    | MemoryDomain::HostMapped { .. }
+            ) || selected.contains(&claim.domain)
+        });
+
+        for domain in selected {
+            let has_model = plan.claims.iter().any(|claim| {
+                claim.domain == domain
+                    && matches!(
+                        claim.class,
+                        MemoryAllocationClass::PersistentWeights
+                            | MemoryAllocationClass::ModelSession
+                    )
+            });
+            let has_workspace = plan.claims.iter().any(|claim| {
+                claim.domain == domain && claim.class == MemoryAllocationClass::TransientWorkspace
+            });
+            let has_kv = plan.claims.iter().any(|claim| {
+                claim.domain == domain && claim.class == MemoryAllocationClass::KvCache
+            });
+            if !has_model {
+                plan.push(MemoryClaim::runtime(
+                    domain.clone(),
+                    owner,
+                    if matches!(
+                        domain,
+                        MemoryDomain::Host
+                            | MemoryDomain::HostPinned { .. }
+                            | MemoryDomain::HostMapped { .. }
+                    ) {
+                        MemoryAllocationClass::ModelSession
+                    } else {
+                        MemoryAllocationClass::PersistentWeights
+                    },
+                    session_bytes,
+                ));
+            }
+            if !has_workspace {
+                plan.push(MemoryClaim::runtime(
+                    domain.clone(),
+                    owner,
+                    MemoryAllocationClass::TransientWorkspace,
+                    workspace_bytes,
+                ));
+            }
+            if !has_kv {
+                plan.push(MemoryClaim::runtime(
+                    domain,
+                    owner,
+                    MemoryAllocationClass::KvCache,
+                    0,
+                ));
+            }
+        }
+        Ok(plan)
+    }
+
+    /// Admit every claim whose adapter is synchronous. If a later claim fails,
+    /// already-created leases are dropped and the plan is atomic to callers.
+    pub(crate) fn admit(&self, plan: &MemoryPlan) -> Result<MemoryLease, String> {
+        let mut lease = MemoryLease::new(plan.claims.clone());
+        for claim in plan.claims() {
+            match &claim.domain {
+                MemoryDomain::Host
+                | MemoryDomain::HostPinned { .. }
+                | MemoryDomain::HostMapped { .. } => {
+                    if let Some(host) = self.host.admit(claim)? {
+                        lease.host.push(host);
+                    }
+                }
+                MemoryDomain::Provider { .. } => {
+                    if let Some(provider) = self.providers.reserve(claim)? {
+                        lease.providers.push(provider);
+                    }
+                }
+                MemoryDomain::Cuda { .. } => {
+                    #[cfg(feature = "gpu-device-pool")]
+                    {
+                        let manager = self.cuda.as_ref().ok_or_else(|| {
+                            format!(
+                                "{} claim for {} has no CUDA memory authority",
+                                claim.domain, claim.owner
+                            )
+                        })?;
+                        if let Some(transient) = manager.admit_transient(claim)? {
+                            lease.cuda_transient.push(transient);
+                        }
+                    }
+                    #[cfg(not(feature = "gpu-device-pool"))]
+                    return Err(format!(
+                        "{} claim for {} requires CUDA memory authority",
+                        claim.domain, claim.owner
+                    ));
+                }
+            }
+        }
+        Ok(lease)
+    }
+
+    /// Begin a model-load transaction. Host and provider claims are reserved
+    /// first; CUDA adapters then serialize load sampling per device.
+    pub(crate) async fn begin_load(
+        self: &Arc<Self>,
+        plan: &MemoryPlan,
+        kind: EngineKind,
+    ) -> Result<MemoryAdmission, String> {
+        let non_cuda_plan = MemoryPlan {
+            claims: plan
+                .claims()
+                .iter()
+                .filter(|claim| !matches!(claim.domain, MemoryDomain::Cuda { .. }))
+                .cloned()
+                .collect(),
+        };
+        let tracks_host_load = non_cuda_plan.claims().iter().any(|claim| {
+            matches!(
+                claim.domain,
+                MemoryDomain::Host
+                    | MemoryDomain::HostPinned { .. }
+                    | MemoryDomain::HostMapped { .. }
+            ) && claim.bytes != 0
+                && matches!(
+                    claim.class,
+                    MemoryAllocationClass::PersistentWeights
+                        | MemoryAllocationClass::ModelSession
+                        | MemoryAllocationClass::TransientWorkspace
+                        | MemoryAllocationClass::ExternallyOwned
+                )
+        });
+        let host_load = if tracks_host_load {
+            Some(self.host.begin_load_reconciliation().await)
+        } else {
+            None
+        };
+        let lease = self.admit(&non_cuda_plan)?;
+        #[allow(unused_mut)]
+        let mut admission = MemoryAdmission {
+            _authority: Arc::clone(self),
+            lease: Some(lease),
+            host_load,
+            cuda_plan: MemoryPlan {
+                claims: plan
+                    .claims()
+                    .iter()
+                    .filter(|claim| matches!(claim.domain, MemoryDomain::Cuda { .. }))
+                    .cloned()
+                    .collect(),
+            },
+            #[cfg(feature = "gpu-device-pool")]
+            cuda: Vec::new(),
+            reconciled: false,
+        };
+
+        #[cfg(not(feature = "gpu-device-pool"))]
+        let _ = kind;
+
+        #[cfg(feature = "gpu-device-pool")]
+        if let Some(manager) = self.cuda.as_ref() {
+            for device_id in admission.cuda_plan.cuda_device_ids() {
+                let report = admission.cuda_plan.external_report_for_cuda(device_id);
+                let owner = owner_for_device(&admission.cuda_plan, device_id)?;
+                if let Some(cuda) = manager
+                    .begin_admission(device_id, owner, kind, &report)
+                    .await?
+                {
+                    admission.cuda.push(cuda);
+                }
+            }
+        }
+        Ok(admission)
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) async fn begin_swap(
+        self: &Arc<Self>,
+        plan: &MemoryPlan,
+    ) -> Result<MemorySwapLease, String> {
+        let mut cuda = Vec::new();
+        if let Some(manager) = self.cuda.as_ref() {
+            for device_id in plan.cuda_device_ids() {
+                let report = plan.external_report_for_cuda(device_id);
+                let owner = owner_for_device(plan, device_id)?;
+                if let Some(admission) = manager
+                    .begin_swap_admission(device_id, owner, &report)
+                    .await?
+                {
+                    cuda.push(admission);
+                }
+            }
+        }
+        Ok(MemorySwapLease {
+            _claims: plan.claims.clone(),
+            _cuda: cuda,
+        })
+    }
+
+    #[cfg(any(
+        feature = "native",
+        feature = "gguf-native",
+        feature = "gguf-cuda-shared-kv"
+    ))]
+    pub(crate) fn cuda_pool(
+        &self,
+        device_id: usize,
+    ) -> Option<Arc<kapsl_hal::gpu_arena::GpuDevicePool>> {
+        self.cuda
+            .as_ref()
+            .and_then(|manager| manager.pool(device_id))
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) fn uses_cuda_environment_allocator(&self, device_id: usize) -> bool {
+        self.cuda
+            .as_ref()
+            .is_some_and(|manager| manager.has_pool(device_id))
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) fn ensure_cuda_pools(
+        &self,
+        bootstrap: &DeviceMemoryBootstrapPlan,
+    ) -> Result<(), String> {
+        if let Some(manager) = self.cuda.as_ref() {
+            manager.ensure_pools_for_plan(bootstrap)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) fn attach_cuda_metrics(&self, metrics: kapsl_monitor::metrics::KapslMetrics) {
+        if let Some(manager) = self.cuda.as_ref() {
+            manager.attach_metrics(metrics);
+        }
+    }
+
+    pub(crate) fn refresh_cuda_pool_metrics(&self) {
+        #[cfg(feature = "gpu-device-pool")]
+        if let Some(manager) = self.cuda.as_ref() {
+            manager.refresh_pool_metrics();
+        }
+    }
+}
+
+#[cfg(any(feature = "gpu-device-pool", test))]
+fn owner_for_device(plan: &MemoryPlan, device_id: usize) -> Result<MemoryOwner, String> {
+    let mut owners = plan.claims().iter().filter_map(|claim| match claim.domain {
+        MemoryDomain::Cuda {
+            device_id: candidate,
+        } if candidate == device_id => Some(claim.owner),
+        _ => None,
+    });
+    let owner = owners
+        .next()
+        .ok_or_else(|| format!("CUDA device {device_id} plan has no owner"))?;
+    if owners.any(|candidate| candidate != owner) {
+        return Err(format!(
+            "CUDA device {device_id} plan mixes multiple model/replica owners"
+        ));
+    }
+    Ok(owner)
+}
+
+/// In-flight load transaction. Dropping it rolls back every domain.
+#[must_use = "reconcile and commit the memory admission after backend load"]
+pub(crate) struct MemoryAdmission {
+    _authority: Arc<MemoryAuthority>,
+    lease: Option<MemoryLease>,
+    host_load: Option<HostMemoryLoadAdmission>,
+    cuda_plan: MemoryPlan,
+    #[cfg(feature = "gpu-device-pool")]
+    cuda: Vec<DeviceMemoryAdmission>,
+    reconciled: bool,
+}
+
+impl MemoryAdmission {
+    pub(crate) fn reconcile(&mut self, actual_report: &BackendMemoryReport) -> Result<(), String> {
+        if let Some(mut host_load) = self.host_load.take() {
+            let lease = self.lease.as_mut().expect("memory admission lease");
+            host_load.reconcile(&mut lease.host)?;
+        }
+
+        #[cfg(feature = "gpu-device-pool")]
+        {
+            let external_cuda = external_cuda_report_from_backend(actual_report);
+            for admission in &mut self.cuda {
+                admission.reconcile(&external_cuda)?;
+            }
+        }
+        if let Some(lease) = self.lease.as_mut() {
+            reconcile_backend_claim_bytes(&mut lease.claims, actual_report);
+        }
+        reconcile_backend_claim_bytes(&mut self.cuda_plan.claims, actual_report);
+        self.reconciled = true;
+        Ok(())
+    }
+
+    pub(crate) fn commit(mut self) -> MemoryLease {
+        assert!(
+            self.reconciled,
+            "memory admission must be reconciled before commit"
+        );
+        let mut lease = self.lease.take().expect("memory admission lease");
+        lease.claims.extend(self.cuda_plan.claims.clone());
+        #[cfg(feature = "gpu-device-pool")]
+        for item in std::mem::take(&mut self.cuda) {
+            let item = item.commit();
+            debug_assert!(self
+                .cuda_plan
+                .claims()
+                .iter()
+                .any(|claim| claim.owner == item.owner()));
+            lease.cuda.push(item);
+        }
+        lease
+    }
+}
+
+/// RAII ownership of all admitted memory in a plan.
+pub(crate) struct MemoryLease {
+    claims: Vec<MemoryClaim>,
+    host: Vec<HostMemoryLease>,
+    providers: Vec<ProviderMemoryLease>,
+    #[cfg(feature = "gpu-device-pool")]
+    cuda: Vec<DeviceMemoryLease>,
+    #[cfg(feature = "gpu-device-pool")]
+    cuda_transient: Vec<DeviceMemoryTransientLease>,
+}
+
+impl MemoryLease {
+    fn new(claims: Vec<MemoryClaim>) -> Self {
+        Self {
+            claims,
+            host: Vec::new(),
+            providers: Vec::new(),
+            #[cfg(feature = "gpu-device-pool")]
+            cuda: Vec::new(),
+            #[cfg(feature = "gpu-device-pool")]
+            cuda_transient: Vec::new(),
+        }
+    }
+
+    pub(crate) fn claims(&self) -> &[MemoryClaim] {
+        &self.claims
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.claims.is_empty()
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) fn reconcile_report(&mut self, report: &BackendMemoryReport) -> Result<(), String> {
+        let external_cuda = external_cuda_report_from_backend(report);
+        for lease in &mut self.cuda {
+            lease.reconcile_report(&external_cuda)?;
+        }
+        reconcile_backend_claim_bytes(&mut self.claims, report);
+        Ok(())
+    }
+}
+
+fn reconcile_backend_claim_bytes(claims: &mut [MemoryClaim], report: &BackendMemoryReport) {
+    for claim in claims {
+        let expected_source = match &claim.source {
+            MemoryClaimSource::Runtime { .. } => BackendMemoryAllocationSource::RuntimeManaged,
+            MemoryClaimSource::External { .. } => BackendMemoryAllocationSource::BackendManaged,
+        };
+        let expected_id = match &claim.source {
+            MemoryClaimSource::Runtime { allocation_id } => allocation_id.as_deref(),
+            MemoryClaimSource::External { allocation_id } => Some(allocation_id.as_str()),
+        };
+        let mut matched = false;
+        let mut actual_bytes = 0usize;
+        for allocation in &report.allocations {
+            if MemoryDomain::from_backend(&allocation.domain) != claim.domain
+                || MemoryAllocationClass::from_backend(allocation.class) != claim.class
+                || allocation.source != expected_source
+                || expected_id.is_some_and(|id| id != allocation.allocation_id.as_str())
+            {
+                continue;
+            }
+            matched = true;
+            actual_bytes = actual_bytes.saturating_add(allocation.bytes);
+        }
+        if matched {
+            claim.bytes = actual_bytes;
+        }
+    }
+}
+
+/// Short-lived lease for the second copy of externally-owned weights during
+/// activation. It also retains the per-device CUDA serialization guards.
+#[cfg(feature = "gpu-device-pool")]
+#[must_use = "hold the swap lease until backend activation finishes"]
+pub(crate) struct MemorySwapLease {
+    _claims: Vec<MemoryClaim>,
+    _cuda: Vec<DeviceMemorySwapAdmission>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kapsl_hal::device::{Device, DeviceBackend};
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    fn cpu_device_info() -> DeviceInfo {
+        DeviceInfo {
+            cpu_cores: 1,
+            total_memory: 10 * 1024 * 1024,
+            os_type: "test".to_string(),
+            os_release: "test".to_string(),
+            has_cuda: false,
+            has_metal: false,
+            has_rocm: false,
+            has_directml: false,
+            devices: vec![Device {
+                id: 0,
+                name: "test-cpu".to_string(),
+                backend: DeviceBackend::Cpu,
+                memory_mb: 0,
+                compute_units: 1,
+                pci_bus_id: None,
+                partition_id: None,
+                driver_version: None,
+                cuda_version: None,
+                compute_capability: None,
+                utilization_gpu_pct: None,
+                temperature_c: None,
+                supports_fp16: false,
+                supports_int8: true,
+            }],
+        }
+    }
+
+    #[test]
+    fn host_plan_preserves_owner_and_allocation_classes() {
+        let owner = MemoryOwner::new(7, 3);
+        let mut plan = MemoryPlan::new();
+        plan.push(MemoryClaim::runtime(
+            MemoryDomain::Host,
+            owner,
+            MemoryAllocationClass::ModelSession,
+            2 * GIB,
+        ));
+        plan.push(MemoryClaim::runtime(
+            MemoryDomain::Host,
+            owner,
+            MemoryAllocationClass::TransientWorkspace,
+            GIB,
+        ));
+        assert_eq!(plan.claims().len(), 2);
+        assert!(plan.claims().iter().all(|claim| claim.owner == owner));
+        assert_eq!(plan.claims()[0].class, MemoryAllocationClass::ModelSession);
+        assert_eq!(
+            plan.claims()[1].class,
+            MemoryAllocationClass::TransientWorkspace
+        );
+    }
+
+    #[test]
+    fn external_report_maps_domains_and_classes() {
+        let owner = MemoryOwner::new(9, 2);
+        let plan = MemoryPlan::external_cuda_report(
+            owner,
+            &ExternalDeviceMemoryReport {
+                allocations: vec![
+                    ExternalDeviceMemory {
+                        allocation_id: "weights:model".to_string(),
+                        device_id: 4,
+                        bytes: 100,
+                    },
+                    ExternalDeviceMemory {
+                        allocation_id: "weights:model:scratch".to_string(),
+                        device_id: 4,
+                        bytes: 20,
+                    },
+                ],
+            },
+        );
+        assert_eq!(plan.cuda_device_ids(), vec![4]);
+        assert_eq!(
+            plan.claims()[0].class,
+            MemoryAllocationClass::PersistentWeights
+        );
+        assert_eq!(
+            plan.claims()[1].class,
+            MemoryAllocationClass::TransientWorkspace
+        );
+        assert_eq!(owner_for_device(&plan, 4).unwrap(), owner);
+    }
+
+    #[test]
+    fn backend_report_preserves_domains_sources_and_stable_ids() {
+        let owner = MemoryOwner::new(21, 6);
+        let report = BackendMemoryReport {
+            allocations: vec![
+                kapsl_engine_api::MemoryAllocation {
+                    allocation_id: "pinned-input".to_string(),
+                    domain: BackendMemoryDomain::HostPinned {
+                        provider: "cuda".to_string(),
+                        device_id: Some(3),
+                    },
+                    class: BackendMemoryAllocationClass::RequestTransient,
+                    source: BackendMemoryAllocationSource::BackendManaged,
+                    bytes: 64,
+                },
+                kapsl_engine_api::MemoryAllocation {
+                    allocation_id: "pooled-weights".to_string(),
+                    domain: BackendMemoryDomain::Cuda { device_id: 3 },
+                    class: BackendMemoryAllocationClass::PersistentWeights,
+                    source: BackendMemoryAllocationSource::RuntimeManaged,
+                    bytes: 128,
+                },
+            ],
+        };
+        let plan = MemoryPlan::from_backend_report(owner, &report);
+        assert_eq!(plan.claims().len(), 2);
+        assert_eq!(
+            plan.claims()[0].domain,
+            MemoryDomain::HostPinned {
+                provider: "cuda".to_string(),
+                device_id: Some(3),
+            }
+        );
+        assert_eq!(
+            plan.claims()[0].source,
+            MemoryClaimSource::External {
+                allocation_id: "pinned-input".to_string(),
+            }
+        );
+        assert_eq!(
+            plan.claims()[1].source,
+            MemoryClaimSource::Runtime {
+                allocation_id: Some("pooled-weights".to_string()),
+            }
+        );
+        assert!(plan.claims().iter().all(|claim| claim.owner == owner));
+    }
+
+    #[test]
+    fn coreml_backend_reports_join_the_selected_metal_domain() {
+        let owner = MemoryOwner::new(31, 4);
+        let report = BackendMemoryReport {
+            allocations: vec![kapsl_engine_api::MemoryAllocation {
+                allocation_id: "coreml-weights".to_string(),
+                domain: BackendMemoryDomain::Provider {
+                    provider: "coreml".to_string(),
+                    device_id: Some(2),
+                },
+                class: BackendMemoryAllocationClass::PersistentWeights,
+                source: BackendMemoryAllocationSource::BackendManaged,
+                bytes: 512,
+            }],
+        };
+        let plan = MemoryPlan::from_backend_report(owner, &report);
+        assert_eq!(
+            plan.claims()[0].domain,
+            MemoryDomain::Provider {
+                provider: "metal".to_string(),
+                device_id: Some(2),
+            }
+        );
+    }
+
+    #[test]
+    fn request_report_retains_every_host_domain_and_provider_adapter() {
+        let owner = MemoryOwner::new(22, 1);
+        let report = BackendMemoryReport {
+            allocations: vec![
+                kapsl_engine_api::MemoryAllocation {
+                    allocation_id: "host".to_string(),
+                    domain: BackendMemoryDomain::Host,
+                    class: BackendMemoryAllocationClass::RequestTransient,
+                    source: BackendMemoryAllocationSource::BackendManaged,
+                    bytes: 10,
+                },
+                kapsl_engine_api::MemoryAllocation {
+                    allocation_id: "mapped".to_string(),
+                    domain: BackendMemoryDomain::HostMapped {
+                        provider: "cuda".to_string(),
+                        device_id: Some(0),
+                    },
+                    class: BackendMemoryAllocationClass::RequestTransient,
+                    source: BackendMemoryAllocationSource::BackendManaged,
+                    bytes: 20,
+                },
+                kapsl_engine_api::MemoryAllocation {
+                    allocation_id: "provider".to_string(),
+                    domain: BackendMemoryDomain::Provider {
+                        provider: "metal".to_string(),
+                        device_id: Some(0),
+                    },
+                    class: BackendMemoryAllocationClass::RequestTransient,
+                    source: BackendMemoryAllocationSource::BackendManaged,
+                    bytes: 30,
+                },
+            ],
+        };
+        let plan = MemoryPlan::request_from_backend_report(owner, &report);
+        assert_eq!(plan.claims().len(), 3);
+        assert!(plan
+            .claims()
+            .iter()
+            .all(|claim| claim.class == MemoryAllocationClass::RequestTransient));
+    }
+
+    #[test]
+    fn host_lease_releases_all_claims_atomically() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let owner = MemoryOwner::new(11, 5);
+        let plan = authority
+            .model_load_plan(
+                &[MemoryDomain::Host],
+                owner,
+                2 * GIB,
+                GIB,
+                &ExternalDeviceMemoryReport::default(),
+            )
+            .unwrap();
+        let lease = authority.admit(&plan).unwrap();
+        assert_eq!(authority.host.reserved_bytes(), 3 * GIB);
+        assert_eq!(lease.claims().len(), 3);
+        drop(lease);
+        assert_eq!(authority.host.reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn model_plan_classifies_every_domain() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let owner = MemoryOwner::new(13, 2);
+        let cuda = MemoryDomain::Cuda { device_id: 0 };
+        let provider = MemoryDomain::Provider {
+            provider: "metal".to_string(),
+            device_id: Some(0),
+        };
+        let plan = authority
+            .model_load_plan(
+                &[MemoryDomain::Host, cuda.clone(), provider.clone()],
+                owner,
+                100,
+                20,
+                &ExternalDeviceMemoryReport::default(),
+            )
+            .unwrap();
+
+        let classes_for = |domain: &MemoryDomain| {
+            plan.claims()
+                .iter()
+                .filter(|claim| &claim.domain == domain)
+                .map(|claim| (claim.class, claim.bytes))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            classes_for(&MemoryDomain::Host),
+            vec![
+                (MemoryAllocationClass::ModelSession, 100),
+                (MemoryAllocationClass::TransientWorkspace, 20),
+                (MemoryAllocationClass::KvCache, 0),
+            ]
+        );
+        for domain in [&cuda, &provider] {
+            assert_eq!(
+                classes_for(domain),
+                vec![
+                    (MemoryAllocationClass::PersistentWeights, 100),
+                    (MemoryAllocationClass::TransientWorkspace, 20),
+                    (MemoryAllocationClass::KvCache, 0),
+                ]
+            );
+        }
+        assert!(plan.claims().iter().all(|claim| claim.owner == owner));
+    }
+
+    #[test]
+    fn backend_rows_outside_selected_device_domains_are_ignored() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let report = BackendMemoryReport {
+            allocations: vec![kapsl_engine_api::MemoryAllocation {
+                allocation_id: "legacy-cuda-estimate".to_string(),
+                domain: BackendMemoryDomain::Cuda { device_id: 0 },
+                class: BackendMemoryAllocationClass::PersistentWeights,
+                source: BackendMemoryAllocationSource::BackendManaged,
+                bytes: GIB,
+            }],
+        };
+        let plan = authority
+            .model_load_plan_with_report(
+                &[MemoryDomain::Host],
+                MemoryOwner::new(3, 0),
+                100,
+                20,
+                &report,
+            )
+            .unwrap();
+        assert!(plan
+            .claims()
+            .iter()
+            .all(|claim| !matches!(claim.domain, MemoryDomain::Cuda { .. })));
+        assert_eq!(plan.claims().len(), 3);
+    }
+
+    #[test]
+    fn provider_adapter_reference_counts_stable_allocations() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let plan_for = |replica_id| {
+            let mut plan = MemoryPlan::new();
+            plan.push(MemoryClaim::external(
+                MemoryDomain::Provider {
+                    provider: "metal".to_string(),
+                    device_id: Some(0),
+                },
+                MemoryOwner::new(4, replica_id),
+                MemoryAllocationClass::PersistentWeights,
+                "weights:shared",
+                GIB,
+            ));
+            plan
+        };
+        let first = authority.admit(&plan_for(1)).unwrap();
+        let second = authority.admit(&plan_for(2)).unwrap();
+        assert_eq!(authority.providers.allocation_count(), 1);
+        drop(first);
+        assert_eq!(authority.providers.allocation_count(), 1);
+        drop(second);
+        assert_eq!(authority.providers.allocation_count(), 0);
+    }
+
+    #[test]
+    fn provider_request_allocations_are_counted_additively() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let owner = MemoryOwner::new(5, 1);
+        let mut plan = MemoryPlan::new();
+        plan.push(MemoryClaim::external(
+            MemoryDomain::Provider {
+                provider: "metal".to_string(),
+                device_id: Some(0),
+            },
+            owner,
+            MemoryAllocationClass::RequestTransient,
+            "request:staging",
+            100,
+        ));
+        let first = authority.admit(&plan).unwrap();
+        let second = authority.admit(&plan).unwrap();
+        assert_eq!(authority.providers.allocation_count(), 2);
+        drop(first);
+        assert_eq!(authority.providers.allocation_count(), 1);
+        drop(second);
+        assert_eq!(authority.providers.allocation_count(), 0);
+    }
+
+    #[test]
+    fn mixed_owners_in_one_cuda_domain_are_rejected() {
+        let mut plan = MemoryPlan::new();
+        for owner in [MemoryOwner::new(1, 0), MemoryOwner::new(1, 1)] {
+            plan.push(MemoryClaim::external(
+                MemoryDomain::Cuda { device_id: 0 },
+                owner,
+                MemoryAllocationClass::ExternallyOwned,
+                format!("allocation:{}", owner.replica_id),
+                1,
+            ));
+        }
+        assert!(owner_for_device(&plan, 0)
+            .unwrap_err()
+            .contains("mixes multiple"));
+    }
+
+    #[test]
+    fn typed_domains_distinguish_cpu_zero_from_cuda_zero() {
+        let host = MemoryDomain::for_provider("cpu", 0);
+        let cuda = MemoryDomain::for_provider("tensorrt", 0);
+        assert_eq!(host, MemoryDomain::Host);
+        assert_eq!(cuda, MemoryDomain::Cuda { device_id: 0 });
+        assert_ne!(host, cuda);
+    }
+
+    #[test]
+    fn request_transient_is_owned_and_released() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let owner = MemoryOwner::new(12, 4);
+        let lease = authority
+            .admit(&MemoryPlan::request_transient(owner, GIB))
+            .unwrap();
+        assert_eq!(authority.host.reserved_bytes(), GIB);
+        assert_eq!(lease.claims()[0].owner, owner);
+        assert_eq!(
+            lease.claims()[0].class,
+            MemoryAllocationClass::RequestTransient
+        );
+        drop(lease);
+        assert_eq!(authority.host.reserved_bytes(), 0);
+    }
+
+    #[test]
+    fn model_plan_requires_an_explicit_domain() {
+        let authority = MemoryAuthority::new(&cpu_device_info()).unwrap();
+        let error = authority
+            .model_load_plan(
+                &[],
+                MemoryOwner::new(1, 0),
+                1,
+                1,
+                &ExternalDeviceMemoryReport::default(),
+            )
+            .unwrap_err();
+        assert!(error.contains("no target domains"));
+    }
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/mod.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/mod.rs
@@ -13,6 +13,7 @@ mod device_budget;
 pub(crate) mod device_memory;
 mod host_memory;
 pub(crate) mod inference_service;
+pub(crate) mod memory;
 pub(crate) mod model;
 pub(crate) mod model_manager;
 pub(crate) mod monitor;
@@ -27,6 +28,7 @@ pub(crate) use config::*;
 #[cfg(feature = "gpu-device-pool")]
 pub(crate) use device_memory::*;
 pub(crate) use inference_service::*;
+pub(crate) use memory::*;
 #[cfg(feature = "gpu-device-pool")]
 pub(crate) use model::load_plan::device_memory_bootstrap_plan;
 pub(crate) use model::*;

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/mod.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod config;
 mod device_budget;
 #[cfg(feature = "gpu-device-pool")]
 pub(crate) mod device_memory;
+mod host_memory;
 pub(crate) mod inference_service;
 pub(crate) mod model;
 pub(crate) mod model_manager;

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
@@ -1,20 +1,63 @@
 use super::*;
-use kapsl_engine_api::{EngineStream, ExternalDeviceMemoryReport};
+use kapsl_engine_api::{EngineStream, ExternalDeviceMemoryReport, MemoryReport};
 
-struct HostMemoryTrackedEngine {
+struct MemoryTrackedEngine {
     inner: Box<dyn kapsl_engine_api::Engine>,
-    lease: Option<super::super::host_memory::HostMemoryLease>,
+    lease: std::sync::Mutex<Option<MemoryLease>>,
+    resources: Arc<RuntimeResources>,
+    owner: MemoryOwner,
+    #[cfg(feature = "gpu-device-pool")]
+    staged_memory_plan: std::sync::Mutex<Option<MemoryPlan>>,
 }
 
-impl Drop for HostMemoryTrackedEngine {
-    fn drop(&mut self) {
+impl MemoryTrackedEngine {
+    fn new(
+        inner: Box<dyn kapsl_engine_api::Engine>,
+        lease: MemoryLease,
+        resources: Arc<RuntimeResources>,
+        owner: MemoryOwner,
+    ) -> Self {
+        Self {
+            inner,
+            lease: std::sync::Mutex::new(Some(lease)),
+            resources,
+            owner,
+            #[cfg(feature = "gpu-device-pool")]
+            staged_memory_plan: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn unload_and_release(&mut self) {
         self.inner.unload();
-        self.lease.take();
+        self.lease.get_mut().unwrap().take();
+    }
+
+    fn request_lease(&self, requests: &[InferenceRequest]) -> Result<MemoryLease, EngineError> {
+        let mut plan = MemoryPlan::new();
+        for request in requests {
+            plan.extend(MemoryPlan::request_from_backend_report(
+                self.owner,
+                &self.inner.planned_request_memory(request),
+            ));
+        }
+        self.resources
+            .memory()
+            .admit(&plan)
+            .map_err(EngineError::resource_exhausted)
+    }
+}
+
+impl Drop for MemoryTrackedEngine {
+    fn drop(&mut self) {
+        self.unload_and_release();
     }
 }
 
 #[async_trait::async_trait]
-impl kapsl_engine_api::Engine for HostMemoryTrackedEngine {
+impl kapsl_engine_api::Engine for MemoryTrackedEngine {
+    fn planned_memory(&self, path: &Path) -> Result<MemoryReport, EngineError> {
+        self.inner.planned_memory(path)
+    }
     fn planned_external_device_memory(
         &self,
         path: &Path,
@@ -27,13 +70,21 @@ impl kapsl_engine_api::Engine for HostMemoryTrackedEngine {
     fn actual_external_device_memory(&self) -> ExternalDeviceMemoryReport {
         self.inner.actual_external_device_memory()
     }
+    fn actual_memory(&self) -> MemoryReport {
+        self.inner.actual_memory()
+    }
+    fn planned_request_memory(&self, request: &InferenceRequest) -> MemoryReport {
+        self.inner.planned_request_memory(request)
+    }
     fn infer(&self, request: &InferenceRequest) -> Result<BinaryTensorPacket, EngineError> {
+        let _request_lease = self.request_lease(std::slice::from_ref(request))?;
         self.inner.infer(request)
     }
     fn infer_batch(
         &self,
         requests: &[InferenceRequest],
     ) -> Result<Vec<BinaryTensorPacket>, EngineError> {
+        let _request_lease = self.request_lease(requests)?;
         self.inner.infer_batch(requests)
     }
     fn max_batch(&self) -> usize {
@@ -46,14 +97,20 @@ impl kapsl_engine_api::Engine for HostMemoryTrackedEngine {
         self.inner.batching_policy()
     }
     fn infer_stream(&self, request: &InferenceRequest) -> EngineStream {
-        self.inner.infer_stream(request)
+        let request_lease = match self.request_lease(std::slice::from_ref(request)) {
+            Ok(lease) => lease,
+            Err(error) => return Box::pin(futures::stream::once(async move { Err(error) })),
+        };
+        Box::pin(self.inner.infer_stream(request).map(move |item| {
+            let _hold = &request_lease;
+            item
+        }))
     }
     async fn warmup(&self) -> Result<(), EngineError> {
         self.inner.warmup().await
     }
     fn unload(&mut self) {
-        self.inner.unload();
-        self.lease.take();
+        self.unload_and_release();
     }
     fn metrics(&self) -> EngineMetrics {
         self.inner.metrics()
@@ -71,201 +128,71 @@ impl kapsl_engine_api::Engine for HostMemoryTrackedEngine {
         self.inner.is_staged()
     }
     async fn stage(&self, path: &Path) -> Result<(), EngineError> {
-        self.inner.stage(path).await
+        #[cfg(feature = "gpu-device-pool")]
+        {
+            let report = self.inner.planned_memory(path)?;
+            self.inner.stage(path).await?;
+            *self.staged_memory_plan.lock().unwrap() =
+                Some(MemoryPlan::from_backend_report(self.owner, &report));
+            Ok(())
+        }
+        #[cfg(not(feature = "gpu-device-pool"))]
+        {
+            self.inner.stage(path).await
+        }
     }
     async fn swap(&self) -> Result<(), EngineError> {
-        self.inner.swap().await
+        #[cfg(feature = "gpu-device-pool")]
+        {
+            let plan = self
+                .staged_memory_plan
+                .lock()
+                .unwrap()
+                .clone()
+                .ok_or_else(|| EngineError::backend("no staged memory plan; call stage() first"))?;
+            let swap_lease = self
+                .resources
+                .memory()
+                .begin_swap(&plan)
+                .await
+                .map_err(EngineError::backend)?;
+            let swap_result = self.inner.swap().await;
+            self.staged_memory_plan.lock().unwrap().take();
+            swap_result?;
+
+            // Activation has released the old weights. Return the temporary
+            // peak before reconciling the persistent lease to the target.
+            drop(swap_lease);
+            let report = self.inner.actual_memory();
+            if let Some(lease) = self.lease.lock().unwrap().as_mut() {
+                lease
+                    .reconcile_report(&report)
+                    .map_err(EngineError::backend)?;
+            }
+            Ok(())
+        }
+        #[cfg(not(feature = "gpu-device-pool"))]
+        {
+            self.inner.swap().await
+        }
     }
 }
 
-fn estimated_host_model_bytes(model_path: &Path) -> Result<usize, String> {
+#[derive(Debug, Clone, Copy)]
+struct EstimatedModelMemory {
+    session_bytes: usize,
+    workspace_bytes: usize,
+}
+
+fn estimated_model_memory(model_path: &Path) -> Result<EstimatedModelMemory, String> {
     let serialized = std::fs::metadata(model_path)
         .map_err(|error| format!("stat model {}: {error}", model_path.display()))?
         .len() as usize;
     // Account for decoded/aligned weights and a bounded execution workspace.
-    Ok(serialized
-        .saturating_mul(5)
-        .saturating_div(4)
-        .saturating_add((serialized / 4).max(256 * 1024 * 1024)))
-}
-
-#[cfg(feature = "gpu-device-pool")]
-struct DeviceMemoryTrackedEngine {
-    // Keep the backend before its leases so backend resources are torn down
-    // before a lease can return admission budget.
-    inner: Box<dyn kapsl_engine_api::Engine>,
-    leases: std::sync::Mutex<Vec<DeviceMemoryLease>>,
-    resources: Arc<RuntimeResources>,
-    model_id: u32,
-    staged_memory_plan: std::sync::Mutex<Option<ExternalDeviceMemoryReport>>,
-}
-
-#[cfg(feature = "gpu-device-pool")]
-impl DeviceMemoryTrackedEngine {
-    fn new(
-        inner: Box<dyn kapsl_engine_api::Engine>,
-        leases: Vec<DeviceMemoryLease>,
-        resources: Arc<RuntimeResources>,
-        model_id: u32,
-    ) -> Self {
-        Self {
-            inner,
-            leases: std::sync::Mutex::new(leases),
-            resources,
-            model_id,
-            staged_memory_plan: std::sync::Mutex::new(None),
-        }
-    }
-
-    fn unload_and_release(&mut self) {
-        self.inner.unload();
-        self.leases.get_mut().unwrap().clear();
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-impl Drop for DeviceMemoryTrackedEngine {
-    fn drop(&mut self) {
-        self.unload_and_release();
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-#[async_trait::async_trait]
-impl kapsl_engine_api::Engine for DeviceMemoryTrackedEngine {
-    fn planned_external_device_memory(
-        &self,
-        model_path: &Path,
-    ) -> Result<ExternalDeviceMemoryReport, EngineError> {
-        self.inner.planned_external_device_memory(model_path)
-    }
-
-    async fn load(&mut self, model_path: &Path) -> Result<(), EngineError> {
-        self.inner.load(model_path).await
-    }
-
-    fn actual_external_device_memory(&self) -> ExternalDeviceMemoryReport {
-        self.inner.actual_external_device_memory()
-    }
-
-    fn infer(&self, request: &InferenceRequest) -> Result<BinaryTensorPacket, EngineError> {
-        self.inner.infer(request)
-    }
-
-    fn infer_batch(
-        &self,
-        requests: &[InferenceRequest],
-    ) -> Result<Vec<BinaryTensorPacket>, EngineError> {
-        self.inner.infer_batch(requests)
-    }
-
-    fn max_batch(&self) -> usize {
-        self.inner.max_batch()
-    }
-
-    fn self_batches(&self) -> bool {
-        self.inner.self_batches()
-    }
-
-    fn batching_policy(&self) -> BatchingPolicy {
-        self.inner.batching_policy()
-    }
-
-    fn infer_stream(&self, request: &InferenceRequest) -> EngineStream {
-        self.inner.infer_stream(request)
-    }
-
-    async fn warmup(&self) -> Result<(), EngineError> {
-        self.inner.warmup().await
-    }
-
-    fn unload(&mut self) {
-        self.unload_and_release();
-    }
-
-    fn metrics(&self) -> EngineMetrics {
-        self.inner.metrics()
-    }
-
-    fn model_info(&self) -> Option<EngineModelInfo> {
-        self.inner.model_info()
-    }
-
-    fn health_check(&self) -> Result<(), EngineError> {
-        self.inner.health_check()
-    }
-
-    fn supports_swap(&self) -> bool {
-        self.inner.supports_swap()
-    }
-
-    fn is_staged(&self) -> bool {
-        self.inner.is_staged()
-    }
-
-    async fn stage(&self, path: &Path) -> Result<(), EngineError> {
-        let planned_report = self.inner.planned_external_device_memory(path)?;
-        self.inner.stage(path).await?;
-        *self.staged_memory_plan.lock().unwrap() = Some(planned_report);
-        Ok(())
-    }
-
-    async fn swap(&self) -> Result<(), EngineError> {
-        let planned_report = self
-            .staged_memory_plan
-            .lock()
-            .unwrap()
-            .clone()
-            .ok_or_else(|| EngineError::backend("no staged memory plan; call stage() first"))?;
-        let mut device_ids: Vec<_> = planned_report
-            .allocations
-            .iter()
-            .map(|allocation| allocation.device_id)
-            .collect();
-        device_ids.sort_unstable();
-        device_ids.dedup();
-
-        let mut swap_admissions = Vec::new();
-        for device_id in device_ids {
-            if let Some(admission) = self
-                .resources
-                .begin_device_memory_swap_admission(device_id, self.model_id, &planned_report)
-                .await
-                .map_err(EngineError::backend)?
-            {
-                swap_admissions.push(admission);
-            }
-        }
-
-        let swap_result = self.inner.swap().await;
-        self.staged_memory_plan.lock().unwrap().take();
-        swap_result?;
-
-        // Activation has released the old weights. Return the temporary peak
-        // reservation before replacing the persistent lease with the target's
-        // measured footprint. There is no await between these operations, so a
-        // waiting load cannot observe the intermediate ledger state.
-        drop(swap_admissions);
-        let report = self.inner.actual_external_device_memory();
-        for lease in self.leases.lock().unwrap().iter_mut() {
-            lease
-                .reconcile_report(&report)
-                .map_err(EngineError::backend)?;
-        }
-        Ok(())
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-pub(super) fn track_device_memory(
-    engine: Box<dyn kapsl_engine_api::Engine>,
-    leases: Vec<DeviceMemoryLease>,
-    resources: Arc<RuntimeResources>,
-    model_id: u32,
-) -> Box<dyn kapsl_engine_api::Engine> {
-    Box::new(DeviceMemoryTrackedEngine::new(
-        engine, leases, resources, model_id,
-    ))
+    Ok(EstimatedModelMemory {
+        session_bytes: serialized.saturating_mul(5).saturating_div(4),
+        workspace_bytes: (serialized / 4).max(256 * 1024 * 1024),
+    })
 }
 
 pub(super) fn create_runtime_backend_for_device(
@@ -276,13 +203,14 @@ pub(super) fn create_runtime_backend_for_device(
     tuning: &OnnxRuntimeTuning,
     resources: &RuntimeResources,
     model_id: u32,
+    replica_id: u32,
 ) -> Result<Box<dyn kapsl_engine_api::Engine>, String> {
     #[cfg(not(any(
         feature = "native",
         feature = "gguf-native",
         feature = "gguf-cuda-shared-kv"
     )))]
-    let _ = (resources, model_id);
+    let _ = (resources, model_id, replica_id);
     #[cfg(any(
         feature = "native",
         feature = "gguf-native",
@@ -293,7 +221,12 @@ pub(super) fn create_runtime_backend_for_device(
     #[cfg(feature = "gguf-native")]
     if kind.is_gguf() {
         let backend = if let Some(pool) = resources.device_pool(device_id) {
-            BackendFactory::create_gguf_native_device_pool(device_id as i32, pool, model_id)?
+            BackendFactory::create_gguf_native_device_pool_for_replica(
+                device_id as i32,
+                pool,
+                model_id,
+                replica_id,
+            )?
         } else {
             BackendFactory::create_gguf_native(device_id as i32, None)?
         };
@@ -303,7 +236,12 @@ pub(super) fn create_runtime_backend_for_device(
     #[cfg(all(feature = "gguf-cuda-shared-kv", not(feature = "gguf-native")))]
     if kind.is_gguf() {
         let backend = if let Some(pool) = resources.device_pool(device_id) {
-            BackendFactory::create_gguf_cuda_device_pool(device_id as i32, pool, model_id)?
+            BackendFactory::create_gguf_cuda_device_pool_for_replica(
+                device_id as i32,
+                pool,
+                model_id,
+                replica_id,
+            )?
         } else {
             BackendFactory::create_gguf_cuda_shared_kv(device_id as i32, None)?
         };
@@ -313,17 +251,24 @@ pub(super) fn create_runtime_backend_for_device(
     #[cfg(feature = "native")]
     if kind == EngineKind::Native {
         if let Some(pool) = resources.device_pool(device_id) {
-            return BackendFactory::create_native_device_pool(device_id as i32, pool, model_id)
-                .map(|backend| Box::new(backend) as Box<dyn kapsl_engine_api::Engine>);
+            return BackendFactory::create_native_device_pool_for_replica(
+                device_id as i32,
+                pool,
+                model_id,
+                replica_id,
+            )
+            .map(|backend| Box::new(backend) as Box<dyn kapsl_engine_api::Engine>);
         }
     }
 
-    BackendFactory::create_backend_for_device_with_tuning(
+    BackendFactory::create_backend_for_device_with_tuning_and_owner(
         manifest,
         provider,
         device_id,
         device_info,
         tuning,
+        model_id,
+        replica_id,
     )
 }
 
@@ -333,13 +278,14 @@ pub(super) fn create_runtime_best_backend(
     tuning: &OnnxRuntimeTuning,
     resources: &RuntimeResources,
     model_id: u32,
+    replica_id: u32,
 ) -> Result<Box<dyn kapsl_engine_api::Engine>, String> {
     #[cfg(not(any(
         feature = "native",
         feature = "gguf-native",
         feature = "gguf-cuda-shared-kv"
     )))]
-    let _ = (resources, model_id);
+    let _ = (resources, model_id, replica_id);
     #[cfg(any(
         feature = "native",
         feature = "gguf-native",
@@ -352,7 +298,12 @@ pub(super) fn create_runtime_best_backend(
         #[cfg(feature = "gguf-native")]
         if kind.is_gguf() {
             let backend = if let Some(pool) = resources.device_pool(device_id) {
-                BackendFactory::create_gguf_native_device_pool(device_id as i32, pool, model_id)?
+                BackendFactory::create_gguf_native_device_pool_for_replica(
+                    device_id as i32,
+                    pool,
+                    model_id,
+                    replica_id,
+                )?
             } else {
                 BackendFactory::create_gguf_native(device_id as i32, None)?
             };
@@ -362,7 +313,12 @@ pub(super) fn create_runtime_best_backend(
         #[cfg(all(feature = "gguf-cuda-shared-kv", not(feature = "gguf-native")))]
         if kind.is_gguf() {
             let backend = if let Some(pool) = resources.device_pool(device_id) {
-                BackendFactory::create_gguf_cuda_device_pool(device_id as i32, pool, model_id)?
+                BackendFactory::create_gguf_cuda_device_pool_for_replica(
+                    device_id as i32,
+                    pool,
+                    model_id,
+                    replica_id,
+                )?
             } else {
                 BackendFactory::create_gguf_cuda_shared_kv(device_id as i32, None)?
             };
@@ -372,98 +328,82 @@ pub(super) fn create_runtime_best_backend(
         #[cfg(feature = "native")]
         if kind == EngineKind::Native {
             if let Some(pool) = resources.device_pool(device_id) {
-                return BackendFactory::create_native_device_pool(device_id as i32, pool, model_id)
-                    .map(|backend| Box::new(backend) as Box<dyn kapsl_engine_api::Engine>);
+                return BackendFactory::create_native_device_pool_for_replica(
+                    device_id as i32,
+                    pool,
+                    model_id,
+                    replica_id,
+                )
+                .map(|backend| Box::new(backend) as Box<dyn kapsl_engine_api::Engine>);
             }
         }
     }
 
-    BackendFactory::create_best_backend_with_tuning(manifest, device_info, tuning)
+    BackendFactory::create_best_backend_with_tuning_and_owner(
+        manifest,
+        device_info,
+        tuning,
+        model_id,
+        replica_id,
+    )
 }
 
 /// Execute the runtime-owned backend load transaction.
 ///
-/// Device admission is acquired from the planned report before the backend can
-/// allocate, reconciled against the measured report after a successful load,
-/// and committed into leases owned by the returned engine. Keeping this in one
-/// place prevents primary loads and autoscaled replicas from drifting apart.
+/// One backend-neutral plan is admitted before the backend can allocate,
+/// reconciled against the backend's cross-domain report plus observed CUDA/RSS
+/// deltas after a successful load, and committed into one lease owned by the
+/// returned engine.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn load_runtime_backend(
     mut backend: Box<dyn kapsl_engine_api::Engine>,
     model_file_path: &Path,
-    admission_device_ids: &[usize],
+    admission_domains: &[MemoryDomain],
     resources: &Arc<RuntimeResources>,
     model_id: u32,
+    replica_id: u32,
     engine_kind: EngineKind,
     load_context: &str,
 ) -> Result<Box<dyn kapsl_engine_api::Engine>, DynError> {
-    let host_memory_lease = resources.begin_host_memory_admission(
-        admission_device_ids,
-        model_id,
-        estimated_host_model_bytes(model_file_path)?,
+    let owner = MemoryOwner::new(model_id, replica_id);
+    let estimate = estimated_model_memory(model_file_path)?;
+    let planned_report = backend
+        .planned_memory(model_file_path)
+        .map_err(|error| format!("backend memory plan failed: {error}"))?;
+    let plan = resources.memory().model_load_plan_with_report(
+        admission_domains,
+        owner,
+        estimate.session_bytes,
+        estimate.workspace_bytes,
+        &planned_report,
     )?;
-    #[cfg(not(feature = "gpu-device-pool"))]
-    let _ = (admission_device_ids, resources, model_id, engine_kind);
-
-    #[cfg(feature = "gpu-device-pool")]
-    let mut device_memory_admissions = {
-        let planned_report = backend
-            .planned_external_device_memory(model_file_path)
-            .map_err(|error| format!("backend memory plan failed: {error}"))?;
-        let mut device_ids = admission_device_ids.to_vec();
-        device_ids.sort_unstable();
-        device_ids.dedup();
-
-        let mut admissions = Vec::new();
-        for device_id in device_ids {
-            if let Some(admission) = resources
-                .begin_device_memory_admission(device_id, model_id, engine_kind, &planned_report)
-                .await?
-            {
-                admissions.push(admission);
-            }
-        }
-        admissions
-    };
+    let mut admission = resources.memory().begin_load(&plan, engine_kind).await?;
 
     if let Err(error) = backend.load(model_file_path).await {
         backend.unload();
         return Err(format!("{load_context}: {error}").into());
     }
 
-    #[cfg(feature = "gpu-device-pool")]
-    {
-        let actual_report = backend.actual_external_device_memory();
-        for admission in &mut device_memory_admissions {
-            if let Err(error) = admission.reconcile(&actual_report) {
-                backend.unload();
-                return Err(error.into());
-            }
-        }
-        let leases = device_memory_admissions
-            .into_iter()
-            .map(DeviceMemoryAdmission::commit)
-            .collect();
-        let backend = track_device_memory(backend, leases, resources.clone(), model_id);
-        Ok(if host_memory_lease.is_some() {
-            Box::new(HostMemoryTrackedEngine {
-                inner: backend,
-                lease: host_memory_lease,
-            })
-        } else {
-            backend
-        })
+    let actual_report = backend.actual_memory();
+    if let Err(error) = admission.reconcile(&actual_report) {
+        backend.unload();
+        return Err(error.into());
     }
-
-    #[cfg(not(feature = "gpu-device-pool"))]
-    Ok(if host_memory_lease.is_some() {
-        Box::new(HostMemoryTrackedEngine {
-            inner: backend,
-            lease: host_memory_lease,
-        })
-    } else {
-        backend
-    })
+    let lease = admission.commit();
+    if lease.is_empty() {
+        return Ok(backend);
+    }
+    log::info!(
+        "[memory-authority] committed {} claims for {}",
+        lease.claims().len(),
+        owner
+    );
+    Ok(Box::new(MemoryTrackedEngine::new(
+        backend,
+        lease,
+        resources.clone(),
+        owner,
+    )))
 }
 
 pub(super) fn monitor_runtime_backend(

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
@@ -1,4 +1,93 @@
 use super::*;
+use kapsl_engine_api::{EngineStream, ExternalDeviceMemoryReport};
+
+struct HostMemoryTrackedEngine {
+    inner: Box<dyn kapsl_engine_api::Engine>,
+    lease: Option<super::super::host_memory::HostMemoryLease>,
+}
+
+impl Drop for HostMemoryTrackedEngine {
+    fn drop(&mut self) {
+        self.inner.unload();
+        self.lease.take();
+    }
+}
+
+#[async_trait::async_trait]
+impl kapsl_engine_api::Engine for HostMemoryTrackedEngine {
+    fn planned_external_device_memory(
+        &self,
+        path: &Path,
+    ) -> Result<ExternalDeviceMemoryReport, EngineError> {
+        self.inner.planned_external_device_memory(path)
+    }
+    async fn load(&mut self, path: &Path) -> Result<(), EngineError> {
+        self.inner.load(path).await
+    }
+    fn actual_external_device_memory(&self) -> ExternalDeviceMemoryReport {
+        self.inner.actual_external_device_memory()
+    }
+    fn infer(&self, request: &InferenceRequest) -> Result<BinaryTensorPacket, EngineError> {
+        self.inner.infer(request)
+    }
+    fn infer_batch(
+        &self,
+        requests: &[InferenceRequest],
+    ) -> Result<Vec<BinaryTensorPacket>, EngineError> {
+        self.inner.infer_batch(requests)
+    }
+    fn max_batch(&self) -> usize {
+        self.inner.max_batch()
+    }
+    fn self_batches(&self) -> bool {
+        self.inner.self_batches()
+    }
+    fn batching_policy(&self) -> BatchingPolicy {
+        self.inner.batching_policy()
+    }
+    fn infer_stream(&self, request: &InferenceRequest) -> EngineStream {
+        self.inner.infer_stream(request)
+    }
+    async fn warmup(&self) -> Result<(), EngineError> {
+        self.inner.warmup().await
+    }
+    fn unload(&mut self) {
+        self.inner.unload();
+        self.lease.take();
+    }
+    fn metrics(&self) -> EngineMetrics {
+        self.inner.metrics()
+    }
+    fn model_info(&self) -> Option<EngineModelInfo> {
+        self.inner.model_info()
+    }
+    fn health_check(&self) -> Result<(), EngineError> {
+        self.inner.health_check()
+    }
+    fn supports_swap(&self) -> bool {
+        self.inner.supports_swap()
+    }
+    fn is_staged(&self) -> bool {
+        self.inner.is_staged()
+    }
+    async fn stage(&self, path: &Path) -> Result<(), EngineError> {
+        self.inner.stage(path).await
+    }
+    async fn swap(&self) -> Result<(), EngineError> {
+        self.inner.swap().await
+    }
+}
+
+fn estimated_host_model_bytes(model_path: &Path) -> Result<usize, String> {
+    let serialized = std::fs::metadata(model_path)
+        .map_err(|error| format!("stat model {}: {error}", model_path.display()))?
+        .len() as usize;
+    // Account for decoded/aligned weights and a bounded execution workspace.
+    Ok(serialized
+        .saturating_mul(5)
+        .saturating_div(4)
+        .saturating_add((serialized / 4).max(256 * 1024 * 1024)))
+}
 
 #[cfg(feature = "gpu-device-pool")]
 struct DeviceMemoryTrackedEngine {
@@ -308,6 +397,11 @@ pub(super) async fn load_runtime_backend(
     engine_kind: EngineKind,
     load_context: &str,
 ) -> Result<Box<dyn kapsl_engine_api::Engine>, DynError> {
+    let host_memory_lease = resources.begin_host_memory_admission(
+        admission_device_ids,
+        model_id,
+        estimated_host_model_bytes(model_file_path)?,
+    )?;
     #[cfg(not(feature = "gpu-device-pool"))]
     let _ = (admission_device_ids, resources, model_id, engine_kind);
 
@@ -350,16 +444,26 @@ pub(super) async fn load_runtime_backend(
             .into_iter()
             .map(DeviceMemoryAdmission::commit)
             .collect();
-        Ok(track_device_memory(
-            backend,
-            leases,
-            resources.clone(),
-            model_id,
-        ))
+        let backend = track_device_memory(backend, leases, resources.clone(), model_id);
+        Ok(if host_memory_lease.is_some() {
+            Box::new(HostMemoryTrackedEngine {
+                inner: backend,
+                lease: host_memory_lease,
+            })
+        } else {
+            backend
+        })
     }
 
     #[cfg(not(feature = "gpu-device-pool"))]
-    Ok(backend)
+    Ok(if host_memory_lease.is_some() {
+        Box::new(HostMemoryTrackedEngine {
+            inner: backend,
+            lease: host_memory_lease,
+        })
+    } else {
+        backend
+    })
 }
 
 pub(super) fn monitor_runtime_backend(

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/replica.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/replica.rs
@@ -131,6 +131,10 @@ pub(super) async fn load_replica(
             .filter_map(|rank| mesh.get_device(rank))
             .map(|device| device.id)
             .collect();
+        let memory_domains: Vec<_> = (0..mesh.world_size)
+            .filter_map(|rank| mesh.get_device(rank))
+            .map(|device| MemoryDomain::for_provider(&device.backend.to_string(), device.id))
+            .collect();
         let backend = create_pipeline_backend(
             &plan,
             logical_provider
@@ -142,9 +146,10 @@ pub(super) async fn load_replica(
         let backend = load_runtime_backend(
             backend,
             &plan.model_file_path,
-            &device_ids,
+            &memory_domains,
             &resources,
             plan.base_model_id,
+            plan.replica_id,
             EngineKind::resolve(&plan.loader.manifest),
             &role.load_context(&plan, None),
         )
@@ -175,13 +180,18 @@ pub(super) async fn load_replica(
                 onnx_tuning,
                 &resources,
                 plan.base_model_id,
+                plan.replica_id,
             )?;
             let backend = load_runtime_backend(
                 backend,
                 &plan.model_file_path,
-                &[device.id],
+                &[MemoryDomain::for_provider(
+                    &device.backend.to_string(),
+                    device.id,
+                )],
                 &resources,
                 plan.base_model_id,
+                plan.replica_id,
                 EngineKind::resolve(&plan.loader.manifest),
                 &role.load_context(&plan, Some(device.id)),
             )
@@ -195,6 +205,15 @@ pub(super) async fn load_replica(
         }
         engines
     } else {
+        let selection =
+            select_mesh_devices(&plan.loader.manifest.hardware_requirements, device_info);
+        let selection = selection.map_err(|error| {
+            format!(
+                "Failed to select a device for {}: {}",
+                role.selection_context(&plan),
+                error
+            )
+        })?;
         let device_id = plan
             .loader
             .manifest
@@ -207,13 +226,18 @@ pub(super) async fn load_replica(
             onnx_tuning,
             &resources,
             plan.base_model_id,
+            plan.replica_id,
         )?;
         let backend = load_runtime_backend(
             backend,
             &plan.model_file_path,
-            &[device_id],
+            &[MemoryDomain::for_provider(
+                &selection.logical_provider,
+                device_id,
+            )],
             &resources,
             plan.base_model_id,
+            plan.replica_id,
             EngineKind::resolve(&plan.loader.manifest),
             &role.load_context(&plan, Some(device_id)),
         )
@@ -269,7 +293,8 @@ fn create_pipeline_backend(
         LLMBackend::with_devices(logical_provider.to_owned(), backend_device_ids.clone())
     } else {
         LLMBackend::with_device_ids(backend_device_ids.clone())
-    };
+    }
+    .with_memory_owner(plan.base_model_id, plan.replica_id);
     #[cfg(feature = "gpu-device-pool")]
     {
         backend = backend.with_env_allocators(
@@ -280,9 +305,13 @@ fn create_pipeline_backend(
     }
 
     let primary_device = device_ids.first().copied().unwrap_or(0);
-    let (kv_pool, kv_blocks_cap, global_sched, sched_engine_id, live_cap) = resources
-        .kv()
-        .attach_engine(primary_device, plan.base_model_id, plan.priority_weight);
+    let (kv_pool, kv_blocks_cap, global_sched, sched_engine_id, live_cap) =
+        resources.kv().attach_engine(
+            primary_device,
+            plan.base_model_id,
+            plan.replica_id,
+            plan.priority_weight,
+        );
     backend = backend
         .with_shared_pool(kv_pool)
         .with_kv_blocks_cap(kv_blocks_cap)

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/resources.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/resources.rs
@@ -29,14 +29,12 @@ impl ResourcePressure {
 
 /// Coordinating facade for runtime-owned resources.
 ///
-/// Logical KV allocation, physical CUDA pooling/admission, and pressure
-/// monitoring remain independent components; this type only gives lifecycle
-/// code one stable owner and a consistent per-process authority boundary.
+/// Logical KV allocation and pressure monitoring remain independent policy
+/// components. All physical/accounting memory domains live below one
+/// `MemoryAuthority` owned here.
 pub(crate) struct RuntimeResources {
     kv: KvCoordinator,
-    host_memory: Arc<super::host_memory::HostMemoryManager>,
-    #[cfg(feature = "gpu-device-pool")]
-    device_memory: Option<Arc<DeviceMemoryManager>>,
+    memory: Arc<MemoryAuthority>,
     pressure: Arc<ResourcePressure>,
 }
 
@@ -49,9 +47,13 @@ impl RuntimeResources {
         }
         #[cfg(not(feature = "gpu-device-pool"))]
         {
+            let memory = MemoryAuthority::new(device_info)?;
             Ok(Arc::new(Self {
-                kv: KvCoordinatorInner::new(device_info),
-                host_memory: super::host_memory::HostMemoryManager::new(device_info),
+                kv: KvCoordinatorInner::new_with_host_budget(
+                    device_info,
+                    Some(memory.host_budget()),
+                ),
+                memory,
                 pressure: ResourcePressure::from_env(),
             }))
         }
@@ -62,10 +64,10 @@ impl RuntimeResources {
         device_info: &DeviceInfo,
         bootstrap: &DeviceMemoryBootstrapPlan,
     ) -> Result<Arc<Self>, String> {
+        let memory = MemoryAuthority::new_with_cuda_plan(device_info, bootstrap)?;
         Ok(Arc::new(Self {
-            kv: KvCoordinatorInner::new(device_info),
-            host_memory: super::host_memory::HostMemoryManager::new(device_info),
-            device_memory: DeviceMemoryManager::from_env_with_plan(device_info, bootstrap)?,
+            kv: KvCoordinatorInner::new_with_host_budget(device_info, Some(memory.host_budget())),
+            memory,
             pressure: ResourcePressure::from_env(),
         }))
     }
@@ -78,14 +80,8 @@ impl RuntimeResources {
         &self.pressure
     }
 
-    pub(crate) fn begin_host_memory_admission(
-        &self,
-        device_ids: &[usize],
-        model_id: u32,
-        requested_bytes: usize,
-    ) -> Result<Option<super::host_memory::HostMemoryLease>, String> {
-        self.host_memory
-            .admit(device_ids, model_id, requested_bytes)
+    pub(crate) fn memory(&self) -> &Arc<MemoryAuthority> {
+        &self.memory
     }
 
     #[cfg(any(
@@ -97,16 +93,12 @@ impl RuntimeResources {
         &self,
         device_id: usize,
     ) -> Option<Arc<kapsl_hal::gpu_arena::GpuDevicePool>> {
-        self.device_memory
-            .as_ref()
-            .and_then(|manager| manager.pool(device_id))
+        self.memory.cuda_pool(device_id)
     }
 
     #[cfg(feature = "gpu-device-pool")]
     pub(crate) fn uses_env_allocators(&self, device_id: usize) -> bool {
-        self.device_memory
-            .as_ref()
-            .is_some_and(|manager| manager.has_pool(device_id))
+        self.memory.uses_cuda_environment_allocator(device_id)
     }
 
     #[cfg(feature = "gpu-device-pool")]
@@ -114,41 +106,7 @@ impl RuntimeResources {
         &self,
         bootstrap: &DeviceMemoryBootstrapPlan,
     ) -> Result<(), String> {
-        if let Some(manager) = self.device_memory.as_ref() {
-            manager.ensure_pools_for_plan(bootstrap)?;
-        }
-        Ok(())
-    }
-
-    #[cfg(feature = "gpu-device-pool")]
-    pub(crate) async fn begin_device_memory_admission(
-        &self,
-        device_id: usize,
-        model_id: u32,
-        kind: EngineKind,
-        planned_report: &ExternalDeviceMemoryReport,
-    ) -> Result<Option<DeviceMemoryAdmission>, String> {
-        let Some(manager) = self.device_memory.as_ref() else {
-            return Ok(None);
-        };
-        manager
-            .begin_admission(device_id, model_id, kind, planned_report)
-            .await
-    }
-
-    #[cfg(feature = "gpu-device-pool")]
-    pub(crate) async fn begin_device_memory_swap_admission(
-        &self,
-        device_id: usize,
-        model_id: u32,
-        planned_report: &ExternalDeviceMemoryReport,
-    ) -> Result<Option<DeviceMemorySwapAdmission>, String> {
-        let Some(manager) = self.device_memory.as_ref() else {
-            return Ok(None);
-        };
-        manager
-            .begin_swap_admission(device_id, model_id, planned_report)
-            .await
+        self.memory.ensure_cuda_pools(bootstrap)
     }
 
     #[cfg(feature = "gpu-device-pool")]
@@ -156,15 +114,10 @@ impl RuntimeResources {
         &self,
         metrics: kapsl_monitor::metrics::KapslMetrics,
     ) {
-        if let Some(manager) = self.device_memory.as_ref() {
-            manager.attach_metrics(metrics);
-        }
+        self.memory.attach_cuda_metrics(metrics);
     }
 
     pub(crate) fn refresh_device_pool_metrics(&self) {
-        #[cfg(feature = "gpu-device-pool")]
-        if let Some(manager) = self.device_memory.as_ref() {
-            manager.refresh_pool_metrics();
-        }
+        self.memory.refresh_cuda_pool_metrics();
     }
 }

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/resources.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/resources.rs
@@ -34,6 +34,7 @@ impl ResourcePressure {
 /// code one stable owner and a consistent per-process authority boundary.
 pub(crate) struct RuntimeResources {
     kv: KvCoordinator,
+    host_memory: Arc<super::host_memory::HostMemoryManager>,
     #[cfg(feature = "gpu-device-pool")]
     device_memory: Option<Arc<DeviceMemoryManager>>,
     pressure: Arc<ResourcePressure>,
@@ -50,6 +51,7 @@ impl RuntimeResources {
         {
             Ok(Arc::new(Self {
                 kv: KvCoordinatorInner::new(device_info),
+                host_memory: super::host_memory::HostMemoryManager::new(device_info),
                 pressure: ResourcePressure::from_env(),
             }))
         }
@@ -62,6 +64,7 @@ impl RuntimeResources {
     ) -> Result<Arc<Self>, String> {
         Ok(Arc::new(Self {
             kv: KvCoordinatorInner::new(device_info),
+            host_memory: super::host_memory::HostMemoryManager::new(device_info),
             device_memory: DeviceMemoryManager::from_env_with_plan(device_info, bootstrap)?,
             pressure: ResourcePressure::from_env(),
         }))
@@ -73,6 +76,16 @@ impl RuntimeResources {
 
     pub(crate) fn pressure(&self) -> &Arc<ResourcePressure> {
         &self.pressure
+    }
+
+    pub(crate) fn begin_host_memory_admission(
+        &self,
+        device_ids: &[usize],
+        model_id: u32,
+        requested_bytes: usize,
+    ) -> Result<Option<super::host_memory::HostMemoryLease>, String> {
+        self.host_memory
+            .admit(device_ids, model_id, requested_bytes)
     }
 
     #[cfg(any(

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
@@ -83,21 +83,40 @@ fn ceiling_is_squeezed(device_id: usize, declared: usize, live_bytes: usize) -> 
 
 impl KvCoordinatorInner {
     pub(crate) fn new(device_info: &DeviceInfo) -> KvCoordinator {
+        Self::new_with_host_budget(device_info, None)
+    }
+
+    fn new_with_host_budget(
+        device_info: &DeviceInfo,
+        host_budget_override: Option<super::host_memory::HostMemoryBudget>,
+    ) -> KvCoordinator {
         const KV_BYTES_PER_BLOCK: usize = 2 * 1024 * 1024;
         const KV_BLOCK_SIZE: usize = 16;
         let mut device_bytes = HashMap::new();
         let mut estimated_kv_tokens: usize = 0;
+        let host_budget = host_budget_override.unwrap_or_else(|| {
+            super::host_memory::HostMemoryBudget::detect(device_info.total_memory)
+        });
         for device in &device_info.devices {
-            if device.backend.to_string().eq_ignore_ascii_case("cpu") {
+            let is_cpu = device.backend.to_string().eq_ignore_ascii_case("cpu");
+            let total = if is_cpu {
+                host_budget.safe_bytes
+            } else {
+                (device.memory_mb as usize).saturating_mul(1024 * 1024)
+            };
+            if total == 0 {
                 continue;
             }
-            let total = (device.memory_mb as usize).saturating_mul(1024 * 1024);
             // Cooperative software-vGPU clamp: when a per-device VRAM cap is
             // configured (HAMi env or the kapsl alias), size the KV budget to
             // the slice rather than the whole card. A no-op when no cap is set
             // or the cap exceeds the card, so default behavior is unchanged and
             // a MIG slice (which already reports its true size) is never inflated.
-            let total = device_vram_cap_bytes(device.id).map_or(total, |cap| total.min(cap));
+            let total = if is_cpu {
+                total
+            } else {
+                device_vram_cap_bytes(device.id).map_or(total, |cap| total.min(cap))
+            };
             device_bytes.insert(device.id, total);
             let kv_blocks = (total / 2) / KV_BYTES_PER_BLOCK;
             estimated_kv_tokens = estimated_kv_tokens.saturating_add(kv_blocks * KV_BLOCK_SIZE);
@@ -360,6 +379,7 @@ impl KvCoordinatorInner {
 mod vram_clamp_tests {
     use super::KvCoordinatorInner;
     use crate::app::constants::CUDA_DEVICE_MEMORY_LIMIT_ENV;
+    use crate::runtime::host_memory::HostMemoryBudget;
     use kapsl_hal::device::{Device, DeviceBackend, DeviceInfo};
 
     const GIB: usize = 1024 * 1024 * 1024;
@@ -383,6 +403,25 @@ mod vram_clamp_tests {
         }
     }
 
+    fn cpu_device(id: usize) -> Device {
+        Device {
+            id,
+            name: "test-cpu".to_string(),
+            backend: DeviceBackend::Cpu,
+            memory_mb: 0,
+            compute_units: 1,
+            pci_bus_id: None,
+            partition_id: None,
+            driver_version: None,
+            cuda_version: None,
+            compute_capability: None,
+            utilization_gpu_pct: None,
+            temperature_c: None,
+            supports_fp16: false,
+            supports_int8: true,
+        }
+    }
+
     fn device_info(devices: Vec<Device>) -> DeviceInfo {
         DeviceInfo {
             cpu_cores: 1,
@@ -395,6 +434,26 @@ mod vram_clamp_tests {
             has_directml: false,
             devices,
         }
+    }
+
+    #[test]
+    fn cpu_kv_budget_is_derived_from_safe_host_memory() {
+        let cpu_id = 4260;
+        let mut info = device_info(vec![cpu_device(cpu_id)]);
+        // DeviceInfo reports host memory in KiB. The host budget retains 20%,
+        // then the KV coordinator dedicates half of that safe budget to KV.
+        info.total_memory = 20 * 1024 * 1024;
+        let state = KvCoordinatorInner::new_with_host_budget(
+            &info,
+            Some(HostMemoryBudget {
+                limit_bytes: 20 * GIB,
+                safe_bytes: 16 * GIB,
+            }),
+        );
+
+        assert_eq!(state.device_bytes.get(&cpu_id).copied(), Some(16 * GIB));
+        let (_, cap, _, _, _) = state.attach_engine(cpu_id, 10, 1);
+        assert_eq!(cap, 4_096);
     }
 
     #[test]

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/shared_kv.rs
@@ -2,6 +2,7 @@ use super::*;
 
 struct KvEngineRecord {
     model_id: u32,
+    replica_id: u32,
     device_id: usize,
     live_cap: Arc<AtomicUsize>,
 }
@@ -82,11 +83,12 @@ fn ceiling_is_squeezed(device_id: usize, declared: usize, live_bytes: usize) -> 
 }
 
 impl KvCoordinatorInner {
+    #[cfg(test)]
     pub(crate) fn new(device_info: &DeviceInfo) -> KvCoordinator {
         Self::new_with_host_budget(device_info, None)
     }
 
-    fn new_with_host_budget(
+    pub(crate) fn new_with_host_budget(
         device_info: &DeviceInfo,
         host_budget_override: Option<super::host_memory::HostMemoryBudget>,
     ) -> KvCoordinator {
@@ -159,6 +161,7 @@ impl KvCoordinatorInner {
         &self,
         device_id: usize,
         model_id: u32,
+        replica_id: u32,
         weight: u32,
     ) -> (
         SharedBlockAllocator,
@@ -192,6 +195,7 @@ impl KvCoordinatorInner {
                 engine_id,
                 KvEngineRecord {
                     model_id,
+                    replica_id,
                     device_id,
                     live_cap: live_cap.clone(),
                 },
@@ -371,6 +375,13 @@ impl KvCoordinatorInner {
             let new_cap =
                 (total_blocks * budget.max_tokens / device_tokens).max(MIN_BLOCKS_PER_ENGINE);
             record.live_cap.store(new_cap, Ordering::Relaxed);
+            log::trace!(
+                "[memory-authority] KV cap for model {} replica {} on device {}: {} blocks",
+                record.model_id,
+                record.replica_id,
+                device_id,
+                new_cap
+            );
         }
     }
 }
@@ -452,7 +463,7 @@ mod vram_clamp_tests {
         );
 
         assert_eq!(state.device_bytes.get(&cpu_id).copied(), Some(16 * GIB));
-        let (_, cap, _, _, _) = state.attach_engine(cpu_id, 10, 1);
+        let (_, cap, _, _, _) = state.attach_engine(cpu_id, 10, 0, 1);
         assert_eq!(cap, 4_096);
     }
 
@@ -476,8 +487,8 @@ mod vram_clamp_tests {
         ]);
         let state = KvCoordinatorInner::new(&info);
 
-        let (_, _, _, _, first_cap) = state.attach_engine(first_device, 10, 1);
-        let (_, _, _, _, second_cap) = state.attach_engine(second_device, 20, 1);
+        let (_, _, _, _, first_cap) = state.attach_engine(first_device, 10, 0, 1);
+        let (_, _, _, _, second_cap) = state.attach_engine(second_device, 20, 3, 1);
 
         // Each device has one engine, so each receives its own full logical KV
         // budget: half of VRAM divided into 2 MiB blocks.


### PR DESCRIPTION
## Summary\n- add a backend-neutral MemoryPlan/MemoryLease authority for host, CUDA, and provider memory domains\n- migrate CPU admission and CUDA pool accounting under model/replica/allocation-class ownership\n- add host RSS reconciliation and per-request reservations\n- pin the SDK feature revision used by the engine until the SDK changes are released\n\n## Validation\n- cargo fmt --all -- --check\n- cargo check -p kapsl\n- cargo test -p kapsl (182 passed)\n- cargo check -p kapsl --features gpu-device-pool,cudarc/cuda-12000\n- cargo check -p kapsl --features native,gguf-native,cudarc/cuda-12000\n\n## Known boundary\n- llama.cpp/GGUF weights and scratch allocations that are owned outside the CUDA pool are represented as externally owned memory rather than physically migrated into the pool.