### PR TITLE
fix(packaging): ignore inherited ONNX provider sidecars

### DIFF
--- a/.github/scripts/package-linux-onnx-backend-packs.sh
+++ b/.github/scripts/package-linux-onnx-backend-packs.sh
@@ -72,6 +72,14 @@ copy_cuda_runtime_libraries() {
   while IFS= read -r -d '' source; do
     name="$(basename "$source")"
     case "$name" in
+      libonnxruntime_providers_*.so*)
+        # The full CUDA runtime bundle also carries ORT provider sidecars.
+        # Split backend packs must use the provider copies staged explicitly
+        # in core_dir/cuda_dir/tensorrt_provider_dir instead of treating those
+        # sidecars as CUDA runtime dependencies (and rejecting the duplicate
+        # basename when their bytes differ).
+        continue
+        ;;
       libcuda.so* | libnvidia-*.so*)
         echo "Refusing to bundle host NVIDIA driver library $name" >&2
         exit 1

--- a/.github/scripts/test-package-linux-onnx-backend-packs.sh
+++ b/.github/scripts/test-package-linux-onnx-backend-packs.sh
@@ -33,6 +33,11 @@ printf 'ORT CUDA\n' > "$test_root/repo/ort-cuda-libs/libonnxruntime_providers_cu
 printf 'ORT TensorRT\n' > "$test_root/repo/ort-tensorrt-libs/libonnxruntime_providers_tensorrt.so"
 printf 'cuDNN\n' > "$test_root/repo/cuda-runtime/libcudnn.so.9"
 printf 'CUDA runtime\n' > "$test_root/repo/cuda-runtime/libcudart.so.12"
+# The full CUDA runtime archive also contains ORT sidecars. Use deliberately
+# different bytes so this fixture catches accidental copying or conflicts with
+# the authoritative provider-specific staging directories above.
+printf 'Bundled ORT shared copy\n' > "$test_root/repo/cuda-runtime/libonnxruntime_providers_shared.so"
+printf 'Bundled ORT CUDA copy\n' > "$test_root/repo/cuda-runtime/libonnxruntime_providers_cuda.so"
 printf 'NVIDIA license\n' > "$test_root/repo/cuda-runtime/NVIDIA-CONTAINER-LICENSE"
 printf 'TensorRT\n' > "$test_root/repo/tensorrt-runtime-libs/libnvinfer.so.10"
 printf 'TensorRT parser\n' > "$test_root/repo/tensorrt-runtime-libs/libnvonnxparser.so.10"
@@ -129,6 +134,10 @@ assert not (cpu / "libonnxruntime_providers_cuda.so").exists()
 assert not (cpu / "libcudnn.so.9").exists()
 cuda = extracted / "cuda12"
 assert (cuda / "kapsl-provider-cuda12.json").is_file()
+assert (cuda / "libonnxruntime_providers_shared.so").read_text() == "ORT shared\n"
+assert (cuda / "libonnxruntime_providers_cuda.so").read_text() == "ORT CUDA\n"
+assert (cuda / "libcudnn.so.9").is_file()
+assert (cuda / "libcudart.so.12").is_file()
 assert not (cuda / "libonnxruntime_providers_tensorrt.so").exists()
 tensorrt = extracted / "tensorrt10"
 assert (tensorrt / "kapsl-provider-cuda12.json").is_file()


### PR DESCRIPTION
## Summary

- keep split ONNX backend packs authoritative for their provider sidecars
- ignore duplicate ORT provider libraries inherited from the monolithic CUDA runtime bundle
- preserve ordinary CUDA, cuDNN, and TensorRT runtime dependencies
- add a regression fixture with deliberately conflicting inherited ORT bytes

## Validation

- `.github/scripts/test-package-linux-onnx-backend-packs.sh`
- `bash -n` on the packager and regression script
- `git diff --check`

This fixes the `Conflicting CUDA dependency named libonnxruntime_providers_cuda.so` failure from beta installer run 33395130917.