### PR TITLE
style(tests): consolidate unittest imports in release tests

### DIFF
--- a/.github/scripts/test_import_signed_backend_release.py
+++ b/.github/scripts/test_import_signed_backend_release.py
@@ -14,8 +14,7 @@ import subprocess
 import tempfile
 import threading
 import types
-import unittest
-from unittest import mock
+from unittest import TestCase, main, mock
 
 
 MODULE_PATH = pathlib.Path(__file__).with_name("import-signed-backend-release.py")
@@ -247,7 +246,7 @@ class ReleaseFixture:
             raise AssertionError(f"invalid fixture path {path}")
 
 
-class SignedBackendReleaseImportTests(unittest.TestCase):
+class SignedBackendReleaseImportTests(TestCase):
     def with_fixture(self) -> tuple[tempfile.TemporaryDirectory[str], ReleaseFixture]:
         temporary = tempfile.TemporaryDirectory(prefix="kapsl-release-import-test-")
         fixture = ReleaseFixture(pathlib.Path(temporary.name))
@@ -368,4 +367,4 @@ class SignedBackendReleaseImportTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()

--- a/.github/scripts/test_preflight_ort_release.py
+++ b/.github/scripts/test_preflight_ort_release.py
@@ -7,8 +7,7 @@ import json
 import os
 from pathlib import Path
 import tempfile
-import unittest
-from unittest import mock
+from unittest import TestCase, main, mock
 
 from test_import_signed_backend_release import ReleaseFixture
 
@@ -22,7 +21,7 @@ SPEC.loader.exec_module(preflight)
 ROOT = Path(__file__).resolve().parents[2]
 
 
-class PreflightTests(unittest.TestCase):
+class PreflightTests(TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
@@ -99,4 +98,4 @@ class PreflightTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()


### PR DESCRIPTION
Use one unittest import in both release test modules: TestCase, main, and mock. This removes the mixed import/import-from warning without changing behavior. Validation: all 16 affected tests and git diff checks passed. No workflow, version, tag, or release changes.