### PR TITLE
fix: qualify llama pack profile in Linux bundle test

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/backend_bundle.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend_bundle.rs
@@ -1234,6 +1234,7 @@ mod tests {
             "runtime_abi": BACKEND_RUNTIME_ABI,
             "platform": "linux-x86_64",
             "execution_mode": "native",
+            "kv_mode": "native",
             "entrypoint": "lib/libkapsl_backend_llama_cpp.so"
         });
         append_bytes(

--- a/kapsl-runtime/crates/kapsl-cli/src/backend_bundle.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend_bundle.rs
@@ -1516,7 +1516,10 @@ mod tests {
         let installed = manager.list().unwrap();
         assert_eq!(installed.len(), 1);
         assert_eq!(installed[0].backend, "llama-cpp");
-        assert_eq!(installed[0].profile, LLAMA_CPP_CPU_PACK_PROFILE);
+        assert_eq!(
+            installed[0].profile,
+            crate::backend_manager::LLAMA_CPP_CPU_PACK_PROFILE
+        );
         assert!(installed[0].valid);
     }
 


### PR DESCRIPTION
## Summary

- qualify the Linux-only offline-bundle assertion through `crate::backend_manager`
- restore compilation for both Ubuntu CI test jobs

## Validation

- `cargo fmt --manifest-path kapsl-runtime/Cargo.toml --all -- --check`
- `cargo test --manifest-path kapsl-runtime/Cargo.toml --workspace`
- `cargo test --manifest-path kapsl-runtime/Cargo.toml -p kapsl --features gpu-device-pool -- --test-threads=1`

Fixes the compile failure in CI run 32852389160.
