### PR TITLE
chore(release): prepare engine 0.2.5

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

- Bump the engine CLI package `kapsl` from `0.2.4` to `0.2.5`.
- Update only its matching workspace Cargo.lock entry; no dependency changes.
- Preserve published v0.2.4, the existing immutable ORT release lock, historical test fixtures, and embedded ORT.

## Validation

- Locked, offline Cargo metadata reports `kapsl` version `0.2.5`.
- `cargo fmt --manifest-path kapsl-runtime/Cargo.toml --all -- --check` and `git diff --check` passed.
- GCP release-policy tests: 23 passed; JIT runner tests: 6 passed; signed backend importer tests: 5 passed.
- `docker/test-release-scripts.sh` passed, including 9 release-wait unit tests.
- Local policy checks against the actual manifest accept the synthetic v0.2.5 tag context and reject v0.2.4; the Docker resolver emits stable version 0.2.5. These are host-only checks, not workflow dispatches or real GPU tests.

## Release prerequisite

This is a version-preparation PR, not authorization to tag a release. The existing `.github/ort-release.lock.json` still targets signed packs compatible with exactly `=0.2.4`. Publish new immutable, signed integration packs compatible with `=0.2.5`, then update the engine lock in a follow-up PR before official stable qualification. Do not invent new artifact identities or modify signatures/hashes to make the old lock appear compatible.

No tags, releases, SDK versions, integration artifacts, secrets, or GPU resources are created or changed by this PR.
