### PR TITLE
chore(release): prepare engine 0.2.4

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

- bump the engine package version from 0.2.3 to 0.2.4
- keep the lockfile package version aligned
- retain embedded ORT as the explicit bridge-release rollback route

## Validation

- cargo metadata --manifest-path kapsl-runtime/Cargo.toml --locked --no-deps --format-version 1
- cargo test --manifest-path kapsl-runtime/Cargo.toml -p kapsl --locked (448 passed)
- python3 .github/scripts/test_gcp_ephemeral_gpu_runner.py (22 passed)
- python3 .github/scripts/test_github_jit_runner.py (6 passed)
- bash .github/scripts/test-onnx-backend-release-contract.sh
- cargo fmt --manifest-path kapsl-runtime/Cargo.toml --all -- --check
- git diff --check

No GPU workflow was manually dispatched; stable GPU qualification remains tag-only.