### PR TITLE
fix(ci): authorize stable GPU OIDC and fail fast on missing release producer

### DIFF
--- a/.github/scripts/test_gcp_ephemeral_gpu_runner.py
+++ b/.github/scripts/test_gcp_ephemeral_gpu_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import copy
 import json
+import re
 import stat
 import subprocess
 import sys
@@ -175,6 +176,40 @@ class StableGpuReleasePolicyTests(unittest.TestCase):
         self.assertIn("stable-release-cpu-conformance:", release)
         self.assertIn("./.github/workflows/ort-cpu-conformance.yml", release)
         self.assertNotIn("ort-cpu-conformance.yml", beta)
+
+    def test_stable_gpu_caller_grants_oidc_for_setup_and_teardown_only(self) -> None:
+        workflows = MODULE_PATH.parent.parent / "workflows"
+        release = (workflows / "release-runtime-installers.yml").read_text(
+            encoding="utf-8"
+        )
+        dispatcher = (workflows / "gpu-device-pool-integration.yml").read_text(
+            encoding="utf-8"
+        )
+
+        def job_permissions(workflow: str, job: str) -> dict[str, str]:
+            block = re.search(
+                rf"(?ms)^  {re.escape(job)}:\n(.*?)(?=^  [\w-]+:|\Z)", workflow
+            )
+            self.assertIsNotNone(block, job)
+            permissions = re.search(
+                r"(?m)^    permissions:\n((?:      [\w-]+: \w+\n)+)",
+                block.group(1),
+            )
+            self.assertIsNotNone(permissions, job)
+            return dict(re.findall(r"([\w-]+): (\w+)", permissions.group(1)))
+
+        caller = job_permissions(release, "stable-release-gpu-conformance")
+        self.assertEqual(
+            caller, {"actions": "read", "contents": "read", "id-token": "write"}
+        )
+        for job in ("prepare-vllm-gcp-runner", "cleanup-vllm-gcp-runner"):
+            with self.subTest(job=job):
+                requested = job_permissions(dispatcher, job)
+                self.assertEqual(requested["id-token"], "write")
+                for permission, level in requested.items():
+                    self.assertEqual(caller.get(permission), level)
+        # Do not broaden this fix into an OIDC grant for build/publication jobs.
+        self.assertEqual(release.count("id-token: write"), 1)
 
     def test_release_publication_waits_for_conformance_and_teardown(self) -> None:
         release = (

--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -49,6 +49,9 @@ jobs:
     name: Wait for release assets
     needs: resolve-version
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Checkout
         if: needs.resolve-version.outputs.wait_for_assets == 'true'
@@ -58,6 +61,9 @@ jobs:
         if: needs.resolve-version.outputs.wait_for_assets == 'true'
         env:
           KAPSL_VERSION: ${{ needs.resolve-version.outputs.runtime_version }}
+          # Manual publication of an existing release has no associated tag run.
+          KAPSL_INSTALLER_RUN_SHA: ${{ github.event_name == 'push' && github.sha || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: docker/wait-for-release-assets.sh
 
   build-and-push:

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -79,6 +79,12 @@ jobs:
     name: Stable release GPU conformance
     needs: [prepare-version, build-cuda-runtime]
     if: needs.prepare-version.outputs.is_stable_release == 'true'
+    # Reusable workflows cannot elevate permissions: both GCP setup and teardown
+    # require OIDC, but ordinary build and publication jobs do not.
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     uses: ./.github/workflows/gpu-device-pool-integration.yml
     with:
       release_tag: ${{ github.ref_name }}

--- a/docker/test-release-scripts.sh
+++ b/docker/test-release-scripts.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+python3 docker/test-wait-for-release-assets.py
+
 version="9.9.9"
 test_root="$(mktemp -d)"
 release_dir="${test_root}/release"

--- a/docker/test-wait-for-release-assets.py
+++ b/docker/test-wait-for-release-assets.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Host-only release waiter tests; no GitHub requests, sleeps, or GPU jobs."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SHA = "a" * 40
+MOCK_COMMAND = """#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+root = Path(os.environ["WAIT_TEST_ROOT"])
+name = Path(sys.argv[0]).name
+log = root / (name + ".json")
+calls = json.loads(log.read_text()) if log.exists() else []
+calls.append(sys.argv[1:])
+log.write_text(json.dumps(calls))
+if name == "gh":
+    if os.environ.get("MOCK_GH_FAILURE") == "true":
+        sys.exit(1)
+    snapshots = json.loads((root / "runs.json").read_text())
+    snapshot = snapshots[min(len(calls) - 1, len(snapshots) - 1)]
+    query = sys.argv[sys.argv.index("--jq") + 1]
+    result = subprocess.run(["jq", "-r", query], input=json.dumps(snapshot), text=True)
+    sys.exit(result.returncode)
+if name == "curl":
+    sys.exit(0 if os.environ.get("MOCK_ASSETS_READY") == "true" else 22)
+"""
+
+
+def installer_run(status="completed", conclusion="success", **overrides):
+    return dict(
+        id=100,
+        head_branch="v0.2.4",
+        head_sha=SHA,
+        status=status,
+        conclusion=conclusion,
+        html_url="https://github.com/kapsl-runtime/kapsl-engine/actions/runs/100",
+    ) | overrides
+
+
+class ReleaseAssetWaitTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        for name in ("gh", "curl", "sleep"):
+            executable = bin_dir / name
+            executable.write_text(MOCK_COMMAND)
+            executable.chmod(0o755)
+        self.env = os.environ | {
+            "PATH": str(bin_dir) + os.pathsep + os.environ["PATH"],
+            "WAIT_TEST_ROOT": str(self.root),
+            "KAPSL_VERSION": "0.2.4",
+            "KAPSL_INSTALLER_RUN_SHA": SHA,
+            "GITHUB_REPOSITORY": "kapsl-runtime/kapsl-engine",
+            "KAPSL_WAIT_ATTEMPTS": "1",
+            "MOCK_ASSETS_READY": "true",
+            "MOCK_GH_FAILURE": "false",
+        }
+        self.env.pop("KAPSL_WAIT_DELAY_SECONDS", None)
+
+    def run_waiter(self, snapshots, **env):
+        (self.root / "runs.json").write_text(json.dumps([
+            {"workflow_runs": runs} for runs in snapshots
+        ]))
+        return subprocess.run(
+            ["sh", str(ROOT / "docker/wait-for-release-assets.sh")],
+            env=self.env | env, text=True, capture_output=True, timeout=20,
+        )
+
+    def calls(self, command):
+        log = self.root / (command + ".json")
+        return json.loads(log.read_text()) if log.exists() else []
+
+    def test_failed_installer_stops_without_asset_requests(self):
+        for conclusion in ("startup_failure", "failure", "cancelled", "timed_out"):
+            with self.subTest(conclusion=conclusion):
+                result = self.run_waiter([[installer_run(conclusion=conclusion)]])
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Installer workflow did not succeed", result.stderr)
+                self.assertIn(conclusion, result.stderr)
+                self.assertIn("/actions/runs/100", result.stderr)
+                self.assertEqual(self.calls("curl"), [])
+                self.assertEqual(self.calls("sleep"), [])
+
+    def test_pending_installer_is_polled_every_thirty_seconds(self):
+        result = self.run_waiter([
+            [installer_run(status="in_progress", conclusion=None)],
+            [installer_run()],
+        ], KAPSL_WAIT_ATTEMPTS="2")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls("sleep"), [["30"]])
+        self.assertEqual(len(self.calls("curl")), 10)
+        self.assertEqual(len(self.calls("gh")), 2)
+        self.assertIn("head_sha=" + SHA, self.calls("gh")[0])
+        self.assertIn("event=push", self.calls("gh")[0])
+        self.assertIn(
+            "repos/kapsl-runtime/kapsl-engine/actions/workflows/release-runtime-installers.yml/runs",
+            self.calls("gh")[0],
+        )
+
+    def test_failure_after_starting_also_stops(self):
+        result = self.run_waiter([
+            [installer_run(status="queued", conclusion=None)],
+            [installer_run(conclusion="failure")],
+        ], KAPSL_WAIT_ATTEMPTS="2")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Installer workflow did not succeed", result.stderr)
+        self.assertEqual(self.calls("curl"), [])
+
+    def test_missing_run_and_unrelated_tags_or_commits_do_not_authorize(self):
+        for runs in (
+            [],
+            [installer_run(head_branch="v0.2.3")],
+            [installer_run(head_sha="b" * 40)],
+        ):
+            with self.subTest(runs=runs):
+                result = self.run_waiter([runs])
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("not_started", result.stdout)
+                self.assertEqual(self.calls("curl"), [])
+
+    def test_newest_matching_run_supersedes_old_failure(self):
+        result = self.run_waiter([[
+            installer_run(id=101),
+            installer_run(id=100, conclusion="failure"),
+        ]])
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(self.calls("curl")), 10)
+
+    def test_github_api_error_fails_closed(self):
+        result = self.run_waiter([[]], MOCK_GH_FAILURE="true")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unable to check the installer workflow", result.stderr)
+        self.assertEqual(self.calls("curl"), [])
+
+    def test_successful_producer_still_requires_all_assets(self):
+        result = self.run_waiter([[installer_run()]], MOCK_ASSETS_READY="false")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Release assets are not complete", result.stdout)
+        self.assertEqual(len(self.calls("curl")), 10)
+
+    def test_manual_existing_release_does_not_require_an_installer_run(self):
+        result = self.run_waiter([[]], KAPSL_INSTALLER_RUN_SHA="")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.calls("gh"), [])
+        self.assertEqual(len(self.calls("curl")), 10)
+
+    def test_workflow_passes_push_commit_and_read_only_permissions(self):
+        workflow = (ROOT / ".github/workflows/release-docker-images.yml").read_text()
+        job = workflow.split("  wait-for-release-assets:\n", 1)[1].split(
+            "  build-and-push:\n", 1
+        )[0]
+        self.assertIn("permissions:\n      actions: read\n      contents: read", job)
+        self.assertIn("github.event_name == 'push' && github.sha || ''", job)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", job)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker/wait-for-release-assets.sh
+++ b/docker/wait-for-release-assets.sh
@@ -4,11 +4,9 @@ set -eu
 : "${KAPSL_VERSION:?KAPSL_VERSION is required}"
 
 release_base="${KAPSL_RELEASE_BASE_URL:-https://github.com/kapsl-runtime/kapsl-engine/releases/download/v${KAPSL_VERSION}}"
-# A clean CUDA runtime build can take over an hour on the hosted two-job
-# release worker. Keep the Docker release waiting long enough for that artifact
-# and its checksum to finish publishing.
-max_attempts="${KAPSL_WAIT_ATTEMPTS:-720}"
-retry_delay="${KAPSL_WAIT_DELAY_SECONDS:-10}"
+# Allow the existing two-hour budget, polling no more often than every 30 seconds.
+max_attempts="${KAPSL_WAIT_ATTEMPTS:-240}"
+retry_delay="${KAPSL_WAIT_DELAY_SECONDS:-30}"
 
 case "${max_attempts}" in
     *[!0-9]* | 0 | "")
@@ -24,6 +22,10 @@ case "${retry_delay}" in
         ;;
 esac
 
+if [ -n "${KAPSL_INSTALLER_RUN_SHA:-}" ]; then
+    : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required to check the installer run}"
+fi
+
 assets="
 kapsl-${KAPSL_VERSION}-linux-x86_64.tar.gz
 kapsl-${KAPSL_VERSION}-linux-aarch64.tar.gz
@@ -34,22 +36,55 @@ kapsl-provider-tensorrt10-${KAPSL_VERSION}-linux-x86_64.tar.gz
 
 attempt=1
 while [ "${attempt}" -le "${max_attempts}" ]; do
-    missing_assets=""
-
-    for asset in ${assets}; do
-        for required_file in "${asset}" "${asset}.sha256"; do
-            if ! curl -fsSLI --connect-timeout 30 "${release_base}/${required_file}" >/dev/null; then
-                missing_assets="${missing_assets} ${required_file}"
-            fi
-        done
-    done
-
-    if [ -z "${missing_assets}" ]; then
-        echo "All runtime and provider release assets are available for ${KAPSL_VERSION}."
-        exit 0
+    installer_pending=false
+    if [ -n "${KAPSL_INSTALLER_RUN_SHA:-}" ]; then
+        # Match both the exact tag and commit, never an unrelated branch run.
+        # Pick the newest matching run so a later attempt supersedes old failures.
+        if ! installer_run="$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/release-runtime-installers.yml/runs" \
+            -f event=push -f head_sha="${KAPSL_INSTALLER_RUN_SHA}" -f per_page=100 \
+            --jq '.workflow_runs
+                | map(select(.head_branch == ("v" + env.KAPSL_VERSION)
+                    and .head_sha == env.KAPSL_INSTALLER_RUN_SHA))
+                | sort_by(.id) | last
+                | if . == null then "not_started"
+                  else [.status, (.conclusion // "pending"), .html_url] | join(" ")
+                  end')"; then
+            echo "Unable to check the installer workflow; refusing to publish Docker images." >&2
+            exit 1
+        fi
+        case "${installer_run}" in
+            'completed success '*) ;;
+            completed\ *)
+                echo "Installer workflow did not succeed: ${installer_run}" >&2
+                echo "Stopping: release assets will not be produced by this run." >&2
+                exit 1
+                ;;
+            *)
+                installer_pending=true
+                echo "Waiting for installer workflow (attempt ${attempt}/${max_attempts}): ${installer_run}"
+                ;;
+        esac
     fi
 
-    echo "Release assets are not complete (attempt ${attempt}/${max_attempts}):${missing_assets}"
+    missing_assets=""
+
+    if [ "${installer_pending}" = false ]; then
+        for asset in ${assets}; do
+            for required_file in "${asset}" "${asset}.sha256"; do
+                if ! curl -fsSLI --connect-timeout 30 "${release_base}/${required_file}" >/dev/null; then
+                    missing_assets="${missing_assets} ${required_file}"
+                fi
+            done
+        done
+
+        if [ -z "${missing_assets}" ]; then
+            echo "All runtime and provider release assets are available for ${KAPSL_VERSION}."
+            exit 0
+        fi
+
+        echo "Release assets are not complete (attempt ${attempt}/${max_attempts}):${missing_assets}"
+    fi
     if [ "${attempt}" -lt "${max_attempts}" ]; then
         sleep "${retry_delay}"
     fi


### PR DESCRIPTION
## Cause

The official v0.2.4 installer run failed GitHub workflow validation before starting any jobs:
https://github.com/kapsl-runtime/kapsl-engine/actions/runs/33963870742

Its reusable GCP setup and cleanup jobs request `id-token: write`, but the calling stable GPU conformance job did not grant it. The parallel Docker release therefore polled ten missing assets/checksums even though no installer producer was running. The waiting Docker run has been canceled; no GPU job started in this release attempt.

## Changes

- Grant OIDC only to the stable GPU conformance call, with read-only Actions and repository access. Keep the stable-tag/Cargo authorization and conformance/teardown publication gates intact.
- Before Docker checks assets on tag pushes, query the installer workflow for the exact tag and commit. Wait while pending; stop with the producer URL and conclusion on failure, cancellation, timeout, or startup failure. Reject GitHub API errors rather than ignoring the producer state.
- Keep manual publication of existing releases asset-based. Require the full archive/checksum set after a successful producer.
- Poll every 30 seconds, preserving the existing approximately two-hour wait budget.
- Add host-only tests for caller/callee permission compatibility and release-wait behavior. No GPU workflow is dispatched by this PR.

## Validation

- `python3 .github/scripts/test_gcp_ephemeral_gpu_runner.py` — 23 passed
- `python3 .github/scripts/test_github_jit_runner.py` — 6 passed
- `python3 docker/test-wait-for-release-assets.py` — 9 passed
- `docker/test-release-scripts.sh` — passed, including missing-checksum and corruption rejection
- `cargo fmt --manifest-path kapsl-runtime/Cargo.toml --all -- --check` — passed
- `git diff --check`, shell syntax checks, and Ruby YAML parsing — passed
- actionlint v1.7.7 on both release workflows and the reusable GPU workflow — passed (ShellCheck disabled because it is not installed locally)
- Read-only check against the actual v0.2.4 tag/commit — immediately rejected `startup_failure` and identified run 33963870742 without requesting assets

## Release safety

This PR does not change versions, integration artifacts, secrets, tags, or embedded ORT. v0.2.4 is already published and must not be moved or reused. After merging through develop and a separate main promotion, prepare a new patch release with matching immutable integration-pack compatibility and verified signer trust before creating its stable tag.
