### PR TITLE
Centralize Rust toolchain and installer layout

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,47 @@
+name: Set up Rust
+description: Install the Rust toolchain declared by this repository or its workspace MSRV
+
+inputs:
+  msrv:
+    description: Install the workspace minimum supported Rust version instead of the pinned toolchain
+    required: false
+    default: "false"
+  targets:
+    description: Comma-separated compilation targets to install
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Rust toolchain
+      id: toolchain
+      shell: bash
+      env:
+        USE_MSRV: ${{ inputs.msrv }}
+      run: |
+        set -euo pipefail
+        repository_root="$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)"
+        if [[ "$USE_MSRV" == "true" ]]; then
+          source_file="$repository_root/kapsl-runtime/Cargo.toml"
+          version="$(sed -nE 's/^[[:space:]]*rust-version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$source_file" | head -n 1)"
+        else
+          source_file="$repository_root/rust-toolchain.toml"
+          version="$(sed -nE 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$source_file" | head -n 1)"
+        fi
+        if [[ -z "$version" ]]; then
+          echo "Could not resolve a Rust version from $source_file" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Install Rust ${{ steps.toolchain.outputs.version }}
+      id: install
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.toolchain.outputs.version }}
+        targets: ${{ inputs.targets }}
+
+    - name: Activate Rust ${{ steps.install.outputs.name }}
+      shell: bash
+      run: echo "RUSTUP_TOOLCHAIN=${{ steps.install.outputs.name }}" >> "$GITHUB_ENV"

--- a/.github/scripts/test-install-script.sh
+++ b/.github/scripts/test-install-script.sh
@@ -3,6 +3,9 @@
 set -eu
 
 version="9.9.9"
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+repository_root="$(CDPATH= cd "${script_dir}/../.." && pwd)"
+installer_dir="${repository_root}/installers"
 test_root="$(mktemp -d)"
 release_dir="${test_root}/release"
 asset_dir="${release_dir}/runtime/v${version}"
@@ -115,8 +118,8 @@ echo "single-exe"
 EOF
 
 # install-cuda.sh fetches the general installer from the same origin.
-cp install.sh "${release_dir}/install.sh"
-cp install.sh "${release_dir}/install-beta-base.sh"
+cp "${installer_dir}/install.sh" "${release_dir}/install.sh"
+cp "${installer_dir}/install.sh" "${release_dir}/install-beta-base.sh"
 cp "${asset_dir}/${portable_asset}" "${beta_asset_dir}/${portable_asset}"
 cp "${asset_dir}/${cuda_asset}" "${beta_asset_dir}/${cuda_asset}"
 cp "${asset_dir}/kapsl-backend-vllm-${version}-linux-x86_64.tar.gz" "${beta_asset_dir}/"
@@ -159,7 +162,7 @@ run_install() {
     fi
 
     set +e
-    PATH="${fake_bin}:${PATH}" sh install.sh "$@" >"${log_file}" 2>&1
+    PATH="${fake_bin}:${PATH}" sh "${installer_dir}/install.sh" "$@" >"${log_file}" 2>&1
     install_status=$?
     set -e
 }
@@ -245,7 +248,7 @@ expect_log "installed on first eligible run"
 reject_log "legacy split"
 
 echo "case: direct CUDA wrapper selects the same merged bundle"
-run_cuda_wrapper "cuda-wrapper" install-cuda.sh
+run_cuda_wrapper "cuda-wrapper" "${installer_dir}/install-cuda.sh"
 expect_status 0
 expect_binary "cuda12"
 expect_file "kapsl-provider-cuda12.json"
@@ -255,7 +258,7 @@ if [ -e "${install_dir}/backends/vllm/bin/python" ]; then
 fi
 
 echo "case: beta CUDA wrapper selects the merged beta bundle"
-run_cuda_wrapper "beta-cuda-wrapper" install-beta-cuda.sh
+run_cuda_wrapper "beta-cuda-wrapper" "${installer_dir}/install-beta-cuda.sh"
 expect_status 0
 expect_binary "cuda12"
 expect_file "kapsl-provider-cuda12.json"
@@ -265,7 +268,7 @@ if [ -e "${install_dir}/backends/vllm/bin/python" ]; then
 fi
 
 echo "case: generic beta wrapper selects portable runtime without an NVIDIA driver"
-run_cuda_wrapper "beta-wrapper-cpu" install-beta.sh
+run_cuda_wrapper "beta-wrapper-cpu" "${installer_dir}/install-beta.sh"
 expect_status 0
 expect_binary "portable"
 
@@ -278,7 +281,7 @@ esac
 exit 0
 EOF
 chmod +x "${fake_bin}/nvidia-smi"
-run_cuda_wrapper "beta-wrapper-cuda" install-beta.sh
+run_cuda_wrapper "beta-wrapper-cuda" "${installer_dir}/install-beta.sh"
 expect_status 0
 expect_binary "cuda12"
 expect_file "kapsl-provider-cuda12.json"

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -83,9 +83,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+        uses: ./.github/actions/setup-rust
 
       - name: Set up Python for accelerator dependency collection
         if: runner.os == 'Windows'
@@ -342,9 +340,7 @@ jobs:
           path: sdk-llama
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+        uses: ./.github/actions/setup-rust
 
       - name: Build kapsl with statically compiled GGUF CUDA
         run: cargo build --manifest-path kapsl-runtime/Cargo.toml -p kapsl --release --no-default-features --features cuda
@@ -552,37 +548,31 @@ jobs:
               --no-progress \
               --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
-          aws s3 cp install.ps1 \
+          aws s3 cp installers/install.ps1 \
             s3://kapsl-installer/install-beta-base.ps1 \
             --content-type "text/plain" \
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
-          aws s3 cp install.sh \
+          aws s3 cp installers/install.sh \
             s3://kapsl-installer/install-beta-base.sh \
             --content-type "text/plain" \
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
-          for script in install-beta.ps1 install-beta-cuda.ps1 install-beta-tensorrt.ps1; do
-            aws s3 cp "$script" \
+          for script_path in \
+            installers/install-beta.ps1 \
+            installers/install-beta-cuda.ps1 \
+            installers/install-beta-tensorrt.ps1 \
+            installers/install-beta-cuda.sh \
+            installers/install-beta.sh; do
+            script="$(basename "$script_path")"
+            aws s3 cp "$script_path" \
               "s3://kapsl-installer/$script" \
               --content-type "text/plain" \
               --no-progress \
               --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
           done
-
-          aws s3 cp install-beta-cuda.sh \
-            s3://kapsl-installer/install-beta-cuda.sh \
-            --content-type "text/plain" \
-            --no-progress \
-            --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
-
-          aws s3 cp install-beta.sh \
-            s3://kapsl-installer/install-beta.sh \
-            --content-type "text/plain" \
-            --no-progress \
-            --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
       - name: Retain current and rollback-compatible beta installers in R2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,12 @@ jobs:
 
       - name: Set up Rust
         if: runner.os != 'Windows'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+        uses: ./.github/actions/setup-rust
 
       - name: Set up Rust (Windows)
         if: runner.os == 'Windows'
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.92.0
           targets: x86_64-pc-windows-msvc
 
       - name: Enable long paths on Windows
@@ -74,6 +71,24 @@ jobs:
           INCLUDE: ${{ github.workspace }}/kapsl-runtime/crates/kapsl-cli;$env:INCLUDE
         run: cargo check --manifest-path kapsl-runtime/Cargo.toml --target x86_64-pc-windows-msvc -p kapsl
 
+  msrv:
+    name: Cargo check (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up workspace MSRV
+        uses: ./.github/actions/setup-rust
+        with:
+          msrv: true
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: msrv
+
+      - name: Check runtime workspace on its minimum Rust version
+        run: cargo check --manifest-path kapsl-runtime/Cargo.toml --workspace --locked
 
   test:
     name: Cargo test (${{ matrix.os }})
@@ -87,15 +102,12 @@ jobs:
 
       - name: Set up Rust
         if: runner.os != 'Windows'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+        uses: ./.github/actions/setup-rust
 
       - name: Set up Rust (Windows)
         if: runner.os == 'Windows'
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/setup-rust
         with:
-          toolchain: 1.92.0
           targets: x86_64-pc-windows-msvc
 
       - name: Enable long paths on Windows

--- a/.github/workflows/gpu-device-pool-integration.yml
+++ b/.github/workflows/gpu-device-pool-integration.yml
@@ -37,9 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+      - uses: ./.github/actions/setup-rust
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -3,10 +3,7 @@ name: Installer Smoke Tests
 on:
   pull_request:
     paths:
-      - "install.sh"
-      - "install-cuda.sh"
-      - "install-beta-cuda.sh"
-      - "install-beta.sh"
+      - "installers/**"
       - ".github/scripts/test-install-script.sh"
       - ".github/scripts/package-linux-cuda-runtime.sh"
       - ".github/scripts/test-package-linux-cuda-runtime.sh"
@@ -53,10 +50,10 @@ jobs:
 
       - name: Check shell syntax
         run: |
-          sh -n install.sh
-          sh -n install-cuda.sh
-          sh -n install-beta-cuda.sh
-          sh -n install-beta.sh
+          sh -n installers/install.sh
+          sh -n installers/install-cuda.sh
+          sh -n installers/install-beta-cuda.sh
+          sh -n installers/install-beta.sh
           sh -n .github/scripts/test-install-script.sh
           bash -n .github/scripts/package-linux-cuda-runtime.sh
           bash -n .github/scripts/test-package-linux-cuda-runtime.sh

--- a/.github/workflows/lazy-llama-cpp-backend-pack-gpu-certification.yml
+++ b/.github/workflows/lazy-llama-cpp-backend-pack-gpu-certification.yml
@@ -48,9 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+      - uses: ./.github/actions/setup-rust
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -84,9 +84,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+        uses: ./.github/actions/setup-rust
 
       - name: Set up Python for accelerator dependency collection
         if: runner.os == 'Windows'
@@ -394,9 +392,7 @@ jobs:
           path: sdk-llama
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+        uses: ./.github/actions/setup-rust
 
       - name: Build kapsl with statically compiled GGUF CUDA
         run: cargo build --manifest-path kapsl-runtime/Cargo.toml -p kapsl --release --no-default-features --features cuda
@@ -571,8 +567,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          for script in install.sh install-cuda.sh; do
-            aws s3 cp "$script" \
+          for script_path in installers/install.sh installers/install-cuda.sh; do
+            script="$(basename "$script_path")"
+            aws s3 cp "$script_path" \
               "s3://kapsl-installer/$script" \
               --content-type "text/plain" \
               --no-progress \
@@ -585,8 +582,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          for script in install.ps1 install-cuda.ps1 install-tensorrt.ps1; do
-            aws s3 cp "$script" \
+          for script_path in installers/install.ps1 installers/install-cuda.ps1 installers/install-tensorrt.ps1; do
+            script="$(basename "$script_path")"
+            aws s3 cp "$script_path" \
               "s3://kapsl-installer/$script" \
               --content-type "text/plain" \
               --no-progress \

--- a/.github/workflows/vllm-shared-pool-conformance.yml
+++ b/.github/workflows/vllm-shared-pool-conformance.yml
@@ -85,9 +85,7 @@ jobs:
         shell: bash
         run: engine/.github/scripts/verify-managed-vllm-sdk-checkout.sh sdk "$KAPSL_VLLM_SDK_REF"
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.92.0
+      - uses: ./engine/.github/actions/setup-rust
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The runtime binary depends on those crates through normal Cargo dependencies.
 - `kapsl-runtime/ui/`: embedded web dashboard assets
 - `kapsl-runtime/docs/`: runtime-specific user and API docs
 - `kapsl-runtime/patches/`: active third-party crate patches used only by this workspace
+- `installers/`: source scripts published at the stable and beta installer URLs
 - `docker/`: Dockerfiles for CPU and CUDA images
 - `docs/`: runtime-specific documentation
 
@@ -59,7 +60,8 @@ RAG primitives, and Python packaging belong in `kapsl-sdk`.
 
 ## Requirements
 
-- Rust `1.92.0`
+- Rust `1.98.0` (pinned by `rust-toolchain.toml`); the runtime workspace MSRV
+  remains Rust `1.92.0`
 - platform build tools for your target OS
 - optional accelerator toolchains depending on which runtime backends you enable
 

--- a/docs/kapsl-cli-user-guide.md
+++ b/docs/kapsl-cli-user-guide.md
@@ -94,7 +94,7 @@ Test the script locally (without hitting the real server):
 cd /tmp/kapsl-test-serve && python3 -m http.server 8787
 
 # In another terminal — override the base URL
-KAPSL_BASE_URL=http://127.0.0.1:8787 KAPSL_INSTALL_DIR=/tmp/kapsl-out sh install.sh
+KAPSL_BASE_URL=http://127.0.0.1:8787 KAPSL_INSTALL_DIR=/tmp/kapsl-out sh installers/install.sh
 ```
 
 ### Build from source

--- a/installers/README.md
+++ b/installers/README.md
@@ -1,0 +1,16 @@
+# Public installers
+
+This directory contains the source scripts published at
+`https://downloads.kapsl.net/`. Repository paths are internal; the release
+workflows publish each script under its existing filename, so public install
+commands remain stable.
+
+- `install.sh` and `install.ps1` contain the shared installer implementation.
+- `install-cuda.*` and `install-tensorrt.ps1` select stable accelerator builds.
+- `install-beta*` selects the beta channel and its accelerator variants.
+
+Keep public filenames backward compatible. If a filename must change, retain
+the old published entry point as a forwarding wrapper for at least one release
+cycle.
+
+Run `.github/scripts/test-install-script.sh` after changing a shell installer.

--- a/installers/install-beta-cuda.ps1
+++ b/installers/install-beta-cuda.ps1
@@ -1,7 +1,7 @@
-# Latest Kapsl beta Windows installer with CUDA 12 and TensorRT 10 support.
+# Published latest Kapsl beta Windows installer with CUDA 12 support.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $source = Invoke-RestMethod -Uri "https://downloads.kapsl.net/install-beta-base.ps1" -UseBasicParsing
 $installer = [ScriptBlock]::Create([string]$source)
-& $installer -Channel "beta" -Accelerator "tensorrt"
+& $installer -Channel "beta" -Accelerator "cuda"

--- a/installers/install-beta-cuda.sh
+++ b/installers/install-beta-cuda.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# One-command Linux x86_64 CUDA installer for the beta channel.
+# Published one-command Linux x86_64 CUDA installer for the beta channel.
 set -e
 
 base_url="${KAPSL_BASE_URL:-https://downloads.kapsl.net}"

--- a/installers/install-beta-tensorrt.ps1
+++ b/installers/install-beta-tensorrt.ps1
@@ -1,7 +1,7 @@
-# Latest Kapsl beta Windows installer with CUDA 12 support.
+# Published latest Kapsl beta Windows installer with CUDA 12 and TensorRT 10 support.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $source = Invoke-RestMethod -Uri "https://downloads.kapsl.net/install-beta-base.ps1" -UseBasicParsing
 $installer = [ScriptBlock]::Create([string]$source)
-& $installer -Channel "beta" -Accelerator "cuda"
+& $installer -Channel "beta" -Accelerator "tensorrt"

--- a/installers/install-beta.ps1
+++ b/installers/install-beta.ps1
@@ -1,4 +1,4 @@
-# Latest Kapsl beta Windows installer.
+# Published latest Kapsl beta Windows installer.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 

--- a/installers/install-beta.sh
+++ b/installers/install-beta.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# One-command installer for the latest Kapsl beta. On Linux x86_64, select the
+# Published one-command installer for the latest Kapsl beta. On Linux x86_64, select the
 # CUDA runtime when a working NVIDIA driver is visible; all other hosts use the
 # portable runtime. KAPSL_ACCELERATOR or --accelerator can override the choice.
 set -e

--- a/installers/install-cuda.ps1
+++ b/installers/install-cuda.ps1
@@ -1,7 +1,7 @@
-# Kapsl Windows installer with CUDA 12 and TensorRT 10 support.
+# Published Kapsl Windows installer with CUDA 12 support.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $source = Invoke-RestMethod -Uri "https://downloads.kapsl.net/install.ps1" -UseBasicParsing
 $installer = [ScriptBlock]::Create([string]$source)
-& $installer -Accelerator "tensorrt"
+& $installer -Accelerator "cuda"

--- a/installers/install-cuda.sh
+++ b/installers/install-cuda.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# One-command Linux x86_64 CUDA installer.
+# Published one-command Linux x86_64 CUDA installer.
 set -e
 
 base_url="${KAPSL_BASE_URL:-https://downloads.kapsl.net}"

--- a/installers/install-tensorrt.ps1
+++ b/installers/install-tensorrt.ps1
@@ -1,7 +1,7 @@
-# Kapsl Windows installer with CUDA 12 support.
+# Published Kapsl Windows installer with CUDA 12 and TensorRT 10 support.
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $source = Invoke-RestMethod -Uri "https://downloads.kapsl.net/install.ps1" -UseBasicParsing
 $installer = [ScriptBlock]::Create([string]$source)
-& $installer -Accelerator "cuda"
+& $installer -Accelerator "tensorrt"

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -1,4 +1,4 @@
-# Kapsl CLI installer for Windows
+# Published Kapsl CLI installer for Windows
 # Usage: irm https://downloads.kapsl.net/install.ps1 | iex
 # Saved-script usage: .\install.ps1 -Accelerator cuda
 [CmdletBinding()]

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Kapsl CLI installer
+# Published Kapsl CLI installer
 # Usage: curl -fsSL https://downloads.kapsl.net/install.sh | sh
 # CUDA: curl -fsSL https://downloads.kapsl.net/install-cuda.sh | sh
 set -e

--- a/kapsl-runtime/Cargo.toml
+++ b/kapsl-runtime/Cargo.toml
@@ -10,5 +10,8 @@ exclude = [
 
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.92"
+
 [patch.crates-io]
 esaxx-rs = { path = "patches/esaxx-rs" }

--- a/kapsl-runtime/DEVELOPER_GUIDE.md
+++ b/kapsl-runtime/DEVELOPER_GUIDE.md
@@ -98,7 +98,8 @@ graph TB
 
 ### Required
 
-- **Rust**: 1.92.0
+- **Rust**: 1.98.0 is the pinned development and release toolchain; Rust 1.92.0
+  is the workspace MSRV
 
   ```bash
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/kapsl-runtime/FULL_DOCUMENTATION.md
+++ b/kapsl-runtime/FULL_DOCUMENTATION.md
@@ -44,7 +44,7 @@ Shared Rust crates live in the separate `kapsl-sdk` repository:
 
 ### 3.1 Prerequisites
 
-- Rust 1.92.0.
+- Rust 1.98.0 is the pinned build toolchain; Rust 1.92.0 is the workspace MSRV.
 - Python 3.9+ for the SDK Python package.
 - Optional GPU/runtime dependencies depending on provider:
   - CUDA/TensorRT (NVIDIA),

--- a/kapsl-runtime/README.md
+++ b/kapsl-runtime/README.md
@@ -6,7 +6,8 @@ For full runtime documentation, see `FULL_DOCUMENTATION.md`.
 
 ## Prerequisites
 
-- Rust 1.92.0
+- Rust 1.98.0 (installed automatically by `rustup` from the repository's
+  `rust-toolchain.toml`); the workspace MSRV is Rust 1.92.0
 - (Optional) CUDA Toolkit for NVIDIA GPU support
 
 ## Layout

--- a/kapsl-runtime/crates/kapsl-backend-abi/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-backend-abi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kapsl-backend-abi"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 license = "Apache-2.0"
 description = "Stable C ABI shared by Kapsl core and native backend packs"
 

--- a/kapsl-runtime/crates/kapsl-backend-llama-cpp/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-backend-llama-cpp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kapsl-backend-llama-cpp"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 build = "build.rs"
 license = "Apache-2.0"
 description = "Native llama.cpp backend pack for Kapsl"

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kapsl"
 version = "0.2.3"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Release profiles. Portable installers use `default`; the Linux CUDA bundle

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.98.0"
+profile = "minimal"


### PR DESCRIPTION
## Summary
- pin repository builds to Rust 1.98.0 while retaining Rust 1.92 as the workspace MSRV
- centralize Rust setup across CI, release, and certification workflows and add an MSRV check
- move public installer sources into installers/ while preserving published filenames and URLs

## Validation
- cargo check --workspace --locked on Rust 1.98.0
- cargo check --workspace --locked on Rust 1.92.0
- cargo test --workspace --locked (393 tests passed)
- installer fixture suite from repository root and an external working directory
- actionlint (custom gpu runner label allowlisted)
- git diff --check