### PR TITLE
ci: qualify signed ORT release candidates

### DIFF
--- a/.github/scripts/test-gpu-device-pool-integration.sh
+++ b/.github/scripts/test-gpu-device-pool-integration.sh
@@ -4,11 +4,14 @@
 #
 # Required when KAPSL_GPU_INTEGRATION=1:
 #   KAPSL_GPU_TEST_BINARY      CUDA + gguf-cuda-shared-kv kapsl binary
-#   KAPSL_GPU_TEST_ORT_MODEL   ONNX or AIMOD model path
-#   KAPSL_GPU_TEST_GGUF_MODEL  uniform-KV causal GGUF or AIMOD model path
+#   Either KAPSL_GPU_TEST_BUNDLE plus KAPSL_BUNDLE_CACHE_DIR, or both:
+#     KAPSL_GPU_TEST_ORT_MODEL   ONNX or AIMOD model path
+#     KAPSL_GPU_TEST_GGUF_MODEL  uniform-KV causal GGUF or AIMOD model path
 #
 # Useful optional inputs:
+#   KAPSL_GPU_TEST_BUNDLE            verified offline bundle containing ORT then GGUF
 #   KAPSL_GPU_TEST_ORT_REQUEST       JSON inference request for the ONNX model
+#   KAPSL_GPU_TEST_ORT_BASELINE_RESPONSE expected response from another certified profile
 #   KAPSL_GPU_TEST_POOL_BYTES        exact fixed backing size (default: strict auto)
 #   KAPSL_GPU_TEST_CUDA_VISIBLE_DEVICES  one physical GPU/UUID (default: 0)
 #   KAPSL_GPU_TEST_VRAM_GROWTH_BYTES reload tolerance (default: 256 MiB)
@@ -17,10 +20,11 @@
 #   KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK require the generic signed ORT route
 #   KAPSL_GPU_TEST_ORT_PROFILE       expected signed profile (cuda12/tensorrt10)
 #   KAPSL_GPU_TEST_ORT_PACK_VERSION  expected immutable ORT pack version
+#   KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE require pack activation without network access
 #   KAPSL_GPU_TEST_OUTPUT_DIR        retained logs and snapshots
 #
-# The two model paths are startup arguments so pool registration necessarily
-# precedes both backend/session constructions. Positive model/replica-scoped
+# Both models are startup arguments so pool registration necessarily precedes
+# both backend/session constructions. Positive model/replica-scoped
 # `owner="onnx:<model>:<replica>:persistent-weights"` bytes prove that ORT
 # actually suballocated from it. Each model is then stopped and started again
 # under the same id while the other remains resident.
@@ -38,6 +42,12 @@ Usage:
     KAPSL_GPU_TEST_BINARY=/path/to/kapsl \\
     KAPSL_GPU_TEST_ORT_MODEL=/models/model.onnx \\
     KAPSL_GPU_TEST_GGUF_MODEL=/models/model.gguf \\
+    $script_name
+
+  KAPSL_GPU_INTEGRATION=1 \\
+    KAPSL_GPU_TEST_BINARY=/path/to/kapsl \\
+    KAPSL_GPU_TEST_BUNDLE=/release/profile.kapsl-bundle \\
+    KAPSL_BUNDLE_CACHE_DIR=/tmp/kapsl-bundles \\
     $script_name
 
 The GPU run fails unless all of these are observed in one process:
@@ -145,6 +155,9 @@ assert_runtime_markers() {
       "initializing ORT $version $profile_label" "$minimum_signed_ort" || return 1
     reject_log_marker "$log_file" "Using embedded ORT rollback" || return 1
     reject_log_marker "$log_file" "Activating embedded ORT rollback route" || return 1
+    if is_true "${KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE:-0}"; then
+      reject_log_marker "$log_file" "Downloading Kapsl backend" || return 1
+    fi
   elif [[ "$registered" != "1" ]]; then
     echo "Expected exactly one embedded ORT pool registration, observed $registered" >&2
     return 1
@@ -456,6 +469,16 @@ run_self_test() {
     assert_runtime_markers "$fixture/signed-ort-rollback.log" 2 2 >/dev/null 2>&1; then
     die "self-test accepted embedded ORT rollback during signed-pack certification"
   fi
+  cp "$fixture/signed-ort.log" "$fixture/signed-ort-download.log"
+  printf '%s\n' 'Downloading Kapsl backend onnx/cuda12 (123 bytes)...' \
+    >>"$fixture/signed-ort-download.log"
+  if KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK=1 \
+    KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE=1 \
+    KAPSL_GPU_TEST_ORT_PROFILE=cuda12 \
+    KAPSL_GPU_TEST_ORT_PACK_VERSION=0.2.0 \
+    assert_runtime_markers "$fixture/signed-ort-download.log" 2 2 >/dev/null 2>&1; then
+    die "self-test accepted a backend download during offline-bundle certification"
+  fi
 
   local value
   cat >"$fixture/metrics.txt" <<'EOF'
@@ -573,6 +596,26 @@ EOF
   ort_reloaded_pool_snapshot_matches \
     "$fixture/ort-reloaded-external-reused.txt" 2000 1500 3221225472 7 1073741824 4294967296 \
     || die "self-test rejected lower ORT external CUDA state after reload"
+
+  printf '%s\n' '{"shape":[1,1],"dtype":"string","data_base64":"Q1VEQQ=="}' \
+    >"$fixture/onnx-response.json"
+  assert_onnx_response_correct "$fixture/onnx-response.json"
+  printf '%s\n' '{"shape":[1,1],"dtype":"string","data_base64":""}' \
+    >"$fixture/empty-onnx-response.json"
+  if (assert_onnx_response_correct "$fixture/empty-onnx-response.json") >/dev/null 2>&1; then
+    die "self-test accepted an empty ONNX generation response"
+  fi
+
+  mkdir -p "$fixture/bundle-source"
+  printf '%s\n' \
+    '{"schema_version":1,"models":[{"path":"models/000-ort.aimod"},{"path":"models/001-gguf.aimod"}]}' \
+    >"$fixture/bundle-source/bundle-manifest.json"
+  tar -C "$fixture/bundle-source" -czf "$fixture/test.kapsl-bundle" bundle-manifest.json
+  resolve_bundle_model_paths "$fixture/test.kapsl-bundle" "$fixture/bundle-cache"
+  [[ "$ort_model" == "$fixture/bundle-cache/"*/models/000-ort.aimod ]] \
+    || die "self-test resolved the wrong bundled ORT model path: $ort_model"
+  [[ "$gguf_model" == "$fixture/bundle-cache/"*/models/001-gguf.aimod ]] \
+    || die "self-test resolved the wrong bundled GGUF model path: $gguf_model"
   rm -rf "$fixture"
   note "harness contract self-test passed"
 }
@@ -823,11 +866,55 @@ run_onnx_inference_if_configured() {
   api_post "/api/models/$onnx_model_id/infer" \
     -H 'Content-Type: application/json' \
     --data-binary "@$request_file" >"$destination"
+  assert_onnx_response_correct "$destination"
+}
+
+assert_onnx_response_correct() {
+  local response_file="$1"
+  local decoded
+  decoded="$(jq -er 'select(.dtype == "string") | .data_base64 | @base64d' "$response_file")" \
+    || die "ONNX response is not a valid UTF-8 tensor: $response_file"
+  [[ -n "$decoded" ]] || die "ONNX response decoded to an empty string: $response_file"
+
+  local baseline="${KAPSL_GPU_TEST_ORT_BASELINE_RESPONSE:-}"
+  if [[ -n "$baseline" ]]; then
+    [[ -s "$baseline" ]] || die "ONNX baseline response is missing or empty: $baseline"
+    local expected
+    expected="$(jq -er 'select(.dtype == "string") | .data_base64 | @base64d' "$baseline")" \
+      || die "ONNX baseline response is not a valid UTF-8 tensor: $baseline"
+    [[ "$decoded" == "$expected" ]] \
+      || die "ONNX output differs from the certified baseline: $response_file"
+  fi
+}
+
+resolve_bundle_model_paths() {
+  local bundle_path="$1"
+  local cache_root="$2"
+  local manifest digest model_count relative
+  manifest="$(tar -xOzf "$bundle_path" bundle-manifest.json)" \
+    || die "cannot read bundle-manifest.json from $bundle_path"
+  jq -e '
+    .schema_version == 1 and
+    (.models | length) == 2 and
+    (.models[0].path | startswith("models/") and endswith(".aimod")) and
+    (.models[1].path | startswith("models/") and endswith(".aimod")) and
+    ([.models[].path | split("/")[]] | all(. != ".." and . != "." and . != ""))
+  ' <<<"$manifest" >/dev/null \
+    || die "offline bundle must contain exactly two safe AIMOD paths (ORT first, GGUF second)"
+  model_count="$(jq -r '.models | length' <<<"$manifest")"
+  [[ "$model_count" == "2" ]] || die "offline bundle contains $model_count models, expected 2"
+  digest="$(sha256sum "$bundle_path" | awk '{print $1}')"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || die "could not compute offline bundle SHA-256"
+
+  relative="$(jq -er '.models[0].path' <<<"$manifest")"
+  ort_model="$cache_root/$digest/$relative"
+  relative="$(jq -er '.models[1].path' <<<"$manifest")"
+  gguf_model="$cache_root/$digest/$relative"
 }
 
 main() {
   if ! is_true "${KAPSL_GPU_INTEGRATION:-0}"; then
-    echo "SKIP: set KAPSL_GPU_INTEGRATION=1 and provide the binary plus ORT/GGUF model paths"
+    echo "SKIP: set KAPSL_GPU_INTEGRATION=1 and provide the binary plus an offline bundle or ORT/GGUF model paths"
     return 0
   fi
 
@@ -837,12 +924,27 @@ main() {
   require_command awk
 
   binary="${KAPSL_GPU_TEST_BINARY:-}"
-  ort_model="${KAPSL_GPU_TEST_ORT_MODEL:-}"
-  gguf_model="${KAPSL_GPU_TEST_GGUF_MODEL:-}"
+  bundle="${KAPSL_GPU_TEST_BUNDLE:-}"
   [[ -n "$binary" ]] || die "KAPSL_GPU_TEST_BINARY is required"
   [[ -x "$binary" ]] || die "Kapsl binary is not executable: $binary"
-  [[ -s "$ort_model" ]] || die "ORT model is missing or empty: $ort_model"
-  [[ -s "$gguf_model" ]] || die "GGUF model is missing or empty: $gguf_model"
+  if [[ -n "$bundle" ]]; then
+    require_command tar
+    require_command sha256sum
+    [[ -s "$bundle" ]] || die "offline bundle is missing or empty: $bundle"
+    [[ -n "${KAPSL_BUNDLE_CACHE_DIR:-}" ]] \
+      || die "KAPSL_BUNDLE_CACHE_DIR is required with KAPSL_GPU_TEST_BUNDLE"
+    mkdir -p "$KAPSL_BUNDLE_CACHE_DIR"
+    resolve_bundle_model_paths "$bundle" "$KAPSL_BUNDLE_CACHE_DIR"
+  else
+    ort_model="${KAPSL_GPU_TEST_ORT_MODEL:-}"
+    gguf_model="${KAPSL_GPU_TEST_GGUF_MODEL:-}"
+    [[ -s "$ort_model" ]] || die "ORT model is missing or empty: $ort_model"
+    [[ -s "$gguf_model" ]] || die "GGUF model is missing or empty: $gguf_model"
+  fi
+
+  if is_true "${KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE:-0}" && [[ -z "$bundle" ]]; then
+    die "KAPSL_GPU_TEST_BUNDLE is required for offline-bundle certification"
+  fi
 
   if is_true "${KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK:-0}"; then
     case "${KAPSL_GPU_TEST_ORT_PROFILE:-}" in
@@ -855,10 +957,10 @@ main() {
       || die "KAPSL_BACKEND_PUBLIC_KEYS is required for signed ORT certification"
     [[ -n "${KAPSL_BACKEND_CACHE_DIR:-}" ]] \
       || die "KAPSL_BACKEND_CACHE_DIR is required for signed ORT certification"
-    if [[ -z "${KAPSL_BACKEND_INDEX_PATH:-}" && -z "${KAPSL_BACKEND_INDEX_URL:-}" ]]; then
+    if [[ -z "$bundle" && -z "${KAPSL_BACKEND_INDEX_PATH:-}" && -z "${KAPSL_BACKEND_INDEX_URL:-}" ]]; then
       die "KAPSL_BACKEND_INDEX_PATH or KAPSL_BACKEND_INDEX_URL is required for signed ORT certification"
     fi
-    if [[ -n "${KAPSL_BACKEND_INDEX_PATH:-}" ]]; then
+    if [[ -z "$bundle" && -n "${KAPSL_BACKEND_INDEX_PATH:-}" ]]; then
       [[ -s "$KAPSL_BACKEND_INDEX_PATH" ]] \
         || die "signed backend index is missing or empty: $KAPSL_BACKEND_INDEX_PATH"
       [[ -s "${KAPSL_BACKEND_INDEX_PATH}.sig" ]] \
@@ -965,10 +1067,20 @@ main() {
       "KAPSL_LAZY_ONNX_PACKS=1"
     )
   fi
+  if [[ -n "$bundle" ]]; then
+    env_args+=(
+      "KAPSL_LAZY_BACKENDS=1"
+      "KAPSL_LAZY_LLAMA_CPP_PACKS=1"
+      "KAPSL_BUNDLE_CACHE_DIR=$KAPSL_BUNDLE_CACHE_DIR"
+    )
+  fi
 
+  model_args=(--model "$ort_model" --model "$gguf_model")
+  if [[ -n "$bundle" ]]; then
+    model_args=("$bundle" --offline)
+  fi
   env "${env_args[@]}" "$binary" run \
-    --model "$ort_model" \
-    --model "$gguf_model" \
+    "${model_args[@]}" \
     --transport socket \
     --socket "$socket_path" \
     --metrics-port "$port" \
@@ -983,15 +1095,19 @@ main() {
   fi
   wait_for_model_status "$onnx_model_id" active || die "ORT model did not become active"
   wait_for_model_status "$gguf_model_id" active || die "GGUF model did not become active"
+  if [[ -n "$bundle" ]]; then
+    [[ -s "$ort_model" ]] || die "offline bundle did not expose the ORT AIMOD: $ort_model"
+    [[ -s "$gguf_model" ]] || die "offline bundle did not expose the GGUF AIMOD: $gguf_model"
+  fi
   api_get /api/models >"$output_dir/models-initial.json"
 
-  if [[ "${ort_model,,}" == *.onnx ]]; then
+  if [[ -n "$bundle" || "${ort_model,,}" == *.onnx ]]; then
     jq -e --argjson id "$onnx_model_id" \
       '.[] | select(.id == $id and ((.format // .framework) == "onnx"))' \
       "$output_dir/models-initial.json" >/dev/null \
       || die "raw model 0 is not reported as ONNX"
   fi
-  if [[ "${gguf_model,,}" == *.gguf ]]; then
+  if [[ -n "$bundle" || "${gguf_model,,}" == *.gguf ]]; then
     jq -e --argjson id "$gguf_model_id" \
       '.[] | select(.id == $id and ((.format // .framework) == "gguf"))' \
       "$output_dir/models-initial.json" >/dev/null \
@@ -1124,6 +1240,12 @@ main() {
   wait_for_model_status "$onnx_model_id" active || die "ORT model did not become active after reload"
   wait_for_model_status "$gguf_model_id" active || die "GGUF model stopped during ORT reload"
   run_onnx_inference_if_configured "$output_dir/onnx-inference-reloaded.json"
+  if [[ -n "${KAPSL_GPU_TEST_ORT_REQUEST:-}" ]]; then
+    initial_onnx_output="$(jq -er '.data_base64' "$output_dir/onnx-inference-initial.json")"
+    reloaded_onnx_output="$(jq -er '.data_base64' "$output_dir/onnx-inference-reloaded.json")"
+    [[ "$initial_onnx_output" == "$reloaded_onnx_output" ]] \
+      || die "ONNX output changed across unload and reload"
+  fi
   sleep "$settle_seconds"
   wait_for_ort_reloaded_pool_snapshot \
     "$initial_external" "$ort_stopped_external" \

--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -25,6 +25,8 @@ parity_certifier=".github/scripts/certify-ort-cpu-parity.sh"
 parity_workflow=".github/workflows/ort-cpu-conformance.yml"
 gpu_pool_certifier=".github/scripts/test-gpu-device-pool-integration.sh"
 gpu_pack_workflow=".github/workflows/lazy-llama-cpp-backend-pack-gpu-certification.yml"
+gpu_entry_workflow=".github/workflows/gpu-device-pool-integration.yml"
+stable_gpu_workflow=".github/workflows/vllm-shared-pool-conformance.yml"
 installer_workflow=".github/workflows/installer-smoke.yml"
 release_workflow=".github/workflows/release-runtime-installers.yml"
 runtime_backend="kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs"
@@ -112,11 +114,29 @@ require_literal "$parity_certifier" 'Activating signed backend route onnx/cpu'
 require_literal "$parity_certifier" 'Activating embedded ORT rollback route'
 require_literal "$gpu_pool_certifier" 'KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK'
 require_literal "$gpu_pool_certifier" 'KAPSL_GPU_TEST_ORT_PACK_VERSION'
+require_literal "$gpu_pool_certifier" 'KAPSL_GPU_TEST_BUNDLE'
+require_literal "$gpu_pool_certifier" 'KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE'
+require_literal "$gpu_pool_certifier" 'KAPSL_GPU_TEST_ORT_BASELINE_RESPONSE'
 require_literal "$gpu_pool_certifier" 'onnx:$onnx_model_id:0:'
 require_literal "$gpu_pool_certifier" 'gguf:$gguf_model_id:0:'
 require_literal "$gpu_pool_certifier" 'Using embedded ORT rollback'
 require_literal "$gpu_pack_workflow" 'KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK: "1"'
 require_literal "$gpu_pack_workflow" 'KAPSL_GENERIC_NATIVE_PACKS: "1"'
+require_literal "$gpu_entry_workflow" 'candidate_artifact:'
+require_literal "$gpu_entry_workflow" 'candidate_artifact: ${{ needs.authorize-stable-release.outputs.candidate_artifact }}'
+require_literal "$gpu_entry_workflow" 'KAPSL_GPU_CANDIDATE_ARTIFACT: ${{ inputs.candidate_artifact }}'
+require_literal "$gpu_entry_workflow" '[[ "$KAPSL_GPU_CANDIDATE_ARTIFACT" != "runtime-cuda-linux-x86_64" ]]'
+require_literal "$gpu_entry_workflow" 'KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}'
+require_literal "$stable_gpu_workflow" 'name: Download the exact CUDA release candidate'
+require_literal "$stable_gpu_workflow" 'KAPSL_GPU_CANDIDATE_ARTIFACT: ${{ inputs.candidate_artifact }}'
+require_literal "$stable_gpu_workflow" '[[ "$KAPSL_GPU_CANDIDATE_ARTIFACT" != "runtime-cuda-linux-x86_64" ]]'
+require_literal "$stable_gpu_workflow" 'engine/.github/ort-release.lock.json'
+require_literal "$stable_gpu_workflow" '90f61e71d6fa8e571d0ab0f95a637a5d7d8ed52f'
+require_literal "$stable_gpu_workflow" 'KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE=1'
+require_literal "$stable_gpu_workflow" 'KAPSL_GPU_TEST_ORT_PROFILE=cuda12'
+require_literal "$stable_gpu_workflow" 'KAPSL_GPU_TEST_ORT_PROFILE=tensorrt10'
+require_literal "$stable_gpu_workflow" 'KAPSL_GPU_TEST_ORT_BASELINE_RESPONSE='
+require_literal "$stable_gpu_workflow" 'engine/.github/scripts/test-gpu-device-pool-integration.sh'
 if ! grep -Eq '^[0-9a-f]{40}$' "$integration_lock" \
   || [ "$(wc -l < "$integration_lock" | tr -d ' ')" != "1" ]; then
   echo "$integration_lock must contain exactly one lowercase 40-hex commit." >&2
@@ -209,6 +229,8 @@ require_literal "$release_workflow" '.github/scripts/import-signed-backend-relea
 require_literal "$release_workflow" '--lock .github/ort-release.lock.json'
 require_literal "$release_workflow" '--expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS"'
 require_literal "$release_workflow" "if: needs.prepare-version.outputs.is_stable_release != 'true'"
+require_literal "$release_workflow" 'needs: [prepare-version, build-cuda-runtime]'
+require_literal "$release_workflow" 'candidate_artifact: runtime-cuda-linux-x86_64'
 
 require_literal "$parity_workflow" 'name: ORT CPU Conformance'
 require_literal "$parity_workflow" "cancel-in-progress: \${{ github.event_name == 'pull_request' }}"

--- a/.github/workflows/gpu-device-pool-integration.yml
+++ b/.github/workflows/gpu-device-pool-integration.yml
@@ -9,6 +9,10 @@ on:
         description: Official stable engine release tag (vMAJOR.MINOR.PATCH)
         required: true
         type: string
+      candidate_artifact:
+        description: Exact CUDA release artifact produced earlier in this workflow run
+        required: true
+        type: string
       sdk_ref:
         description: Exact kapsl-sdk commit certified for the stable release
         required: true
@@ -18,8 +22,16 @@ on:
         required: false
         default: "0"
         type: string
+    secrets:
+      KAPSL_BACKEND_PUBLIC_KEYS:
+        description: Trusted raw Base64 Ed25519 backend index public key set
+        required: true
+      GPU_RUNNER_GITHUB_APP_PRIVATE_KEY:
+        description: GitHub App private key used only to create and delete the ephemeral JIT runner
+        required: true
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -33,6 +45,7 @@ jobs:
     outputs:
       release_tag: ${{ steps.policy.outputs.release_tag }}
       sdk_ref: ${{ steps.policy.outputs.sdk_ref }}
+      candidate_artifact: ${{ steps.policy.outputs.candidate_artifact }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -42,8 +55,13 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
           KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+          KAPSL_GPU_CANDIDATE_ARTIFACT: ${{ inputs.candidate_artifact }}
         run: |
           set -Eeuo pipefail
+          if [[ "$KAPSL_GPU_CANDIDATE_ARTIFACT" != "runtime-cuda-linux-x86_64" ]]; then
+            echo "Stable GPU certification requires runtime-cuda-linux-x86_64 from this release run." >&2
+            exit 1
+          fi
           python3 .github/scripts/validate_stable_gpu_release.py \
             --event-name "$GITHUB_EVENT_NAME" \
             --ref-type "$GITHUB_REF_TYPE" \
@@ -53,6 +71,7 @@ jobs:
             --sdk-ref "$KAPSL_VLLM_SDK_REF"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "sdk_ref=$KAPSL_VLLM_SDK_REF" >> "$GITHUB_OUTPUT"
+          echo "candidate_artifact=$KAPSL_GPU_CANDIDATE_ARTIFACT" >> "$GITHUB_OUTPUT"
 
   prepare-vllm-gcp-runner:
     needs: authorize-stable-release
@@ -285,9 +304,12 @@ jobs:
     uses: ./.github/workflows/vllm-shared-pool-conformance.yml
     with:
       release_tag: ${{ needs.authorize-stable-release.outputs.release_tag }}
+      candidate_artifact: ${{ needs.authorize-stable-release.outputs.candidate_artifact }}
       sdk_ref: ${{ needs.authorize-stable-release.outputs.sdk_ref }}
       cuda_visible_devices: ${{ inputs.cuda_visible_devices }}
       runner_label: ${{ needs.prepare-vllm-gcp-runner.outputs.runner_label }}
+    secrets:
+      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
 
   cleanup-vllm-gcp-runner:
     needs: [authorize-stable-release, prepare-vllm-gcp-runner, vllm-shared-pool-gcp]

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -7,6 +7,7 @@ on:
       - "v*"
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -76,11 +77,12 @@ jobs:
 
   stable-release-gpu-conformance:
     name: Stable release GPU conformance
-    needs: prepare-version
+    needs: [prepare-version, build-cuda-runtime]
     if: needs.prepare-version.outputs.is_stable_release == 'true'
     uses: ./.github/workflows/gpu-device-pool-integration.yml
     with:
       release_tag: ${{ github.ref_name }}
+      candidate_artifact: runtime-cuda-linux-x86_64
       sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
       cuda_visible_devices: "0"
     secrets: inherit

--- a/.github/workflows/vllm-shared-pool-conformance.yml
+++ b/.github/workflows/vllm-shared-pool-conformance.yml
@@ -7,6 +7,10 @@ on:
         description: Official stable engine release tag (vMAJOR.MINOR.PATCH)
         required: true
         type: string
+      candidate_artifact:
+        description: Exact CUDA release artifact produced earlier in this workflow run
+        required: true
+        type: string
       sdk_ref:
         description: Exact lowercase 40-hex kapsl-sdk commit containing the adapter
         required: true
@@ -20,8 +24,13 @@ on:
         required: false
         default: gpu
         type: string
+    secrets:
+      KAPSL_BACKEND_PUBLIC_KEYS:
+        description: Trusted raw Base64 Ed25519 backend index public key set
+        required: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
@@ -35,14 +44,20 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
           KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
-        run: >-
-          python3 .github/scripts/validate_stable_gpu_release.py
-          --event-name "$GITHUB_EVENT_NAME"
-          --ref-type "$GITHUB_REF_TYPE"
-          --ref-name "$GITHUB_REF_NAME"
-          --release-tag "$RELEASE_TAG"
-          --manifest kapsl-runtime/crates/kapsl-cli/Cargo.toml
-          --sdk-ref "$KAPSL_VLLM_SDK_REF"
+          KAPSL_GPU_CANDIDATE_ARTIFACT: ${{ inputs.candidate_artifact }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "$KAPSL_GPU_CANDIDATE_ARTIFACT" != "runtime-cuda-linux-x86_64" ]]; then
+            echo "Stable GPU certification requires runtime-cuda-linux-x86_64 from this release run." >&2
+            exit 1
+          fi
+          python3 .github/scripts/validate_stable_gpu_release.py \
+            --event-name "$GITHUB_EVENT_NAME" \
+            --ref-type "$GITHUB_REF_TYPE" \
+            --ref-name "$GITHUB_REF_NAME" \
+            --release-tag "$RELEASE_TAG" \
+            --manifest kapsl-runtime/crates/kapsl-cli/Cargo.toml \
+            --sdk-ref "$KAPSL_VLLM_SDK_REF"
 
   flash-attn:
     needs: authorize-stable-release
@@ -52,7 +67,7 @@ jobs:
     container:
       image: nvidia/cuda:13.0.2-devel-ubuntu24.04@sha256:5dc1bca23d05bd37b011be68ec470c03b403a5da07ec3a86e41af9470e9d0cc6
       options: --runtime=nvidia --gpus all
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       CUDA_VISIBLE_DEVICES: ${{ inputs.cuda_visible_devices }}
       CUDA_LAUNCH_BLOCKING: "1"
@@ -73,6 +88,7 @@ jobs:
       EXPECTED_RUST_SDK_VERSION: "0.3.0"
       EXPECTED_RUST_KV_ABI_VERSION: "0.6.0"
       KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
       PYTORCH_INDEX_URL: https://download.pytorch.org/whl/cu130
       VLLM_WHEEL_SHA256: 3bc943a7ba18c547d8777b14c15640b6f4d8f7bd268a4cec76a1fbbf8d8d3c70
       VLLM_WHEEL_URL: https://wheels.vllm.ai/2ec6f0d71ea3b350952630e310efcda1c744ff4d/vllm-0.26.1rc1.dev1130%2Bg2ec6f0d71-cp38-abi3-manylinux_2_28_x86_64.whl
@@ -1339,6 +1355,307 @@ jobs:
             fi
           fi
 
+      - name: Download the exact CUDA release candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.candidate_artifact }}
+          path: ${{ runner.temp }}/kapsl-release-candidate-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Verify the immutable ORT bridge candidate
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -Eeuo pipefail
+          candidate_artifacts="$RUNNER_TEMP/kapsl-release-candidate-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          candidate_root="$RUNNER_TEMP/kapsl-release-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          bridge_work="$RUNNER_TEMP/kapsl-ort-bridge-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          bridge_evidence="$OUTPUT_DIR/ort-bridge"
+          version="${RELEASE_TAG#v}"
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ -n "$KAPSL_BACKEND_PUBLIC_KEYS" ]] || {
+            echo "KAPSL_BACKEND_PUBLIC_KEYS is required for stable signed-pack qualification." >&2
+            exit 1
+          }
+          test -s "$candidate_artifacts/backend-index.json"
+          test -s "$candidate_artifacts/backend-index.json.sig"
+          runtime_archive="$candidate_artifacts/kapsl-$version-linux-x86_64-cuda12.tar.gz"
+          runtime_checksum="${runtime_archive}.sha256"
+          test -s "$runtime_archive"
+          test -s "$runtime_checksum"
+          expected_runtime_sha=$(awk 'NR == 1 { print $1 }' "$runtime_checksum")
+          actual_runtime_sha=$(sha256sum "$runtime_archive" | awk '{ print $1 }')
+          [[ "$actual_runtime_sha" == "$expected_runtime_sha" ]] || {
+            echo "CUDA release candidate archive failed its published checksum." >&2
+            exit 1
+          }
+          mkdir -p "$candidate_root" "$bridge_work" "$bridge_evidence"
+          tar -xzf "$runtime_archive" -C "$candidate_root"
+          test -x "$candidate_root/kapsl"
+          "$candidate_root/kapsl" --version | tee "$bridge_evidence/candidate-version.txt"
+          grep -Eq "(^|[[:space:]])$version([[:space:]]|$)" \
+            "$bridge_evidence/candidate-version.txt"
+
+          python3 - "$candidate_artifacts/backend-index.json" \
+            engine/.github/ort-release.lock.json "$version" \
+            "$bridge_evidence/candidate-index-contract.json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          index_path, lock_path, version, output_path = map(pathlib.Path, sys.argv[1:])
+          index = json.loads(index_path.read_text(encoding="utf-8"))
+          lock = json.loads(lock_path.read_text(encoding="utf-8"))
+          version_text = str(version)
+          if index.get("schema_version") != 1 or index.get("runtime_version") != version_text:
+              raise SystemExit("candidate backend index does not target the stable runtime")
+          expected_profiles = lock.get("profiles")
+          packs = [pack for pack in index.get("packs", []) if pack.get("backend") == "onnx"]
+          actual_profiles = sorted(pack.get("profile") for pack in packs)
+          if actual_profiles != sorted(expected_profiles):
+              raise SystemExit(
+                  f"candidate ORT profiles differ from the immutable release lock: {actual_profiles!r}"
+              )
+          for pack in packs:
+              if pack.get("pack_version") != lock.get("pack_version"):
+                  raise SystemExit("candidate ORT pack version differs from the release lock")
+              if pack.get("compatible_kapsl") != f"={version_text}":
+                  raise SystemExit("candidate ORT pack does not exactly target this runtime")
+              if pack.get("execution_mode") != "native":
+                  raise SystemExit("candidate ORT pack is not an in-process native adapter")
+              if pack.get("accelerator_requirements", {}).get("implicit_cpu_fallback") is not False:
+                  raise SystemExit("candidate ORT pack permits implicit CPU fallback")
+          report = {
+              "schema_version": 1,
+              "runtime_version": version_text,
+              "release_tag": lock["release_tag"],
+              "source_commit": lock["source_commit"],
+              "pack_version": lock["pack_version"],
+              "profiles": actual_profiles,
+          }
+          pathlib.Path(output_path).write_text(
+              json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+          sha256sum "$candidate_artifacts/backend-index.json" \
+            "$candidate_artifacts/backend-index.json.sig" \
+            "$runtime_archive" > "$bridge_evidence/candidate-artifacts.sha256"
+          ort_pack_version=$(jq -er .pack_version engine/.github/ort-release.lock.json)
+          {
+            echo "CANDIDATE_ARTIFACTS_DIR=$candidate_artifacts"
+            echo "CANDIDATE_RUNTIME_BINARY=$candidate_root/kapsl"
+            echo "ORT_BRIDGE_WORK_DIR=$bridge_work"
+            echo "ORT_BRIDGE_EVIDENCE_DIR=$bridge_evidence"
+            echo "ORT_PACK_VERSION=$ort_pack_version"
+          } >> "$GITHUB_ENV"
+
+      - name: Download and verify the pinned ORT generation model
+        shell: bash
+        env:
+          ORT_MODEL_REVISION: 90f61e71d6fa8e571d0ab0f95a637a5d7d8ed52f
+        run: |
+          set -Eeuo pipefail
+          model_dir="$ORT_BRIDGE_WORK_DIR/tiny-random-gpt2-onnx"
+          "$VENV_DIR/bin/python" - "$model_dir" "$ORT_MODEL_REVISION" <<'PY'
+          import sys
+          from huggingface_hub import snapshot_download
+
+          snapshot_download(
+              repo_id="onnx-community/tiny-random-gpt2-ONNX",
+              revision=sys.argv[2],
+              local_dir=sys.argv[1],
+              allow_patterns=[
+                  "config.json",
+                  "generation_config.json",
+                  "merges.txt",
+                  "onnx/model.onnx",
+                  "special_tokens_map.json",
+                  "tokenizer.json",
+                  "tokenizer_config.json",
+                  "vocab.json",
+              ],
+          )
+          PY
+          (
+            cd "$model_dir"
+            sha256sum --check <<'EOF'
+          935121200917262375ee8a179461219005d4992767823a4f7460dbd4b648023b  config.json
+          e7f6144153c0e1c0ccd6c327134b1bcc8f4e36e164d903935b08753947126636  generation_config.json
+          1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5  merges.txt
+          e18370ba6247c564a4aef7b6a83aa86d5d036f47a73c0935e51bbcfe178141a1  onnx/model.onnx
+          98412137ae43c77f8af52eb51b19c3536d3242cb55339167d841005fa94a23b7  special_tokens_map.json
+          1fe93b6152957cf9cfd6d89002467f789ce8b3f3e000b3a2edf27c808ddd0b9e  tokenizer.json
+          70049a392a6fd4dd1343d076e1f0e64d98ae821287c80638f603364ae21e64d7  tokenizer_config.json
+          3ba3c3109ff33976c4bd966589c11ee14fcaa1f4c9e5e154c2ed7f99d80709e7  vocab.json
+          EOF
+          )
+          printf '%s\n' "$ORT_MODEL_REVISION" \
+            > "$ORT_BRIDGE_EVIDENCE_DIR/model-revision.txt"
+          (
+            cd "$model_dir"
+            sha256sum config.json generation_config.json merges.txt onnx/model.onnx \
+              special_tokens_map.json tokenizer.json tokenizer_config.json vocab.json
+          ) > "$ORT_BRIDGE_EVIDENCE_DIR/model-files.sha256"
+          echo "ORT_MODEL_DIR=$model_dir" >> "$GITHUB_ENV"
+
+      - name: Build exact CUDA and TensorRT offline qualification bundles
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          "$VENV_DIR/bin/python" - "$ORT_MODEL_DIR" "$ORT_BRIDGE_WORK_DIR" <<'PY'
+          import json
+          import pathlib
+          import shutil
+          import sys
+
+          source = pathlib.Path(sys.argv[1])
+          root = pathlib.Path(sys.argv[2])
+          files = [
+              "config.json",
+              "generation_config.json",
+              "merges.txt",
+              "onnx/model.onnx",
+              "special_tokens_map.json",
+              "tokenizer.json",
+              "tokenizer_config.json",
+              "vocab.json",
+          ]
+          for profile, provider in (("cuda12", "cuda"), ("tensorrt10", "tensorrt")):
+              context = root / f"context-{profile}"
+              context.mkdir(parents=True, exist_ok=False)
+              for relative in files:
+                  destination = context / relative
+                  destination.parent.mkdir(parents=True, exist_ok=True)
+                  shutil.copyfile(source / relative, destination)
+              metadata = {
+                  "project_name": f"ort-bridge-{profile}",
+                  "version": "1.0.0",
+                  "model_file": "onnx/model.onnx",
+                  "format": "onnx",
+                  "model_type": "causal-lm",
+                  "task": "generate",
+                  "hardware_requirements": {
+                      "preferred_provider": provider,
+                      "fallback_providers": [],
+                      "device_id": 0,
+                  },
+                  "metadata": {"serving": {"backend_pack": "onnx"}},
+              }
+              (context / "metadata.json").write_text(
+                  json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+              )
+          PY
+          cuda_aimod="$ORT_BRIDGE_WORK_DIR/ort-bridge-cuda12.aimod"
+          tensorrt_aimod="$ORT_BRIDGE_WORK_DIR/ort-bridge-tensorrt10.aimod"
+          "$CANDIDATE_RUNTIME_BINARY" build "$ORT_BRIDGE_WORK_DIR/context-cuda12" \
+            --output "$cuda_aimod"
+          "$CANDIDATE_RUNTIME_BINARY" build "$ORT_BRIDGE_WORK_DIR/context-tensorrt10" \
+            --output "$tensorrt_aimod"
+          test -s "$cuda_aimod"
+          test -s "$tensorrt_aimod"
+
+          cuda_bundle="$ORT_BRIDGE_WORK_DIR/ort-bridge-cuda12.kapsl-bundle"
+          tensorrt_bundle="$ORT_BRIDGE_WORK_DIR/ort-bridge-tensorrt10.kapsl-bundle"
+          bundle_cache="$ORT_BRIDGE_WORK_DIR/bundle-build-backends"
+          KAPSL_GENERIC_NATIVE_PACKS=1 \
+          KAPSL_LAZY_BACKENDS=1 \
+          KAPSL_LAZY_ONNX_PACKS=1 \
+          KAPSL_LAZY_LLAMA_CPP_PACKS=1 \
+          KAPSL_BACKEND_INDEX_PATH="$CANDIDATE_ARTIFACTS_DIR/backend-index.json" \
+          KAPSL_BACKEND_CACHE_DIR="$bundle_cache" \
+            "$CANDIDATE_RUNTIME_BINARY" bundle "$cuda_aimod" "$LLAMA_PACKAGE" \
+              --target linux-x86_64-cuda \
+              --backend-artifacts-dir "$CANDIDATE_ARTIFACTS_DIR" \
+              --output "$cuda_bundle"
+          KAPSL_GENERIC_NATIVE_PACKS=1 \
+          KAPSL_LAZY_BACKENDS=1 \
+          KAPSL_LAZY_ONNX_PACKS=1 \
+          KAPSL_LAZY_LLAMA_CPP_PACKS=1 \
+          KAPSL_BACKEND_INDEX_PATH="$CANDIDATE_ARTIFACTS_DIR/backend-index.json" \
+          KAPSL_BACKEND_CACHE_DIR="$bundle_cache" \
+            "$CANDIDATE_RUNTIME_BINARY" bundle "$tensorrt_aimod" "$LLAMA_PACKAGE" \
+              --target linux-x86_64-tensorrt \
+              --backend-artifacts-dir "$CANDIDATE_ARTIFACTS_DIR" \
+              --output "$tensorrt_bundle"
+          test -s "$cuda_bundle"
+          test -s "$tensorrt_bundle"
+          for profile in cuda12 tensorrt10; do
+            bundle="$ORT_BRIDGE_WORK_DIR/ort-bridge-$profile.kapsl-bundle"
+            accelerator=cuda
+            [[ "$profile" == tensorrt10 ]] && accelerator=tensorrt
+            tar -xOzf "$bundle" bundle-manifest.json \
+              > "$ORT_BRIDGE_EVIDENCE_DIR/bundle-$profile.json"
+            jq -e --arg version "${{ inputs.release_tag }}" \
+              --arg profile "$profile" --arg accelerator "$accelerator" '
+                .schema_version == 1 and
+                .runtime_version == ($version | ltrimstr("v")) and
+                .target.accelerator == $accelerator and
+                (.models | length) == 2 and
+                ([.backends[] | select(.backend == "onnx") | .profile] == [$profile]) and
+                ([.backends[] | select(.backend == "llama-cpp") | .profile] == ["cuda12"])
+              ' "$ORT_BRIDGE_EVIDENCE_DIR/bundle-$profile.json" >/dev/null
+          done
+          jq -cn --arg prompt "The bridge release uses signed backend packs." \
+            '{input:{shape:[1,1],dtype:"string",data_base64:($prompt|@base64)},session_id:"ort-stable-qualification",metadata:{max_new_tokens:8,min_new_tokens:8,temperature:0.0,seed:7}}' \
+            > "$ORT_BRIDGE_WORK_DIR/ort-request.json"
+          sha256sum "$cuda_aimod" "$tensorrt_aimod" "$cuda_bundle" "$tensorrt_bundle" \
+            > "$ORT_BRIDGE_EVIDENCE_DIR/qualification-inputs.sha256"
+          {
+            echo "ORT_CUDA_BUNDLE=$cuda_bundle"
+            echo "ORT_TENSORRT_BUNDLE=$tensorrt_bundle"
+            echo "ORT_QUALIFICATION_REQUEST=$ORT_BRIDGE_WORK_DIR/ort-request.json"
+          } >> "$GITHUB_ENV"
+
+      - name: Qualify the exact signed ORT CUDA 12 pack
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          KAPSL_GPU_INTEGRATION=1 \
+          KAPSL_GPU_TEST_BINARY="$CANDIDATE_RUNTIME_BINARY" \
+          KAPSL_GPU_TEST_BUNDLE="$ORT_CUDA_BUNDLE" \
+          KAPSL_GPU_TEST_ORT_REQUEST="$ORT_QUALIFICATION_REQUEST" \
+          KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK=1 \
+          KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE=1 \
+          KAPSL_GPU_TEST_ORT_PROFILE=cuda12 \
+          KAPSL_GPU_TEST_ORT_PACK_VERSION="$ORT_PACK_VERSION" \
+          KAPSL_GPU_TEST_CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
+          KAPSL_GPU_TEST_LOAD_TIMEOUT_SECONDS=900 \
+          KAPSL_GPU_TEST_PORT=19095 \
+          KAPSL_BACKEND_CACHE_DIR="$ORT_BRIDGE_WORK_DIR/cache-cuda12" \
+          KAPSL_BUNDLE_CACHE_DIR="$ORT_BRIDGE_WORK_DIR/bundles-cuda12" \
+          KAPSL_GPU_TEST_OUTPUT_DIR="$ORT_BRIDGE_EVIDENCE_DIR/cuda12" \
+            engine/.github/scripts/test-gpu-device-pool-integration.sh
+
+      - name: Qualify the exact signed ORT TensorRT 10 pack
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          KAPSL_GPU_INTEGRATION=1 \
+          KAPSL_GPU_TEST_BINARY="$CANDIDATE_RUNTIME_BINARY" \
+          KAPSL_GPU_TEST_BUNDLE="$ORT_TENSORRT_BUNDLE" \
+          KAPSL_GPU_TEST_ORT_REQUEST="$ORT_QUALIFICATION_REQUEST" \
+          KAPSL_GPU_TEST_ORT_BASELINE_RESPONSE="$ORT_BRIDGE_EVIDENCE_DIR/cuda12/onnx-inference-initial.json" \
+          KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK=1 \
+          KAPSL_GPU_TEST_REQUIRE_OFFLINE_BUNDLE=1 \
+          KAPSL_GPU_TEST_ORT_PROFILE=tensorrt10 \
+          KAPSL_GPU_TEST_ORT_PACK_VERSION="$ORT_PACK_VERSION" \
+          KAPSL_GPU_TEST_CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
+          KAPSL_GPU_TEST_LOAD_TIMEOUT_SECONDS=900 \
+          KAPSL_GPU_TEST_PORT=19096 \
+          KAPSL_BACKEND_CACHE_DIR="$ORT_BRIDGE_WORK_DIR/cache-tensorrt10" \
+          KAPSL_BUNDLE_CACHE_DIR="$ORT_BRIDGE_WORK_DIR/bundles-tensorrt10" \
+          KAPSL_GPU_TEST_OUTPUT_DIR="$ORT_BRIDGE_EVIDENCE_DIR/tensorrt10" \
+            engine/.github/scripts/test-gpu-device-pool-integration.sh
+
+      - name: Remove signed ORT qualification scratch
+        if: always()
+        shell: bash
+        run: |
+          candidate_artifacts="$RUNNER_TEMP/kapsl-release-candidate-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          candidate_root="$RUNNER_TEMP/kapsl-release-runtime-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          bridge_work="$RUNNER_TEMP/kapsl-ort-bridge-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          rm -rf "$candidate_artifacts" "$candidate_root" "$bridge_work"
+
       - name: Upload conformance evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -1350,4 +1667,5 @@ jobs:
             ${{ runner.temp }}/kapsl-vllm-${{ github.run_id }}-${{ github.run_attempt }}/*.txt
             ${{ runner.temp }}/kapsl-vllm-${{ github.run_id }}-${{ github.run_attempt }}/*.sha256
             ${{ runner.temp }}/kapsl-vllm-${{ github.run_id }}-${{ github.run_attempt }}/wheels/*.whl
+            ${{ runner.temp }}/kapsl-vllm-${{ github.run_id }}-${{ github.run_attempt }}/ort-bridge/**
           if-no-files-found: error


### PR DESCRIPTION
## Summary

- make stable GPU conformance consume the exact CUDA runtime artifact built earlier in the same release run
- require that artifact name at both reusable-workflow boundaries
- build verified offline CUDA12 and TensorRT10 bundles from the pinned signed ORT release
- exercise both signed native profiles through the candidate runtime with embedded fallback and backend downloads forbidden
- validate deterministic inference output, signed route markers, governed model and replica allocation ownership, unload and reload reclamation, and mixed ORT plus llama.cpp isolation
- retain unconditional qualification scratch cleanup and the existing unconditional ephemeral-runner teardown
- gate release publication on the completed stable conformance chain

## Dependency

This PR is stacked on #199, which is stacked on #198. Its current review diff contains only stable qualification wiring. Bases will be moved to `develop` as preceding PRs merge.

## GPU policy

This PR does not provision a GPU. The real CUDA and TensorRT paths remain unreachable unless an official tag matches `vMAJOR.MINOR.PATCH` and exactly matches the Cargo version. The first permitted real run is the official stable bridge release.

## Validation

- GPU harness contract self-test
- ONNX and llama.cpp release-contract tests
- GCP ephemeral-runner tests (22 passed)
- GitHub JIT-runner tests (6 passed)
- signed-release importer tests (5 passed)
- actionlint and YAML parsing
- locked Cargo metadata
- `cargo fmt --all -- --check`
- `git diff --check`
- inherited resolver tree: `cargo test -p kapsl` (448 passed)