### PR TITLE
fix(release): restore GPU secret contract and prepare 0.2.7

### DIFF
--- a/.github/ort-release.lock.json
+++ b/.github/ort-release.lock.json
@@ -1,17 +1,17 @@
 {
   "backend": "onnx",
   "catalog": {
-    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.6-linux-x86_64.release.json",
-    "sha256": "1861b4fb5202b7650b6719d2b44bed9aeddc57487d4de1cdae69d97a8eb168ba",
-    "signature": "ed25519:xZabmooCypEJdDBp+g9jR6TtNJZh+DxNSpO9K/C3Ngh3ckNVwloL7h5fqyeXkpUaNY0xFv9RU+7lrMt5o+WyAQ==",
+    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7-linux-x86_64.release.json",
+    "sha256": "b76ba4052ad7c0ae3b1caec70c621a1d4bde23d07134fa789e7c09c849c1bc67",
+    "signature": "ed25519:u7cHF6IM8JCQ7PFK6PN2UkFXnkZllW9iplLTUZ/ospo+hhjmJAfL96Aei9YalcSaVJ7vtKIW58tZzg0OTcW8Ag==",
     "signature_asset": {
-      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.6-linux-x86_64.release.json.sig",
-      "sha256": "c5233d2b608886891e637595c950afc5add57f49fa8b4ec026b1e6a8c2eead9c",
+      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7-linux-x86_64.release.json.sig",
+      "sha256": "5f483740472d5653dbc5ae33bf94534fe5f2a455259ff44ee60c5cd2adab7aa2",
       "size": 97
     },
     "size": 6755
   },
-  "compatible_kapsl": "=0.2.6",
+  "compatible_kapsl": "=0.2.7",
   "pack_version": "0.2.0",
   "platform": "linux-x86_64",
   "profiles": [
@@ -19,7 +19,7 @@
     "cuda12",
     "tensorrt10"
   ],
-  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.6",
+  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7",
   "repository": "kapsl-runtime/kapsl-integrations",
   "schema_version": 1,
   "source_commit": "0b7a10f4ffcc8347f161c1fa3015802d9acd2695"

--- a/.github/scripts/test_gcp_ephemeral_gpu_runner.py
+++ b/.github/scripts/test_gcp_ephemeral_gpu_runner.py
@@ -211,6 +211,48 @@ class StableGpuReleasePolicyTests(unittest.TestCase):
         # Do not broaden this fix into an OIDC grant for build/publication jobs.
         self.assertEqual(release.count("id-token: write"), 1)
 
+    def test_github_app_key_is_owned_by_the_protected_environment(self) -> None:
+        workflows = MODULE_PATH.parent.parent / "workflows"
+        dispatcher = (workflows / "gpu-device-pool-integration.yml").read_text(
+            encoding="utf-8"
+        )
+        release = (workflows / "release-runtime-installers.yml").read_text(
+            encoding="utf-8"
+        )
+        call_contract = dispatcher.split("  workflow_call:\n", 1)[1].split(
+            "\npermissions:\n", 1
+        )[0]
+        caller = release.split("  stable-release-gpu-conformance:\n", 1)[1].split(
+            "\n  release-conformance-gate:\n", 1
+        )[0]
+
+        app_key_contract = call_contract.split(
+            "      GPU_RUNNER_GITHUB_APP_PRIVATE_KEY:\n", 1
+        )[1].split("\n\n", 1)[0]
+        self.assertIn("required: false", app_key_contract)
+        self.assertNotIn("required: true", app_key_contract)
+        self.assertNotIn("secrets: inherit", caller)
+        self.assertIn(
+            "KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}",
+            caller,
+        )
+        for job in ("prepare-vllm-gcp-runner", "cleanup-vllm-gcp-runner"):
+            with self.subTest(job=job):
+                block = re.search(
+                    rf"(?ms)^  {re.escape(job)}:\n(.*?)(?=^  [\w-]+:|\Z)",
+                    dispatcher,
+                )
+                self.assertIsNotNone(block, job)
+                self.assertIn(
+                    "environment: gcp-gpu-conformance", block.group(1)
+                )
+                self.assertIn(
+                    "secrets.GPU_RUNNER_GITHUB_APP_PRIVATE_KEY", block.group(1)
+                )
+        self.assertEqual(
+            dispatcher.count("secrets.GPU_RUNNER_GITHUB_APP_PRIVATE_KEY"), 2
+        )
+
     def test_release_publication_waits_for_conformance_and_teardown(self) -> None:
         release = (
             MODULE_PATH.parent.parent / "workflows" / "release-runtime-installers.yml"

--- a/.github/workflows/gpu-device-pool-integration.yml
+++ b/.github/workflows/gpu-device-pool-integration.yml
@@ -26,9 +26,11 @@ on:
       KAPSL_BACKEND_PUBLIC_KEYS:
         description: Trusted raw Base64 Ed25519 backend index public key set
         required: true
+      # Declared for expression validation, but supplied by the protected
+      # gcp-gpu-conformance environment on the setup and cleanup jobs.
       GPU_RUNNER_GITHUB_APP_PRIVATE_KEY:
-        description: GitHub App private key used only to create and delete the ephemeral JIT runner
-        required: true
+        description: Environment-owned GitHub App key for the ephemeral JIT runner
+        required: false
 
 permissions:
   actions: read
@@ -78,6 +80,8 @@ jobs:
     if: needs.authorize-stable-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # The GitHub App key is owned by this protected environment. Environment
+    # secrets cannot be passed through a reusable workflow's caller contract.
     environment: gcp-gpu-conformance
     permissions:
       contents: read
@@ -316,6 +320,8 @@ jobs:
     if: always() && needs.authorize-stable-release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Use the same protected environment so teardown can mint its own narrowly
+    # scoped App token even when conformance fails.
     environment: gcp-gpu-conformance
     permissions:
       contents: read

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -108,7 +108,8 @@ jobs:
       candidate_artifact: runtime-cuda-linux-x86_64
       sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
       cuda_visible_devices: "0"
-    secrets: inherit
+    secrets:
+      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
 
   release-conformance-gate:
     name: Gate publication on stable conformance and teardown

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Cause

Stable engine v0.2.6 completed all installer builds, signed ORT import and full CPU performance parity, then GitHub rejected the reusable GPU workflow before assigning a runner:

> Secret GPU_RUNNER_GITHUB_APP_PRIVATE_KEY is required, but not provided while calling.

Run: https://github.com/kapsl-runtime/kapsl-engine/actions/runs/34020614344

The private key already exists in the protected `gcp-gpu-conformance` environment. Environment secrets cannot be passed from a reusable-workflow caller. Declaring it as a required caller secret therefore made the call impossible before the environment-scoped setup job could start.

No GPU runner, VM or cleanup target was created by the failed run: the authorization job had no runner or steps, and setup/conformance/cleanup were skipped.

## Fix

- Keep the key in the reusable workflow schema for expression validation, but make it optional at the caller boundary.
- Continue obtaining it only in the setup and unconditional-cleanup jobs through their protected `gcp-gpu-conformance` environment.
- Replace broad `secrets: inherit` at the stable caller with the one caller-owned secret that is actually required: `KAPSL_BACKEND_PUBLIC_KEYS`.
- Add a regression test covering the caller contract, both environment-scoped consumers and both private-key references.
- Advance the engine crate and lockfile to 0.2.7.
- Pin the immutable signed ORT 0.2.7 catalog by exact name, size, SHA-256 and Ed25519 signature.

This follows GitHub's documented environment-secret behavior for reusable workflows: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows

Published ORT release: https://github.com/kapsl-runtime/kapsl-integrations/releases/tag/kapsl-ort-packs-v0.2.0-kapsl-v0.2.7

## Validation

- Live trusted ORT preflight verified signed metadata and part availability for CPU, CUDA 12 and TensorRT 10.
- GCP runner/policy tests: 24 passed.
- JIT runner tests: 6 passed.
- actionlint v1.7.7 passed for the caller and reusable GPU workflows (ShellCheck disabled because it is not installed locally).
- JSON parsing, Cargo metadata/version, Rust formatting and `git diff --check` passed.
- The protected environment still contains `GPU_RUNNER_GITHUB_APP_PRIVATE_KEY`; no private key was read, moved, replaced or committed.

## Release safety

No GPU workflow is dispatched by this PR. Published v0.2.6 is unchanged and will not be moved or reused. The next real GPU qualification can start only from a new official stable v0.2.7 tag after this change is promoted through develop and main.
