### PR TITLE
ci: reserve real GPU conformance for stable releases

### DIFF
--- a/.github/scripts/test_gcp_ephemeral_gpu_runner.py
+++ b/.github/scripts/test_gcp_ephemeral_gpu_runner.py
@@ -22,6 +22,15 @@ runner = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = runner
 SPEC.loader.exec_module(runner)
 
+POLICY_PATH = Path(__file__).with_name("validate_stable_gpu_release.py")
+POLICY_SPEC = importlib.util.spec_from_file_location(
+    "validate_stable_gpu_release", POLICY_PATH
+)
+assert POLICY_SPEC and POLICY_SPEC.loader
+policy = importlib.util.module_from_spec(POLICY_SPEC)
+sys.modules[POLICY_SPEC.name] = policy
+POLICY_SPEC.loader.exec_module(policy)
+
 
 class IdentityTests(unittest.TestCase):
     def test_identity_is_unique_bounded_and_expiring(self) -> None:
@@ -49,6 +58,90 @@ class IdentityTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn('--label "${{ steps.identity.outputs.runner_label }}"', dispatcher)
         self.assertNotIn("--label gpu", dispatcher)
+
+
+class StableGpuReleasePolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.manifest = Path(self.temporary.name) / "Cargo.toml"
+        self.manifest.write_text(
+            '[package]\nname = "kapsl"\nversion = "0.2.4"\n',
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def authorize(self, **overrides: object) -> None:
+        values: dict[str, object] = {
+            "event_name": "push",
+            "ref_type": "tag",
+            "ref_name": "v0.2.4",
+            "release_tag": "v0.2.4",
+            "manifest": self.manifest,
+            "sdk_ref": "a" * 40,
+        }
+        values.update(overrides)
+        policy.authorize(**values)
+
+    def test_official_stable_release_is_authorized(self) -> None:
+        self.authorize()
+
+    def test_manual_branch_beta_and_prerelease_contexts_are_rejected(self) -> None:
+        invalid = (
+            {"event_name": "workflow_dispatch"},
+            {"ref_type": "branch", "ref_name": "main", "release_tag": "main"},
+            {
+                "ref_name": "v0.2.4-beta.20260831.abcdef12",
+                "release_tag": "v0.2.4-beta.20260831.abcdef12",
+            },
+            {"ref_name": "v0.2.4-rc.1", "release_tag": "v0.2.4-rc.1"},
+            {"ref_name": "v0.2.5", "release_tag": "v0.2.5"},
+            {"release_tag": "v0.2.5"},
+            {"sdk_ref": "main"},
+        )
+        for overrides in invalid:
+            with self.subTest(overrides), self.assertRaises(policy.AuthorizationError):
+                self.authorize(**overrides)
+
+    def test_every_real_gpu_entry_point_is_stable_release_only(self) -> None:
+        workflows = MODULE_PATH.parent.parent / "workflows"
+        dispatcher = (workflows / "gpu-device-pool-integration.yml").read_text(
+            encoding="utf-8"
+        )
+        conformance = (workflows / "vllm-shared-pool-conformance.yml").read_text(
+            encoding="utf-8"
+        )
+        lazy = (
+            workflows / "lazy-llama-cpp-backend-pack-gpu-certification.yml"
+        ).read_text(encoding="utf-8")
+        stable_release = (workflows / "release-runtime-installers.yml").read_text(
+            encoding="utf-8"
+        )
+        beta_release = (workflows / "beta-runtime-installers.yml").read_text(
+            encoding="utf-8"
+        )
+
+        for workflow in (dispatcher, conformance, lazy):
+            self.assertIn("workflow_call:", workflow)
+            self.assertNotIn("workflow_dispatch:", workflow)
+            self.assertIn("validate_stable_gpu_release.py", workflow)
+
+        self.assertIn('cron: "17 */6 * * *"', dispatcher)
+        self.assertIn("if: github.event_name == 'schedule'", dispatcher)
+        self.assertIn("PROVISIONING_MODEL: STANDARD", dispatcher)
+        self.assertNotIn("runs-on: [self-hosted, linux, x64, gpu]", dispatcher)
+
+        self.assertIn("stable-release-gpu-conformance:", stable_release)
+        self.assertIn("./.github/workflows/gpu-device-pool-integration.yml", stable_release)
+        self.assertIn("is_stable_release:", stable_release)
+        self.assertIn(
+            "if: needs.prepare-version.outputs.is_stable_release == 'true'",
+            stable_release,
+        )
+        self.assertIn("release_tag: ${{ github.ref_name }}", stable_release)
+        self.assertIn("sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}", stable_release)
+        self.assertNotIn("gpu-device-pool-integration.yml", beta_release)
 
 
 class ProvisionTests(unittest.TestCase):

--- a/.github/scripts/validate_stable_gpu_release.py
+++ b/.github/scripts/validate_stable_gpu_release.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+STABLE_TAG_RE = re.compile(
+    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+)
+SDK_REF_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class AuthorizationError(ValueError):
+    """The workflow context is not an official stable release."""
+
+
+def runtime_version(manifest: Path) -> str:
+    for line in manifest.read_text(encoding="utf-8").splitlines():
+        match = re.fullmatch(r'version\s*=\s*"([^"]+)"', line.strip())
+        if match is not None:
+            return match.group(1)
+    raise AuthorizationError(f"runtime version is missing from {manifest}")
+
+
+def authorize(
+    *,
+    event_name: str,
+    ref_type: str,
+    ref_name: str,
+    release_tag: str,
+    manifest: Path,
+    sdk_ref: str | None = None,
+) -> None:
+    if event_name != "push":
+        raise AuthorizationError("real GPU certification requires a tag push")
+    if ref_type != "tag":
+        raise AuthorizationError("real GPU certification requires a tag ref")
+    if ref_name != release_tag:
+        raise AuthorizationError("release tag does not match the triggering ref")
+    if STABLE_TAG_RE.fullmatch(release_tag) is None:
+        raise AuthorizationError(
+            "real GPU certification requires a stable vMAJOR.MINOR.PATCH tag"
+        )
+
+    expected_version = release_tag.removeprefix("v")
+    actual_version = runtime_version(manifest)
+    if actual_version != expected_version:
+        raise AuthorizationError(
+            f"release tag version {expected_version} does not match runtime {actual_version}"
+        )
+
+    if sdk_ref is not None and SDK_REF_RE.fullmatch(sdk_ref) is None:
+        raise AuthorizationError(
+            "stable release SDK ref must be an exact lowercase 40-hex commit"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Authorize a real GPU job only for an official stable release tag."
+    )
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--ref-type", required=True)
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--sdk-ref")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        authorize(
+            event_name=args.event_name,
+            ref_type=args.ref_type,
+            ref_name=args.ref_name,
+            release_tag=args.release_tag,
+            manifest=args.manifest,
+            sdk_ref=args.sdk_ref,
+        )
+    except AuthorizationError as error:
+        raise SystemExit(f"stable GPU release authorization failed: {error}")
+    print(f"authorized stable GPU release: {args.release_tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/gpu-device-pool-integration.yml
+++ b/.github/workflows/gpu-device-pool-integration.yml
@@ -3,55 +3,19 @@ name: GPU Device Pool Integration
 on:
   schedule:
     - cron: "17 */6 * * *"
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      suite:
-        description: GPU conformance suite to execute
+      release_tag:
+        description: Official stable engine release tag (vMAJOR.MINOR.PATCH)
         required: true
-        default: device-pool
-        type: choice
-        options:
-          - device-pool
-          - vllm-shared-pool
+        type: string
       sdk_ref:
-        description: Exact kapsl-sdk commit for the managed-vLLM suite
-        required: false
-        type: string
-      runner_backend:
-        description: Runner lifecycle for the managed-vLLM suite
+        description: Exact kapsl-sdk commit certified for the stable release
         required: true
-        default: gcp-ephemeral
-        type: choice
-        options:
-          - gcp-ephemeral
-          - self-hosted
-      provisioning_model:
-        description: GCE provisioning model (Spot is cheaper but can be preempted)
-        required: true
-        default: SPOT
-        type: choice
-        options:
-          - SPOT
-          - STANDARD
-      ort_model_path:
-        description: Absolute path to a CUDA-compatible ONNX/AIMOD artifact on the GPU runner
-        required: false
-        type: string
-      gguf_model_path:
-        description: Absolute path to a uniform-KV causal GGUF/AIMOD artifact on the GPU runner
-        required: false
-        type: string
-      ort_request_path:
-        description: Optional absolute path to a model-specific ONNX inference JSON request
-        required: false
-        type: string
-      pool_bytes:
-        description: Optional exact pool size (for example 8g); empty uses strict automatic sizing
-        required: false
         type: string
       cuda_visible_devices:
-        description: Exactly one CUDA device index, GPU UUID, or MIG UUID
-        required: true
+        description: Exactly one CUDA device index
+        required: false
         default: "0"
         type: string
 
@@ -63,59 +27,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ort-gguf-sharing:
-    if: inputs.suite == 'device-pool'
-    # The runner must have a CUDA developer toolkit, ORT CUDA dependencies,
-    # nvidia-smi, curl, jq, and both model artifacts at the input paths.
-    runs-on: [self-hosted, linux, x64, gpu]
-    timeout-minutes: 90
+  authorize-stable-release:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.policy.outputs.release_tag }}
+      sdk_ref: ${{ steps.policy.outputs.sdk_ref }}
     steps:
-      - name: Validate device-pool model inputs
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          test -n "${{ inputs.ort_model_path }}" || {
-            echo "ort_model_path is required for the device-pool suite" >&2
-            exit 1
-          }
-          test -n "${{ inputs.gguf_model_path }}" || {
-            echo "gguf_model_path is required for the device-pool suite" >&2
-            exit 1
-          }
-
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: ./.github/actions/setup-rust
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Build stable shared-KV CUDA runtime
-        run: >-
-          cargo build --manifest-path kapsl-runtime/Cargo.toml
-          --release -p kapsl --no-default-features --features cuda
-
-      - name: Exercise ORT/GGUF sharing and both unload/reload cycles
+      - name: Authorize official stable release GPU certification
+        id: policy
+        shell: bash
         env:
-          KAPSL_GPU_INTEGRATION: "1"
-          KAPSL_GPU_TEST_BINARY: ${{ github.workspace }}/kapsl-runtime/target/release/kapsl
-          KAPSL_GPU_TEST_ORT_MODEL: ${{ inputs.ort_model_path }}
-          KAPSL_GPU_TEST_GGUF_MODEL: ${{ inputs.gguf_model_path }}
-          KAPSL_GPU_TEST_ORT_REQUEST: ${{ inputs.ort_request_path }}
-          KAPSL_GPU_TEST_POOL_BYTES: ${{ inputs.pool_bytes }}
-          KAPSL_GPU_TEST_CUDA_VISIBLE_DEVICES: ${{ inputs.cuda_visible_devices }}
-          KAPSL_GPU_TEST_OUTPUT_DIR: ${{ runner.temp }}/kapsl-gpu-pool-${{ github.run_id }}-${{ github.run_attempt }}
-        run: .github/scripts/test-gpu-device-pool-integration.sh
-
-      - name: Upload GPU integration diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: gpu-device-pool-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/kapsl-gpu-pool-${{ github.run_id }}-${{ github.run_attempt }}
-          if-no-files-found: warn
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+        run: |
+          set -Eeuo pipefail
+          python3 .github/scripts/validate_stable_gpu_release.py \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --ref-type "$GITHUB_REF_TYPE" \
+            --ref-name "$GITHUB_REF_NAME" \
+            --release-tag "$RELEASE_TAG" \
+            --manifest kapsl-runtime/crates/kapsl-cli/Cargo.toml \
+            --sdk-ref "$KAPSL_VLLM_SDK_REF"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "sdk_ref=$KAPSL_VLLM_SDK_REF" >> "$GITHUB_OUTPUT"
 
   prepare-vllm-gcp-runner:
-    if: inputs.suite == 'vllm-shared-pool' && inputs.runner_backend == 'gcp-ephemeral'
+    needs: authorize-stable-release
+    if: needs.authorize-stable-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     environment: gcp-gpu-conformance
@@ -137,7 +78,7 @@ jobs:
       GCP_GPU_PROVISIONER_SERVICE_ACCOUNT: ${{ vars.GCP_GPU_PROVISIONER_SERVICE_ACCOUNT }}
       GCP_GPU_RUNNER_GROUP_ID: ${{ vars.GCP_GPU_RUNNER_GROUP_ID }}
       GPU_RUNNER_GITHUB_APP_ID: ${{ vars.GPU_RUNNER_GITHUB_APP_ID }}
-      KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+      KAPSL_VLLM_SDK_REF: ${{ needs.authorize-stable-release.outputs.sdk_ref }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -256,7 +197,7 @@ jobs:
       - name: Create ephemeral GCE L4 runner
         shell: bash
         env:
-          PROVISIONING_MODEL: ${{ inputs.provisioning_model }}
+          PROVISIONING_MODEL: STANDARD
         run: |
           set -Eeuo pipefail
           runner_arguments=(
@@ -338,26 +279,19 @@ jobs:
           path: ${{ runner.temp }}/kapsl-gpu-runner-serial.log
           if-no-files-found: warn
 
-  vllm-shared-pool-self-hosted:
-    if: inputs.suite == 'vllm-shared-pool' && inputs.runner_backend == 'self-hosted'
-    uses: ./.github/workflows/vllm-shared-pool-conformance.yml
-    with:
-      sdk_ref: ${{ inputs.sdk_ref }}
-      cuda_visible_devices: ${{ inputs.cuda_visible_devices }}
-      runner_label: gpu
-
   vllm-shared-pool-gcp:
-    needs: prepare-vllm-gcp-runner
-    if: inputs.suite == 'vllm-shared-pool' && inputs.runner_backend == 'gcp-ephemeral' && needs.prepare-vllm-gcp-runner.result == 'success'
+    needs: [authorize-stable-release, prepare-vllm-gcp-runner]
+    if: needs.authorize-stable-release.result == 'success' && needs.prepare-vllm-gcp-runner.result == 'success'
     uses: ./.github/workflows/vllm-shared-pool-conformance.yml
     with:
-      sdk_ref: ${{ inputs.sdk_ref }}
+      release_tag: ${{ needs.authorize-stable-release.outputs.release_tag }}
+      sdk_ref: ${{ needs.authorize-stable-release.outputs.sdk_ref }}
       cuda_visible_devices: ${{ inputs.cuda_visible_devices }}
       runner_label: ${{ needs.prepare-vllm-gcp-runner.outputs.runner_label }}
 
   cleanup-vllm-gcp-runner:
-    needs: [prepare-vllm-gcp-runner, vllm-shared-pool-gcp]
-    if: always() && inputs.suite == 'vllm-shared-pool' && inputs.runner_backend == 'gcp-ephemeral'
+    needs: [authorize-stable-release, prepare-vllm-gcp-runner, vllm-shared-pool-gcp]
+    if: always() && needs.authorize-stable-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: gcp-gpu-conformance

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -39,8 +39,11 @@ on:
       - ".github/scripts/test_certify_mixed_backend_concurrency.py"
       - ".github/workflows/vllm-shared-pool-conformance.yml"
       - ".github/workflows/gpu-device-pool-integration.yml"
+      - ".github/workflows/release-runtime-installers.yml"
+      - ".github/workflows/beta-runtime-installers.yml"
       - ".github/scripts/gcp_ephemeral_gpu_runner.py"
       - ".github/scripts/github_jit_runner.py"
+      - ".github/scripts/validate_stable_gpu_release.py"
       - ".github/scripts/test_gcp_ephemeral_gpu_runner.py"
       - ".github/scripts/test_github_jit_runner.py"
       - ".github/scripts/validate_model_package_backend.py"
@@ -104,6 +107,7 @@ jobs:
           python3 -m py_compile .github/scripts/test_certify_mixed_backend_concurrency.py
           python3 -m py_compile .github/scripts/gcp_ephemeral_gpu_runner.py
           python3 -m py_compile .github/scripts/github_jit_runner.py
+          python3 -m py_compile .github/scripts/validate_stable_gpu_release.py
           python3 -m py_compile .github/scripts/test_gcp_ephemeral_gpu_runner.py
           python3 -m py_compile .github/scripts/test_github_jit_runner.py
           python3 -m py_compile .github/scripts/validate_model_package_backend.py

--- a/.github/workflows/lazy-llama-cpp-backend-pack-gpu-certification.yml
+++ b/.github/workflows/lazy-llama-cpp-backend-pack-gpu-certification.yml
@@ -1,8 +1,12 @@
 name: Lazy llama.cpp Backend Pack GPU Certification
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
+      release_tag:
+        description: Official stable engine release tag (vMAJOR.MINOR.PATCH)
+        required: true
+        type: string
       backend_index_url:
         description: Public HTTPS URL of the signed candidate backend-index.json
         required: true
@@ -29,12 +33,12 @@ on:
         type: string
       cuda_visible_devices:
         description: Exactly one CUDA device index, GPU UUID, or MIG UUID
-        required: true
+        required: false
         default: "0"
         type: string
       benchmark_requests:
         description: Measured streaming requests for each eager/lazy performance case
-        required: true
+        required: false
         default: "20"
         type: string
 
@@ -42,7 +46,25 @@ permissions:
   contents: read
 
 jobs:
+  authorize-stable-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject non-stable, beta, and manual GPU contexts
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: >-
+          python3 .github/scripts/validate_stable_gpu_release.py
+          --event-name "$GITHUB_EVENT_NAME"
+          --ref-type "$GITHUB_REF_TYPE"
+          --ref-name "$GITHUB_REF_NAME"
+          --release-tag "$RELEASE_TAG"
+          --manifest kapsl-runtime/crates/kapsl-cli/Cargo.toml
+
   certify:
+    needs: authorize-stable-release
     runs-on: [self-hosted, linux, x64, gpu]
     timeout-minutes: 150
     steps:

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -29,6 +29,7 @@ jobs:
       numeric_version: ${{ steps.version.outputs.numeric_version }}
       deb_version: ${{ steps.version.outputs.deb_version }}
       is_release: ${{ steps.version.outputs.is_release }}
+      is_stable_release: ${{ steps.version.outputs.is_stable_release }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,6 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo_version="$(grep -m1 '^version = ' kapsl-runtime/crates/kapsl-cli/Cargo.toml | cut -d '"' -f2)"
+          is_stable_release=false
           if [ "${GITHUB_REF_TYPE:-}" = "tag" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
             version="${GITHUB_REF_NAME#v}"
             if [ "$cargo_version" != "$version" ]; then
@@ -46,6 +48,9 @@ jobs:
               exit 1
             fi
             is_release=true
+            if [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              is_stable_release=true
+            fi
           else
             version="${cargo_version}-dev.${GITHUB_RUN_NUMBER}"
             is_release=false
@@ -61,6 +66,18 @@ jobs:
           echo "numeric_version=$numeric_version" >> "$GITHUB_OUTPUT"
           echo "deb_version=$deb_version" >> "$GITHUB_OUTPUT"
           echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
+          echo "is_stable_release=$is_stable_release" >> "$GITHUB_OUTPUT"
+
+  stable-release-gpu-conformance:
+    name: Stable release GPU conformance
+    needs: prepare-version
+    if: needs.prepare-version.outputs.is_stable_release == 'true'
+    uses: ./.github/workflows/gpu-device-pool-integration.yml
+    with:
+      release_tag: ${{ github.ref_name }}
+      sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
+      cuda_visible_devices: "0"
+    secrets: inherit
 
   build-runtime-installers:
     name: Build runtime installer (${{ matrix.os }})

--- a/.github/workflows/vllm-shared-pool-conformance.yml
+++ b/.github/workflows/vllm-shared-pool-conformance.yml
@@ -1,24 +1,12 @@
 name: vLLM Shared-Pool Conformance
 
 on:
-  workflow_dispatch:
-    inputs:
-      sdk_ref:
-        description: Exact lowercase 40-hex kapsl-sdk commit containing the adapter
-        required: true
-        type: string
-      cuda_visible_devices:
-        description: Physical GPU ordinals/UUIDs exposed to the probe (for example 0 or 0,2)
-        required: true
-        default: "0"
-        type: string
-      runner_label:
-        description: Unique self-hosted runner label; gpu selects a persistent runner
-        required: false
-        default: gpu
-        type: string
   workflow_call:
     inputs:
+      release_tag:
+        description: Official stable engine release tag (vMAJOR.MINOR.PATCH)
+        required: true
+        type: string
       sdk_ref:
         description: Exact lowercase 40-hex kapsl-sdk commit containing the adapter
         required: true
@@ -37,7 +25,27 @@ permissions:
   contents: read
 
 jobs:
+  authorize-stable-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reject non-stable, beta, and manual GPU contexts
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+        run: >-
+          python3 .github/scripts/validate_stable_gpu_release.py
+          --event-name "$GITHUB_EVENT_NAME"
+          --ref-type "$GITHUB_REF_TYPE"
+          --ref-name "$GITHUB_REF_NAME"
+          --release-tag "$RELEASE_TAG"
+          --manifest kapsl-runtime/crates/kapsl-cli/Cargo.toml
+          --sdk-ref "$KAPSL_VLLM_SDK_REF"
+
   flash-attn:
+    needs: authorize-stable-release
     # The host supplies only the NVIDIA driver and GPUs. The immutable job image
     # pins the toolkit used by both the runtime build and the vLLM wheel.
     runs-on: [self-hosted, linux, x64, "${{ inputs.runner_label }}"]

--- a/docs/gcp-ephemeral-gpu-conformance.md
+++ b/docs/gcp-ephemeral-gpu-conformance.md
@@ -7,7 +7,8 @@ permanent self-hosted runner is required.
 The implemented lifecycle is:
 
 ```text
-workflow_dispatch
+official vMAJOR.MINOR.PATCH release tag
+  -> Release Runtime Installers calls the reusable GPU workflow
   -> GitHub OIDC authenticates to a narrow GCP provisioner account
   -> a GitHub App creates a repository-scoped JIT runner registration
   -> one g2-standard-12 VM (one NVIDIA L4, 24 GiB VRAM) starts
@@ -26,8 +27,8 @@ Two independent fallbacks limit cost if GitHub is cancelled or unavailable:
 The VM has no Google service account, receives no GitHub App token, and adds no
 inbound firewall rule. Only the single-use JIT configuration is copied into VM
 metadata. Its unique label deliberately omits the generic `gpu` label, so an
-older queued job cannot claim it. The workflow retains the existing
-`self-hosted` option for a permanent `gpu` runner.
+older queued job cannot claim it. Each reusable workflow independently
+revalidates the stable-release tag context before selecting a GPU runner.
 
 ## 1. Create the GCP project and quota
 
@@ -51,9 +52,9 @@ gcloud services enable \
   --project "$GCP_GPU_PROJECT_ID"
 ```
 
-G2 availability and Spot capacity vary by zone. `SPOT` is cheaper and is the
-workflow default, but it can be preempted. Use `STANDARD` for the final
-acceptance run or after a Spot-capacity failure.
+G2 availability varies by zone. Official release conformance always uses the
+`STANDARD` provisioning model so a Spot preemption cannot invalidate release
+evidence.
 
 ## 2. Pin an immutable NVIDIA 580 image
 
@@ -197,12 +198,14 @@ not the App key or token.
 
 ## 7. Configure the protected GitHub environment
 
-Create the environment `gcp-gpu-conformance` and restrict it to protected
-branches. Do not add a required-reviewer rule if cleanup must be completely
-unattended: GitHub evaluates environment protection for each job, including the
-always-run deletion job and scheduled sweeper. Manual `workflow_dispatch`
-already requires repository write access. Protect the allowed branches from
-direct pushes and require review for workflow changes.
+Create the environment `gcp-gpu-conformance` with custom deployment policies
+that allow the `main` branch and `v*` tags. `main` is required for the scheduled
+expired-runner sweeper; release tags are required for conformance. Do not add a
+required-reviewer rule if cleanup must be completely unattended: GitHub
+evaluates environment protection for each job, including the always-run
+deletion job and scheduled sweeper. The workflow itself accepts only an exact
+stable `vMAJOR.MINOR.PATCH` tag and rejects branches, manual dispatches, beta
+tags, and release candidates before provisioning.
 
 Set these environment variables:
 
@@ -224,12 +227,18 @@ Set this environment secret:
 | --- | --- |
 | `GPU_RUNNER_GITHUB_APP_PRIVATE_KEY` | Entire PEM private key downloaded from the App |
 
+Set the repository variable `KAPSL_VLLM_SDK_REF` to the exact lowercase
+40-character commit for the SDK release certified with the engine release.
+Update it deliberately when promoting a new SDK release; branch names and
+floating tags are rejected.
+
 After creating the environment in the repository settings and saving the App
 private key as `github-app-private-key.pem`, the non-interactive configuration
 is:
 
 ```bash
 export GPU_RUNNER_GITHUB_APP_ID=123456
+export KAPSL_VLLM_SDK_REF=0123456789abcdef0123456789abcdef01234567
 
 gh api --method PUT \
   repos/kapsl-runtime/kapsl-engine/environments/gcp-gpu-conformance >/dev/null
@@ -253,6 +262,9 @@ gh secret set GPU_RUNNER_GITHUB_APP_PRIVATE_KEY \
   --repo kapsl-runtime/kapsl-engine \
   --env gcp-gpu-conformance \
   < github-app-private-key.pem
+gh variable set KAPSL_VLLM_SDK_REF \
+  --repo kapsl-runtime/kapsl-engine \
+  --body "$KAPSL_VLLM_SDK_REF"
 ```
 
 For the private-subnet option, also set `GCP_GPU_SUBNET` to the full resource
@@ -264,19 +276,12 @@ that is why the narrowly installed App is required.
 
 ## 8. Run conformance
 
-Use the exact certified SDK commit. From this remediation branch, the current
-commit is `d5dcd0b09629f00853dfbbf810bba08d5d411d5d`:
-
-```bash
-gh workflow run gpu-device-pool-integration.yml \
-  --repo kapsl-runtime/kapsl-engine \
-  --ref feature/vllm-complete-remediation \
-  -f suite=vllm-shared-pool \
-  -f runner_backend=gcp-ephemeral \
-  -f provisioning_model=SPOT \
-  -f sdk_ref=d5dcd0b09629f00853dfbbf810bba08d5d411d5d \
-  -f cuda_visible_devices=0
-```
+There is no manual GPU trigger. After the separate `develop` to `main` release
+PR is merged, pushing the official stable `vMAJOR.MINOR.PATCH` tag starts
+`release-runtime-installers.yml`, which calls the GPU workflow exactly once.
+The beta installer workflow does not call it. The GPU entry-point workflows
+expose only `workflow_call`, and each repeats the stable-tag authorization
+before a real GPU runner can be selected.
 
 The hosted preparation job waits until the exact unique runner is online before
 it releases the conformance job, preventing a silent 24-hour self-hosted-runner
@@ -284,7 +289,7 @@ queue. If you deliberately configure environment reviewers, approve every
 pending lifecycle job promptly, including cleanup; otherwise rely on branch
 restrictions for an unattended run.
 
-Use `provisioning_model=STANDARD` for the final performance acceptance run.
+The official run always uses `STANDARD` provisioning.
 
 ## Diagnostics and cleanup
 


### PR DESCRIPTION
## Summary

- invoke managed-vLLM real-GPU conformance only from the official stable runtime release workflow
- reject manual, branch, beta, RC, mismatched-version, and floating-SDK contexts before provisioning
- remove persistent/manual GPU bypasses while retaining the scheduled expired-runner sweeper
- keep automatic JIT runner, VM, and boot-disk teardown and document the stable release path

## Validation

- actionlint on all changed workflows
- 54 Python host tests
- managed-vLLM, llama.cpp, and ONNX release-contract suites
- 6 managed-vLLM Rust tests and 26 KV-control Rust tests using published SDK 0.3.0 / KV ABI 0.6.0 crates
- cargo fmt --check and git diff --check

No real-GPU run was dispatched, as required by the new stable-release-only policy. The GPU environment now permits main for the sweeper and v* tags for releases; the exact-semver workflow guard excludes prereleases before any VM is created.