### PR TITLE
fix(ci): gate ORT conformance by release context

### DIFF
--- a/.github/scripts/certify-ort-cpu-parity.sh
+++ b/.github/scripts/certify-ort-cpu-parity.sh
@@ -11,6 +11,15 @@ set -euo pipefail
 : "${KAPSL_ORT_PARITY_MODEL_SHA256:?KAPSL_ORT_PARITY_MODEL_SHA256 is required}"
 : "${KAPSL_ORT_PARITY_PUBLIC_KEY:?KAPSL_ORT_PARITY_PUBLIC_KEY is required}"
 
+conformance_mode="${KAPSL_ORT_CONFORMANCE_MODE:-performance}"
+case "$conformance_mode" in
+  smoke | performance) ;;
+  *)
+    echo "KAPSL_ORT_CONFORMANCE_MODE must be smoke or performance." >&2
+    exit 1
+    ;;
+esac
+
 if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
   echo "ORT CPU parity is currently certified only on Linux x86_64." >&2
   exit 1
@@ -20,7 +29,7 @@ repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 integrations_repo_dir="${KAPSL_ORT_INTEGRATIONS_REPO_DIR:-$repo_root/kapsl-integrations-ort}"
 model_repo_dir="${KAPSL_ORT_PARITY_MODEL_REPO_DIR:-$repo_root/kapsl-sdk-ort-model}"
 artifacts_dir="${KAPSL_ORT_PARITY_ARTIFACTS_DIR:-$repo_root/dist}"
-evidence_dir="${KAPSL_ORT_PARITY_EVIDENCE_DIR:-$artifacts_dir/ort-cpu-parity}"
+evidence_dir="${KAPSL_ORT_PARITY_EVIDENCE_DIR:-$artifacts_dir/ort-cpu-$conformance_mode}"
 index_path="$artifacts_dir/backend-index.json"
 archive_name="kapsl-backend-onnx-cpu-${KAPSL_VERSION}-linux-x86_64.tar.gz"
 archive_path="$artifacts_dir/$archive_name"
@@ -163,7 +172,8 @@ python3 - \
   "$KAPSL_ORT_PARITY_PUBLIC_KEY" \
   "$baseline_backend_cache" \
   "$candidate_backend_cache" \
-  "$shared_model_cache" <<'PY'
+  "$shared_model_cache" \
+  "$conformance_mode" <<'PY'
 import json
 import pathlib
 import sys
@@ -180,7 +190,76 @@ import sys
     baseline_backend_cache,
     candidate_backend_cache,
     shared_model_cache,
+    conformance_mode,
 ) = sys.argv[1:]
+
+if conformance_mode == "smoke":
+    workload = {
+        "model_id": 0,
+        "warmup_requests": 0,
+        "requests_per_payload": 1,
+        "trials": 1,
+        "concurrency": [1],
+        "timeout_seconds": 30,
+        "readiness_timeout_seconds": 120,
+        "cooldown_seconds": 0,
+        "rss_sample_seconds": 0,
+    }
+    # The pinned integrations harness requires numeric performance fields.
+    # PR smoke supplies non-restrictive sentinels, then enforces only route,
+    # process, request-success, and tensor-correctness evidence below.
+    gates = {
+        "max_abs_error": 0.000001,
+        "max_rel_error": 0.00001,
+        "min_throughput_ratio": 0,
+        "max_p95_latency_ratio": 1_000_000_000,
+        "max_p99_latency_ratio": 1_000_000_000,
+        "max_model_memory_ratio": 1_000_000_000,
+        "max_model_memory_increase_bytes": 9_223_372_036_854_775_807,
+        "max_peak_rss_ratio": 1_000_000_000,
+        "max_peak_rss_increase_bytes": 9_223_372_036_854_775_807,
+        "max_startup_ratio": 1_000_000_000,
+        "require_zero_failures": True,
+        "require_model_memory": False,
+        "require_process_identity": True,
+        "require_process_rss": False,
+        "require_route_evidence": True,
+        "require_startup_evidence": False,
+    }
+    sequence = ["baseline", "candidate", "candidate", "baseline"]
+else:
+    workload = {
+        "model_id": 0,
+        "warmup_requests": 40,
+        "requests_per_payload": 1000,
+        "trials": 3,
+        "concurrency": [1, 4],
+        "timeout_seconds": 30,
+        "readiness_timeout_seconds": 120,
+        "cooldown_seconds": 0.25,
+        "rss_sample_seconds": 0.05,
+    }
+    gates = {
+        "max_abs_error": 0.000001,
+        "max_rel_error": 0.00001,
+        "min_throughput_ratio": 0.8,
+        "max_p95_latency_ratio": 1.25,
+        "max_p99_latency_ratio": 1.35,
+        "max_model_memory_ratio": 1.2,
+        "max_model_memory_increase_bytes": 67108864,
+        "max_peak_rss_ratio": 1.2,
+        "max_peak_rss_increase_bytes": 268435456,
+        "max_startup_ratio": 1.5,
+        "require_zero_failures": True,
+        "require_model_memory": False,
+        "require_process_identity": True,
+        "require_process_rss": True,
+        "require_route_evidence": True,
+        "require_startup_evidence": True,
+    }
+    # Four samples per route keep a single host-scheduler startup outlier from
+    # controlling the median while preserving balanced ABBA ordering.
+    sequence = ["baseline", "candidate", "candidate", "baseline"] * 2
 
 command = [
     engine_binary,
@@ -202,7 +281,7 @@ common_env = {
 }
 config = {
     "schema_version": 1,
-    "suite_id": "ort-cpu-forward-host-smoke",
+    "suite_id": f"ort-cpu-forward-{conformance_mode}",
     "task_profile": "forward",
     "identity": {
         "engine_commit": engine_ref,
@@ -222,38 +301,9 @@ config = {
             },
         }
     ],
-    "workload": {
-        "model_id": 0,
-        "warmup_requests": 40,
-        "requests_per_payload": 1000,
-        "trials": 3,
-        "concurrency": [1, 4],
-        "timeout_seconds": 30,
-        "readiness_timeout_seconds": 120,
-        "cooldown_seconds": 0.25,
-        "rss_sample_seconds": 0.05,
-    },
-    "gates": {
-        "max_abs_error": 0.000001,
-        "max_rel_error": 0.00001,
-        "min_throughput_ratio": 0.8,
-        "max_p95_latency_ratio": 1.25,
-        "max_p99_latency_ratio": 1.35,
-        "max_model_memory_ratio": 1.2,
-        "max_model_memory_increase_bytes": 67108864,
-        "max_peak_rss_ratio": 1.2,
-        "max_peak_rss_increase_bytes": 268435456,
-        "max_startup_ratio": 1.5,
-        "require_zero_failures": True,
-        "require_model_memory": False,
-        "require_process_identity": True,
-        "require_process_rss": True,
-        "require_route_evidence": True,
-        "require_startup_evidence": True,
-    },
-    # Four samples per route keep a single host-scheduler startup outlier from
-    # controlling the median while preserving balanced ABBA ordering.
-    "sequence": ["baseline", "candidate", "candidate", "baseline"] * 2,
+    "workload": workload,
+    "gates": gates,
+    "sequence": sequence,
     "allowed_variant_env_differences": [
         "KAPSL_BACKEND_CACHE_DIR",
         "KAPSL_GENERIC_NATIVE_PACKS",
@@ -298,10 +348,93 @@ PYTHONDONTWRITEBYTECODE=1 python3 "$parity_harness" certify \
   --config "$config_path" \
   --output-dir "$evidence_dir" || certification_status=$?
 
+mkdir -p "$evidence_dir"
 rm -f "$evidence_dir/kapsl.sock"
 cp "$work_root/backend-ensure.log" "$evidence_dir/backend-ensure.log"
 cp "$work_root/backend-list.json" "$evidence_dir/backend-list.json"
 cp "$config_path" "$evidence_dir/certification-config.json"
+
+if [ "$conformance_mode" = "smoke" ]; then
+  smoke_validation_status=0
+  python3 - \
+    "$evidence_dir" \
+    "$evidence_dir/smoke-validation.json" \
+    "$certification_status" <<'PY' || smoke_validation_status=$?
+import json
+import pathlib
+import sys
+
+evidence_dir = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+harness_status = int(sys.argv[3])
+failures = []
+
+if harness_status not in (0, 1):
+    failures.append(f"conformance harness exited before comparison: {harness_status}")
+
+try:
+    report = json.loads((evidence_dir / "report.json").read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as error:
+    report = {}
+    failures.append(f"read conformance report: {error}")
+
+if report.get("suite_id") != "ort-cpu-forward-smoke":
+    failures.append("conformance report is not the PR correctness-smoke suite")
+if not report.get("process_identity", {}).get("verified", False):
+    failures.append("baseline and packaged routes did not use one owned process identity")
+correctness = report.get("correctness", {})
+if not correctness or any(
+    not result.get("passed", False) for result in correctness.values()
+):
+    failures.append("embedded and packaged ORT outputs were not equivalent")
+captures = report.get("captures", {})
+if captures.get("baseline_sessions") != 2 or captures.get("candidate_sessions") != 2:
+    failures.append("smoke did not complete the balanced load/unload lifecycle")
+
+capture_paths = sorted(evidence_dir.glob("[0-9][0-9]-*.json"))
+if len(capture_paths) != 4:
+    failures.append("smoke did not retain all four lifecycle captures")
+for capture_path in capture_paths:
+    try:
+        capture = json.loads(capture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        failures.append(f"read {capture_path.name}: {error}")
+        continue
+    if not capture.get("route_evidence", {}).get("verified", False):
+        failures.append(f"{capture_path.name} did not prove its selected route")
+    if capture.get("warmup_failures"):
+        failures.append(f"{capture_path.name} recorded warmup failures")
+    if any(int(trial.get("failures", 0)) != 0 for trial in capture.get("trials", [])):
+        failures.append(f"{capture_path.name} recorded request failures")
+
+validation = {
+    "schema_version": 1,
+    "status": "passed" if not failures else "failed",
+    "harness_comparison_status": harness_status,
+    "enforced": [
+        "signed packaged route activation",
+        "owned-process identity",
+        "zero request failures",
+        "tensor correctness",
+        "balanced load and unload lifecycle",
+    ],
+    "not_enforced_on_pull_requests": [
+        "throughput",
+        "p95 latency",
+        "p99 latency",
+        "startup latency",
+        "model memory",
+        "process RSS",
+    ],
+    "failures": failures,
+}
+output_path.write_text(json.dumps(validation, indent=2) + "\n", encoding="utf-8")
+if failures:
+    raise SystemExit("; ".join(failures))
+PY
+  certification_status=$smoke_validation_status
+fi
+
 python3 - \
   "$evidence_dir/certification-inputs.json" \
   "$engine_ref" \
@@ -350,5 +483,5 @@ payload = {
 pathlib.Path(output).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
 
-echo "ORT CPU host parity evidence: $evidence_dir"
+echo "ORT CPU host $conformance_mode evidence: $evidence_dir"
 exit "$certification_status"

--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -149,11 +149,13 @@ for workflow in \
 done
 
 require_literal "$parity_workflow" 'name: ORT CPU Conformance'
-require_literal "$parity_workflow" 'cancel-in-progress: true'
+require_literal "$parity_workflow" "cancel-in-progress: \${{ github.event_name == 'pull_request' }}"
 require_literal "$parity_workflow" '.github/ort-cpu-parity.lock.json'
 require_literal "$parity_workflow" 'repository: kapsl-runtime/kapsl-sdk'
 require_literal "$parity_workflow" '.github/scripts/certify-ort-cpu-parity.sh'
-require_literal "$parity_certifier" '"sequence": ["baseline", "candidate", "candidate", "baseline"] * 2'
+require_literal "$parity_workflow" 'KAPSL_ORT_CONFORMANCE_MODE:'
+require_literal "$parity_certifier" 'not_enforced_on_pull_requests'
+require_literal "$parity_certifier" 'sequence = ["baseline", "candidate", "candidate", "baseline"] * 2'
 require_literal "$installer_workflow" '.github/scripts/test-package-linux-ort-accelerator-backends.sh'
 if grep -Fq 'Certify embedded versus packaged ORT CPU parity' "$installer_workflow"; then
   echo "$installer_workflow must not run ORT performance conformance." >&2

--- a/.github/scripts/test_gcp_ephemeral_gpu_runner.py
+++ b/.github/scripts/test_gcp_ephemeral_gpu_runner.py
@@ -143,6 +143,68 @@ class StableGpuReleasePolicyTests(unittest.TestCase):
         self.assertIn("sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}", stable_release)
         self.assertNotIn("gpu-device-pool-integration.yml", beta_release)
 
+    def test_cpu_performance_parity_is_not_a_pull_request_gate(self) -> None:
+        root = MODULE_PATH.parent.parent
+        workflows = root / "workflows"
+        cpu = (workflows / "ort-cpu-conformance.yml").read_text(encoding="utf-8")
+        release = (workflows / "release-runtime-installers.yml").read_text(
+            encoding="utf-8"
+        )
+        beta = (workflows / "beta-runtime-installers.yml").read_text(
+            encoding="utf-8"
+        )
+        harness = (root / "scripts" / "certify-ort-cpu-parity.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("pull_request:", cpu)
+        self.assertIn("workflow_call:", cpu)
+        self.assertIn("workflow_dispatch:", cpu)
+        self.assertIn('if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]', cpu)
+        self.assertIn("mode=smoke", cpu)
+        self.assertIn("mode=performance", cpu)
+        self.assertIn("validate_stable_gpu_release.py", cpu)
+        self.assertIn("KAPSL_ORT_CONFORMANCE_MODE:", cpu)
+        self.assertIn(
+            'conformance_mode="${KAPSL_ORT_CONFORMANCE_MODE:-performance}"',
+            harness,
+        )
+        self.assertIn('"requests_per_payload": 1', harness)
+        self.assertIn('"requests_per_payload": 1000', harness)
+        self.assertIn('"not_enforced_on_pull_requests"', harness)
+        self.assertIn("stable-release-cpu-conformance:", release)
+        self.assertIn("./.github/workflows/ort-cpu-conformance.yml", release)
+        self.assertNotIn("ort-cpu-conformance.yml", beta)
+
+    def test_release_publication_waits_for_conformance_and_teardown(self) -> None:
+        release = (
+            MODULE_PATH.parent.parent / "workflows" / "release-runtime-installers.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("release-conformance-gate:", release)
+        self.assertIn("if: always()", release)
+        self.assertIn("stable-release-cpu-conformance", release)
+        self.assertIn("stable-release-gpu-conformance", release)
+        self.assertIn("GPU_CONFORMANCE_AND_TEARDOWN_RESULT", release)
+        self.assertEqual(release.count("release-conformance-gate]"), 2)
+
+    def test_pull_request_workflows_cancel_obsolete_runs_per_pr(self) -> None:
+        workflows = MODULE_PATH.parent.parent / "workflows"
+        for name in (
+            "ci.yml",
+            "docker-smoke.yml",
+            "installer-smoke.yml",
+            "ort-cpu-conformance.yml",
+        ):
+            with self.subTest(workflow=name):
+                workflow = (workflows / name).read_text(encoding="utf-8")
+                self.assertIn("pull_request:", workflow)
+                self.assertIn("github.event.pull_request.number || github.ref", workflow)
+                self.assertIn(
+                    "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+                    workflow,
+                )
+
 
 class ProvisionTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cargo-check:
     name: Cargo check (${{ matrix.os }})

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: docker-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   release-scripts:
     name: Test release asset scripts

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -74,6 +74,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: installer-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   install-script:
     name: Test install.sh

--- a/.github/workflows/ort-cpu-conformance.yml
+++ b/.github/workflows/ort-cpu-conformance.yml
@@ -13,6 +13,7 @@ on:
       - ".github/scripts/test-onnx-backend-release-contract.sh"
       - ".github/scripts/test-package-linux-ort-cpu-backend.sh"
       - ".github/scripts/test-verify-ort-integration-checkout.sh"
+      - ".github/scripts/validate_stable_gpu_release.py"
       - ".github/scripts/verify-ort-integration-checkout.sh"
       - ".github/workflows/ort-cpu-conformance.yml"
       - "kapsl-runtime/Cargo.lock"
@@ -26,6 +27,7 @@ on:
       - "kapsl-runtime/crates/kapsl-cli/src/http/models/**"
       - "kapsl-runtime/crates/kapsl-cli/src/runtime/model/**"
       - "kapsl-runtime/crates/kapsl-cli/src/runtime/serving/**"
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -33,16 +35,37 @@ permissions:
 
 concurrency:
   group: ort-cpu-conformance-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ort-cpu-release-handoff:
-    name: ORT CPU release handoff and conformance
+    name: ORT CPU release handoff and ${{ github.event_name == 'pull_request' && 'correctness smoke' || 'performance parity' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - name: Checkout engine
         uses: actions/checkout@v4
+
+      - name: Resolve and authorize conformance mode
+        id: conformance-mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            mode=smoke
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            mode=performance
+            echo "Full CPU performance parity was deliberately dispatched."
+          else
+            mode=performance
+            python3 .github/scripts/validate_stable_gpu_release.py \
+              --event-name "$GITHUB_EVENT_NAME" \
+              --ref-type "$GITHUB_REF_TYPE" \
+              --ref-name "$GITHUB_REF_NAME" \
+              --release-tag "$GITHUB_REF_NAME" \
+              --manifest kapsl-runtime/crates/kapsl-cli/Cargo.toml
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
 
       - name: Resolve exact release inputs
         id: release-inputs
@@ -187,8 +210,9 @@ jobs:
               raise SystemExit("signed index does not contain exactly one standard-ABI ORT CPU pack")
           PY
 
-      - name: Certify embedded versus packaged ORT CPU parity
+      - name: Run embedded versus packaged ORT CPU conformance
         env:
+          KAPSL_ORT_CONFORMANCE_MODE: ${{ steps.conformance-mode.outputs.mode }}
           KAPSL_ORT_PARITY_HARNESS: ${{ steps.ort-parity-harness.outputs.harness_path }}
           KAPSL_ORT_PARITY_HARNESS_PATH: ${{ steps.release-inputs.outputs.conformance_path }}
           KAPSL_ORT_PARITY_HARNESS_SHA256: ${{ steps.release-inputs.outputs.conformance_entrypoint_sha256 }}
@@ -197,11 +221,11 @@ jobs:
           KAPSL_ORT_PARITY_MODEL_SHA256: ${{ steps.release-inputs.outputs.model_sha256 }}
         run: .github/scripts/certify-ort-cpu-parity.sh
 
-      - name: Upload ORT CPU parity evidence
+      - name: Upload ORT CPU conformance evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: ort-cpu-parity-${{ github.run_id }}
-          path: dist/ort-cpu-parity
+          name: ort-cpu-${{ steps.conformance-mode.outputs.mode }}-${{ github.run_id }}
+          path: dist/ort-cpu-${{ steps.conformance-mode.outputs.mode }}
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -68,6 +68,12 @@ jobs:
           echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
           echo "is_stable_release=$is_stable_release" >> "$GITHUB_OUTPUT"
 
+  stable-release-cpu-conformance:
+    name: Stable release CPU performance parity
+    needs: prepare-version
+    if: needs.prepare-version.outputs.is_stable_release == 'true'
+    uses: ./.github/workflows/ort-cpu-conformance.yml
+
   stable-release-gpu-conformance:
     name: Stable release GPU conformance
     needs: prepare-version
@@ -78,6 +84,44 @@ jobs:
       sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
       cuda_visible_devices: "0"
     secrets: inherit
+
+  release-conformance-gate:
+    name: Gate publication on stable conformance and teardown
+    needs:
+      - prepare-version
+      - stable-release-cpu-conformance
+      - stable-release-gpu-conformance
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the appropriate qualification results
+        shell: bash
+        env:
+          PREPARE_RESULT: ${{ needs.prepare-version.result }}
+          IS_STABLE_RELEASE: ${{ needs.prepare-version.outputs.is_stable_release }}
+          CPU_CONFORMANCE_RESULT: ${{ needs.stable-release-cpu-conformance.result }}
+          GPU_CONFORMANCE_AND_TEARDOWN_RESULT: ${{ needs.stable-release-gpu-conformance.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$PREPARE_RESULT" != "success" ]]; then
+            echo "Release version preparation did not succeed." >&2
+            exit 1
+          fi
+          if [[ "$IS_STABLE_RELEASE" == "true" ]]; then
+            if [[ "$CPU_CONFORMANCE_RESULT" != "success" ]]; then
+              echo "Stable CPU performance parity did not succeed." >&2
+              exit 1
+            fi
+            if [[ "$GPU_CONFORMANCE_AND_TEARDOWN_RESULT" != "success" ]]; then
+              echo "Stable GPU conformance or its unconditional teardown did not succeed." >&2
+              exit 1
+            fi
+          else
+            if [[ "$CPU_CONFORMANCE_RESULT" != "skipped" || "$GPU_CONFORMANCE_AND_TEARDOWN_RESULT" != "skipped" ]]; then
+              echo "Prerelease and development workflows must not invoke stable conformance." >&2
+              exit 1
+            fi
+          fi
 
   build-runtime-installers:
     name: Build runtime installer (${{ matrix.os }})
@@ -505,7 +549,7 @@ jobs:
 
   upload-release-assets:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build-runtime-installers, build-cuda-runtime]
+    needs: [build-runtime-installers, build-cuda-runtime, release-conformance-gate]
     runs-on: ubuntu-latest
     steps:
       - name: Download installer artifacts
@@ -574,7 +618,7 @@ jobs:
           files: github-release-assets/**
 
   upload-r2:
-    needs: [prepare-version, build-runtime-installers, build-cuda-runtime]
+    needs: [prepare-version, build-runtime-installers, build-cuda-runtime, release-conformance-gate]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- run a four-session ORT CPU correctness and lifecycle smoke on pull requests without enforcing throughput, latency, startup, memory, or RSS thresholds
- reserve full CPU performance parity for deliberate manual dispatches and official stable release qualification
- keep real GPU conformance behind the existing stable-tag and exact Cargo-version authorization
- block stable release publication until CPU parity and GPU conformance, including unconditional teardown, both succeed
- cancel obsolete runs for the same pull request across all PR workflows
- leave embedded ORT and its rollback path unchanged

## Validation

- python3 .github/scripts/test_gcp_ephemeral_gpu_runner.py
- python3 .github/scripts/test_github_jit_runner.py
- cargo fmt --all -- --check
- git diff --check
- .github/scripts/test-onnx-backend-release-contract.sh
- .github/scripts/test-package-linux-ort-cpu-backend.sh
- .github/scripts/test-verify-ort-integration-checkout.sh
- .github/scripts/test-generate-backend-index.sh
- actionlint on all changed workflows

No GPU workflow was dispatched.