### PR TITLE
fix: diagnose Cloudflare challenges during backend publication

### DIFF
--- a/.github/scripts/test-generate-backend-index.sh
+++ b/.github/scripts/test-generate-backend-index.sh
@@ -114,6 +114,64 @@ cp "$root/artifacts/backend-index.json.sig" "$public_release/backend-index.json.
   "$root/artifacts/backend-index.json" \
   "$public_base/runtime/beta/v1.2.3"
 
+python3 - "$root" <<'PY'
+import http.server
+import json
+import pathlib
+import subprocess
+import sys
+import threading
+
+root = pathlib.Path(sys.argv[1])
+requests = []
+
+
+class Challenge(http.server.BaseHTTPRequestHandler):
+    def deny(self):
+        requests.append((self.command, self.path))
+        self.send_response(403)
+        self.send_header("cf-mitigated", "challenge")
+        self.send_header("cf-ray", "fixture-ray-id")
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        if self.command == "GET":
+            self.wfile.write(b"<html>Just a moment...</html>")
+
+    do_GET = deny
+    do_HEAD = deny
+
+    def log_message(self, *args):
+        pass
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Challenge)
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+try:
+    public_root = f"http://127.0.0.1:{server.server_port}/runtime/beta/v1.2.3"
+    index = json.loads((root / "artifacts/backend-index.json").read_text())
+    index["packs"] = [{"artifact": f"{public_root}/pack.tar.gz"}]
+    local_index = root / "challenge-index.json"
+    local_index.write_text(json.dumps(index))
+    pathlib.Path(f"{local_index}.sig").write_text("fixture signature")
+    for mode, expected_request in [([], ("GET", "/runtime/beta/v1.2.3/backend-index.json")),
+                                   (["--artifacts-only"], ("HEAD", "/runtime/beta/v1.2.3/pack.tar.gz"))]:
+        requests.clear()
+        result = subprocess.run(
+            [".github/scripts/verify-public-backend-release.sh", str(local_index), public_root, *mode],
+            capture_output=True, text=True, timeout=5,
+        )
+        assert result.returncode != 0, "Challenge response must fail verification"
+        assert "Cloudflare browser challenge" in result.stderr, result.stderr
+        assert "fixture-ray-id" in result.stderr, result.stderr
+        assert public_root in result.stderr, result.stderr
+        assert requests == [expected_request], requests
+finally:
+    server.shutdown()
+    server.server_close()
+    thread.join()
+PY
+
 openssl genpkey -algorithm ED25519 -out "$root/wrong-key.pem" >/dev/null 2>&1
 wrong_public_key="$(openssl pkey -in "$root/wrong-key.pem" -pubout -outform DER | tail -c 32 | base64 | tr -d '\n')"
 if .github/scripts/generate-backend-index.py \

--- a/.github/scripts/test-generate-backend-index.sh
+++ b/.github/scripts/test-generate-backend-index.sh
@@ -91,13 +91,11 @@ public_release="$root/public/runtime/beta/v1.2.3"
 mkdir -p "$public_release"
 cp "$root/artifacts/pack.tar.gz" "$public_release/pack.tar.gz"
 cp "$root/artifacts/pack-macos.tar.gz" "$public_release/pack-macos.tar.gz"
-cp "$root/artifacts/backend-index.json" "$public_release/backend-index.json"
-cp "$root/artifacts/backend-index.json.sig" "$public_release/backend-index.json.sig"
 python3 -m http.server 18082 --bind 127.0.0.1 --directory "$root/public" \
   >"$root/http.log" 2>&1 &
 server_pid="$!"
 attempt=1
-while ! curl -fsSI "$public_base/runtime/beta/v1.2.3/backend-index.json" >/dev/null; do
+while ! curl -fsSI "$public_base/runtime/beta/v1.2.3/pack.tar.gz" >/dev/null; do
   if [ "$attempt" -ge 20 ]; then
     cat "$root/http.log" >&2
     echo "Timed out waiting for backend release fixture server." >&2
@@ -106,6 +104,12 @@ while ! curl -fsSI "$public_base/runtime/beta/v1.2.3/backend-index.json" >/dev/n
   attempt=$((attempt + 1))
   sleep 1
 done
+.github/scripts/verify-public-backend-release.sh \
+  "$root/artifacts/backend-index.json" \
+  "$public_base/runtime/beta/v1.2.3" \
+  --artifacts-only
+cp "$root/artifacts/backend-index.json" "$public_release/backend-index.json"
+cp "$root/artifacts/backend-index.json.sig" "$public_release/backend-index.json.sig"
 .github/scripts/verify-public-backend-release.sh \
   "$root/artifacts/backend-index.json" \
   "$public_base/runtime/beta/v1.2.3"

--- a/.github/scripts/verify-public-backend-release.sh
+++ b/.github/scripts/verify-public-backend-release.sh
@@ -24,11 +24,51 @@ trap cleanup EXIT INT TERM
 wait_for_public_object() {
   local url="$1"
   shift
+  local deadline=$((SECONDS + 600))
+  local http_status curl_exit remaining request_timeout
   echo "Waiting for public release object: $url" >&2
-  curl --fail --silent --show-error --location \
-    --retry 60 --retry-delay 10 --retry-max-time 600 --retry-all-errors \
-    --connect-timeout 15 \
-    "$@" "$url"
+  while true; do
+    remaining=$((deadline - SECONDS))
+    if [ "$remaining" -le 0 ]; then
+      echo "Timed out waiting for public release object: $url" >&2
+      return 1
+    fi
+    request_timeout=30
+    if [ "$remaining" -lt "$request_timeout" ]; then
+      request_timeout="$remaining"
+    fi
+    : > "$scratch/http-headers"
+    if http_status="$(curl --fail --silent --show-error --location \
+      --connect-timeout 15 --max-time "$request_timeout" \
+      --dump-header "$scratch/http-headers" --write-out '%{http_code}' \
+      "$@" "$url")"; then
+      curl_exit=0
+    else
+      curl_exit=$?
+    fi
+
+    if grep -Eiq '^cf-mitigated:[[:space:]]*challenge[[:space:]]*$' "$scratch/http-headers"; then
+      echo "Cloudflare browser challenge blocked public release object: $url" >&2
+      grep -Ei '^(HTTP/|cf-ray:|cf-mitigated:|server:|content-type:)' "$scratch/http-headers" >&2 || true
+      echo "Check the matching Ray ID in Cloudflare Security Events and exempt intended public downloads from the triggering challenge rule. Automated release clients cannot complete browser challenges." >&2
+      return 1
+    fi
+    if [ "$curl_exit" -eq 0 ] && [ "$http_status" = 200 ]; then
+      return 0
+    fi
+
+    echo "Public release object failed: $url (HTTP $http_status, curl exit $curl_exit)" >&2
+    grep -Ei '^(HTTP/|cf-ray:|cf-mitigated:|server:|content-type:)' "$scratch/http-headers" >&2 || true
+    case "$http_status" in
+      000|404|408|429|5??) ;;
+      *) return 1 ;;
+    esac
+    if [ "$((deadline - SECONDS))" -le 30 ]; then
+      echo "Public release object did not become available within the retry budget: $url" >&2
+      return 1
+    fi
+    sleep 30
+  done
 }
 
 if [ "$mode" != "--artifacts-only" ]; then
@@ -72,7 +112,7 @@ if [ ! -s "$scratch/artifact-urls" ]; then
   exit 1
 fi
 while IFS= read -r artifact; do
-  wait_for_public_object "$artifact" --head >/dev/null
+  wait_for_public_object "$artifact" --head --output /dev/null
 done < "$scratch/artifact-urls"
 
 if [ "$mode" = "--artifacts-only" ]; then

--- a/.github/scripts/verify-public-backend-release.sh
+++ b/.github/scripts/verify-public-backend-release.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "usage: verify-public-backend-release.sh LOCAL_INDEX PUBLIC_RELEASE_ROOT" >&2
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ] || { [ "$#" -eq 3 ] && [ "$3" != "--artifacts-only" ]; }; then
+  echo "usage: verify-public-backend-release.sh LOCAL_INDEX PUBLIC_RELEASE_ROOT [--artifacts-only]" >&2
   exit 2
 fi
 
 local_index="$1"
 public_root="${2%/}"
+mode="${3:-}"
 local_signature="${local_index}.sig"
 if [ ! -f "$local_index" ] || [ ! -f "$local_signature" ]; then
   echo "Local backend index and signature are required." >&2
@@ -20,13 +21,25 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-for name in backend-index.json backend-index.json.sig; do
+wait_for_public_object() {
+  local url="$1"
+  shift
+  echo "Waiting for public release object: $url" >&2
   curl --fail --silent --show-error --location \
-    --retry 8 --retry-delay 5 --retry-all-errors \
-    --output "$scratch/$name" "$public_root/$name"
-done
-cmp "$local_index" "$scratch/backend-index.json"
-cmp "$local_signature" "$scratch/backend-index.json.sig"
+    --retry 60 --retry-delay 10 --retry-max-time 600 --retry-all-errors \
+    --connect-timeout 15 \
+    "$@" "$url"
+}
+
+if [ "$mode" != "--artifacts-only" ]; then
+  for name in backend-index.json backend-index.json.sig; do
+    wait_for_public_object \
+      "$public_root/$name" \
+      --output "$scratch/$name"
+  done
+  cmp "$local_index" "$scratch/backend-index.json"
+  cmp "$local_signature" "$scratch/backend-index.json.sig"
+fi
 
 python3 - "$local_index" "$public_root" <<'PY' > "$scratch/artifact-urls"
 import json
@@ -59,9 +72,11 @@ if [ ! -s "$scratch/artifact-urls" ]; then
   exit 1
 fi
 while IFS= read -r artifact; do
-  curl --fail --silent --show-error --location --head \
-    --retry 8 --retry-delay 5 --retry-all-errors \
-    "$artifact" >/dev/null
+  wait_for_public_object "$artifact" --head >/dev/null
 done < "$scratch/artifact-urls"
 
-echo "Verified signed backend release through $public_root"
+if [ "$mode" = "--artifacts-only" ]; then
+  echo "Verified backend artifacts through $public_root"
+else
+  echo "Verified signed backend release through $public_root"
+fi

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -564,7 +564,7 @@ jobs:
             "$public_root" \
             --artifacts-only
 
-          for name in backend-index.json backend-index.json.sig; do
+          for name in backend-index.json.sig backend-index.json; do
             aws s3 cp "release-assets/$name" \
               "$release_root/$name" \
               --no-progress \

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -548,15 +548,32 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
+          release_root="s3://kapsl-installer/runtime/beta/v${{ needs.prepare-version.outputs.version }}"
+          public_root="https://downloads.kapsl.net/runtime/beta/v${{ needs.prepare-version.outputs.version }}"
+
           aws s3 cp release-assets/ \
-            s3://kapsl-installer/runtime/beta/v${{ needs.prepare-version.outputs.version }}/ \
+            "$release_root/" \
             --recursive \
+            --exclude "backend-index.json" \
+            --exclude "backend-index.json.sig" \
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
           .github/scripts/verify-public-backend-release.sh \
             release-assets/backend-index.json \
-            https://downloads.kapsl.net/runtime/beta/v${{ needs.prepare-version.outputs.version }}
+            "$public_root" \
+            --artifacts-only
+
+          for name in backend-index.json backend-index.json.sig; do
+            aws s3 cp "release-assets/$name" \
+              "$release_root/$name" \
+              --no-progress \
+              --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+          done
+
+          .github/scripts/verify-public-backend-release.sh \
+            release-assets/backend-index.json \
+            "$public_root"
 
           # Keep the mutable latest directory as an exact mirror. Artifact names
           # contain their version, so --delete prevents old betas accumulating here.

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -73,6 +73,12 @@ on:
       - ".github/workflows/installer-smoke.yml"
       - ".github/workflows/ort-cpu-conformance.yml"
   workflow_dispatch:
+    inputs:
+      public_release_version:
+        description: "Diagnose public downloads for an existing version (without v); empty runs smoke tests"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -82,8 +88,74 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  public-download-diagnostic:
+    name: Diagnose public release downloads
+    if: github.event_name == 'workflow_dispatch' && inputs.public_release_version != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check public responses from the hosted runner
+        env:
+          RELEASE_VERSION: ${{ inputs.public_release_version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import subprocess
+          import tempfile
+
+          version = os.environ["RELEASE_VERSION"]
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", version):
+              raise SystemExit("Invalid release version")
+          channel = "runtime/beta" if "-" in version else "runtime"
+          root = f"https://downloads.kapsl.net/{channel}/v{version}"
+          failures = []
+          subprocess.run(["curl", "--version"], check=True)
+          with tempfile.TemporaryDirectory() as directory:
+              headers = pathlib.Path(directory) / "headers"
+              body = pathlib.Path(directory) / "body"
+
+              def probe(url, head=False):
+                  command = ["curl", "--silent", "--show-error", "--proto", "=https",
+                             "--connect-timeout", "15", "--max-time", "30",
+                             "--dump-header", str(headers), "--output", str(body),
+                             "--write-out", "%{http_code}"]
+                  if head:
+                      command.append("--head")
+                  result = subprocess.run(command + [url], capture_output=True, text=True)
+                  print(f"{'HEAD' if head else 'GET'} {url}: HTTP {result.stdout}, curl exit {result.returncode}", flush=True)
+                  if headers.exists():
+                      for line in headers.read_text(errors="replace").splitlines():
+                          if line.lower().startswith(("http/", "server:", "content-type:", "cf-ray:",
+                                                      "cf-mitigated:", "cf-cache-status:", "location:")):
+                              print(repr(line), flush=True)
+                  if result.returncode != 0 or result.stdout != "200":
+                      failures.append(url)
+                      print(repr(result.stderr[:1024]), flush=True)
+                      if not head and body.exists():
+                          with body.open("rb") as response:
+                              print(repr(response.read(2048).decode(errors="replace")), flush=True)
+                      return None
+                  return None if head else body.read_bytes()
+
+              probe("https://downloads.kapsl.net/install.sh", head=True)
+              index_bytes = probe(f"{root}/backend-index.json")
+              probe(f"{root}/backend-index.json.sig")
+              if index_bytes:
+                  for pack in json.loads(index_bytes)["packs"]:
+                      url = pack["artifact"]
+                      if not url.startswith(root + "/") or "?" in url or "#" in url:
+                          raise SystemExit("Artifact is outside the public release root")
+                      probe(url, head=True)
+          if failures:
+              raise SystemExit(f"Public download verification failed for {len(failures)} object(s)")
+          PY
+
   install-script:
     name: Test install.sh
+    if: github.event_name != 'workflow_dispatch' || inputs.public_release_version == ''
     # Must be Linux x86_64: install.sh gates the CUDA runtime on that platform,
     # so nothing else exercises the paths this covers.
     runs-on: ubuntu-latest

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -671,7 +671,7 @@ jobs:
             "$public_root" \
             --artifacts-only
 
-          for name in backend-index.json backend-index.json.sig; do
+          for name in backend-index.json.sig backend-index.json; do
             aws s3 cp "release-assets/$name" \
               "$release_root/$name" \
               --no-progress \

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -655,15 +655,32 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
+          release_root="s3://kapsl-installer/runtime/v${{ needs.prepare-version.outputs.version }}"
+          public_root="https://downloads.kapsl.net/runtime/v${{ needs.prepare-version.outputs.version }}"
+
           aws s3 cp release-assets/ \
-            s3://kapsl-installer/runtime/v${{ needs.prepare-version.outputs.version }}/ \
+            "$release_root/" \
             --recursive \
+            --exclude "backend-index.json" \
+            --exclude "backend-index.json.sig" \
             --no-progress \
             --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
 
           .github/scripts/verify-public-backend-release.sh \
             release-assets/backend-index.json \
-            https://downloads.kapsl.net/runtime/v${{ needs.prepare-version.outputs.version }}
+            "$public_root" \
+            --artifacts-only
+
+          for name in backend-index.json backend-index.json.sig; do
+            aws s3 cp "release-assets/$name" \
+              "$release_root/$name" \
+              --no-progress \
+              --endpoint-url https://b93d1b956d4a35c986540bb51f7404a2.r2.cloudflarestorage.com
+          done
+
+          .github/scripts/verify-public-backend-release.sh \
+            release-assets/backend-index.json \
+            "$public_root"
 
       - name: Upload Linux installer scripts to R2 (stable URLs)
         env:


### PR DESCRIPTION
Beta publication successfully uploads its assets to R2, then fails when Cloudflare challenges the GitHub-hosted runner's public download requests. The old verification script reports only HTTP 403 and retries without identifying the URL or cause. A hosted diagnostic reproduced `cf-mitigated: challenge` for both the existing installer and the backend index: [run 33932624553](https://github.com/kapsl-runtime/kapsl-engine/actions/runs/33932624553).

This change reports the failed URL and Cloudflare Ray ID and stops immediately for browser challenges and other non-retryable HTTP errors. Transient failures retain a ten-minute retry budget with a 30-second interval and bounded request timeouts. Beta and stable publication verify pack availability before publishing the signature and index, and still require the public index and signature to match their local bytes before proceeding.

Installer Smoke Tests also gains an optional manual diagnostic for an existing public release. It performs read-only HTTP checks from a hosted runner without release credentials, rebuilding, uploading, or provisioning a GPU. Ordinary PR tests remain local and host-only.

This PR improves publication and diagnostics; it cannot remove the Cloudflare challenge. The triggering Cloudflare rule must exempt the intended public downloads. The earlier claim that vLLM upload propagation caused the failure was not supported by the logs and has been replaced by the reproduced diagnosis.

Validation: signed-index generation/publication tests (including immediate rejection of challenged GET and HEAD requests), 28 GCP/JIT runner gating tests, shell syntax, YAML parsing, and diff checks pass locally. Rust formatting passed for the original workflow-only change. PR CI is running for the updated commit.
