### PR TITLE
fix(release): include NVIDIA license in llama CUDA pack

### DIFF
--- a/.github/scripts/package-linux-llama-cpp-backend-packs.sh
+++ b/.github/scripts/package-linux-llama-cpp-backend-packs.sh
@@ -176,9 +176,13 @@ package_profile() {
     cp "$gcc_license" "$root/licenses/GCC-RUNTIME-COPYRIGHT"
   fi
   if [ "$accelerator" = "cuda" ]; then
-    nvidia_license="${KAPSL_NVIDIA_LICENSE_FILE:-${KAPSL_CUDA_RUNTIME_ROOT:-}/NVIDIA-CONTAINER-LICENSE}"
-    if [ -z "$nvidia_license" ] || [ ! -f "$nvidia_license" ]; then
-      echo "Missing NVIDIA redistribution license for llama.cpp CUDA pack." >&2
+    nvidia_license="${KAPSL_NVIDIA_LICENSE_FILE:-}"
+    if [ -z "$nvidia_license" ] && [ -n "${KAPSL_CUDA_RUNTIME_ROOT:-}" ]; then
+      nvidia_license="${KAPSL_CUDA_RUNTIME_ROOT%/}/NVIDIA-CONTAINER-LICENSE"
+    fi
+    nvidia_license="${nvidia_license:-/NGC-DL-CONTAINER-LICENSE}"
+    if [ ! -f "$nvidia_license" ]; then
+      echo "Missing NVIDIA redistribution license for llama.cpp CUDA pack: $nvidia_license" >&2
       exit 1
     fi
     cp "$nvidia_license" "$root/licenses/NVIDIA-CONTAINER-LICENSE"

--- a/.github/scripts/test-llama-cpp-backend-release-contract.sh
+++ b/.github/scripts/test-llama-cpp-backend-release-contract.sh
@@ -34,6 +34,7 @@ require_literal "$packager" '"kv_mode": kv_mode'
 require_literal "$packager" 'KAPSL_LLAMA_CPP_KV_MODE=$kv_mode'
 require_literal "$packager" 'copy_runtime_dependencies "$library" "$root/lib" "$accelerator"'
 require_literal "$packager" 'NVIDIA-CONTAINER-LICENSE'
+require_literal "$packager" 'nvidia_license="${nvidia_license:-/NGC-DL-CONTAINER-LICENSE}"'
 require_literal "$packager" 'NVIDIA driver libraries must not be bundled'
 require_literal "$packager" '"execution_mode": "native"'
 require_literal "$packager" '"entrypoint": "lib/libkapsl_backend_llama_cpp.so"'
@@ -44,6 +45,7 @@ for workflow in \
   require_literal "$workflow" '.github/scripts/package-linux-llama-cpp-backend-packs.sh'
   require_literal "$workflow" 'Package llama.cpp backend packs from published SDK crates'
   require_literal "$workflow" 'cargo build --manifest-path kapsl-runtime/Cargo.toml --locked'
+  require_literal "$workflow" 'KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE'
 done
 
 if grep -Eq 'KAPSL_LLAMA_SDK_(DIR|REF)|sdk-llama|patch\.crates-io\.kapsl-(llm|engine-api)' \

--- a/.github/scripts/test-package-linux-llama-cpp-backend-packs.sh
+++ b/.github/scripts/test-package-linux-llama-cpp-backend-packs.sh
@@ -97,7 +97,7 @@ chmod +x "$test_root/bin/patchelf"
   RUNNER_ARCH=X64 \
   RUNNER_TEMP="$test_root/runner" \
   KAPSL_VERSION=1.2.3 \
-  KAPSL_NVIDIA_LICENSE_FILE="$test_root/NVIDIA-CONTAINER-LICENSE" \
+  KAPSL_CUDA_RUNTIME_ROOT="$test_root" \
   KAPSL_LLAMA_CPU_LIBRARY="$test_root/libllama-cpu.so" \
   KAPSL_LLAMA_CUDA_LIBRARY="$test_root/libllama-cuda.so" \
   .github/scripts/package-linux-llama-cpp-backend-packs.sh

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -296,6 +296,7 @@ jobs:
       CARGO_BUILD_JOBS: "2"
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
       CUDA_PATH: /usr/local/cuda
+      KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE
       KAPSL_VERSION: ${{ needs.prepare-version.outputs.version }}
       KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
       KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -411,6 +411,7 @@ jobs:
       CARGO_BUILD_JOBS: "2"
       CMAKE_BUILD_PARALLEL_LEVEL: "2"
       CUDA_PATH: /usr/local/cuda
+      KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE
       KAPSL_VERSION: ${{ needs.prepare-version.outputs.version }}
       KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
       KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}


### PR DESCRIPTION
## Summary

- use the NVIDIA container redistribution license as the default for llama.cpp CUDA packs
- pass the container license path explicitly in beta and stable CUDA packaging jobs
- retain explicit license-file and staged CUDA-runtime overrides
- extend release contract and packager fixture coverage

## Failure fixed

Beta Runtime Installers run 33757512214 completed the CUDA build, then failed while packaging llama.cpp with: Missing NVIDIA redistribution license for llama.cpp CUDA pack.

## Validation

- bash syntax checks for changed scripts
- workflow YAML parsing
- bash .github/scripts/test-llama-cpp-backend-release-contract.sh
- bash .github/scripts/test-onnx-backend-release-contract.sh
- python3 .github/scripts/test_gcp_ephemeral_gpu_runner.py (22 passed)
- python3 .github/scripts/test_github_jit_runner.py (6 passed)
- cargo metadata --manifest-path kapsl-runtime/Cargo.toml --locked --no-deps --format-version 1
- cargo fmt --manifest-path kapsl-runtime/Cargo.toml --all -- --check
- git diff --check

No GPU workflow was dispatched.