### PR TITLE
ci: fail fast and parallelize cached release builds

### DIFF
--- a/.github/actions/cache-rust-build/action.yml
+++ b/.github/actions/cache-rust-build/action.yml
@@ -1,0 +1,33 @@
+name: Cache Rust build dependencies
+description: Cache the real runtime workspace and ORT download sidecars, isolated by build profile
+inputs:
+  key:
+    required: true
+    description: Platform, toolchain image and feature-profile cache namespace
+  workspaces:
+    required: false
+    default: kapsl-runtime -> target
+    description: Cargo workspace and target directory mapping
+runs:
+  using: composite
+  steps:
+    - name: Resolve ORT cache paths
+      id: paths
+      shell: bash
+      run: |
+        echo "unix=$HOME/.cache/ort.pyke.io" >> "$GITHUB_OUTPUT"
+        echo "macos=$HOME/Library/Caches/ort.pyke.io" >> "$GITHUB_OUTPUT"
+        echo "windows=${LOCALAPPDATA:-$HOME/.cache}/ort.pyke.io" >> "$GITHUB_OUTPUT"
+    - name: Restore compiler and dependency cache
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      with:
+        shared-key: ${{ inputs.key }}
+        workspaces: ${{ inputs.workspaces }}
+        env-vars: KAPSL_BACKEND_PUBLIC_KEYS CUDA_PATH CMAKE_POSITION_INDEPENDENT_CODE
+        cache-directories: |
+          ${{ steps.paths.outputs.unix }}
+          ${{ steps.paths.outputs.macos }}
+          ${{ steps.paths.outputs.windows }}
+        # PRs restore trusted base-branch caches but never update them. Avoid
+        # caching signing credentials, packaging scratch or release artifacts.
+        save-if: ${{ github.event_name != 'pull_request' }}

--- a/.github/actions/cache-rust-build/action.yml
+++ b/.github/actions/cache-rust-build/action.yml
@@ -8,6 +8,10 @@ inputs:
     required: false
     default: kapsl-runtime -> target
     description: Cargo workspace and target directory mapping
+  save-pr-cache:
+    required: false
+    default: "false"
+    description: Allow an unprivileged PR check to save its isolated merge-ref cache
 runs:
   using: composite
   steps:
@@ -28,6 +32,10 @@ runs:
           ${{ steps.paths.outputs.unix }}
           ${{ steps.paths.outputs.macos }}
           ${{ steps.paths.outputs.windows }}
-        # PRs restore trusted base-branch caches but never update them. Avoid
-        # caching signing credentials, packaging scratch or release artifacts.
-        save-if: ${{ github.event_name != 'pull_request' }}
+        # PR writes are opt-in and scoped by GitHub to refs/pull/<n>/merge;
+        # branch/tag jobs cannot restore them. Other PR checks remain read-only.
+        # Never cache signing credentials, packaging scratch or release artifacts.
+        save-if: ${{ github.event_name != 'pull_request' || inputs.save-pr-cache == 'true' }}
+        # Keep dependencies available to fix a failing PR smoke test; failed
+        # trusted-branch/release jobs still do not save compilation caches here.
+        cache-on-failure: ${{ github.event_name == 'pull_request' && inputs.save-pr-cache == 'true' }}

--- a/.github/scripts/package-linux-llama-cpp-backend-packs.sh
+++ b/.github/scripts/package-linux-llama-cpp-backend-packs.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 : "${KAPSL_VERSION:?KAPSL_VERSION is required}"
 
+selected_profile="${KAPSL_LLAMA_PACK_PROFILE:-all}"
+case "$selected_profile" in
+  all|cpu|cuda12) ;;
+  *) echo "KAPSL_LLAMA_PACK_PROFILE must be all, cpu or cuda12." >&2; exit 1 ;;
+esac
+build_only="${KAPSL_LLAMA_BUILD_ONLY:-false}"
+case "$build_only" in
+  true|false) ;;
+  *) echo "KAPSL_LLAMA_BUILD_ONLY must be true or false." >&2; exit 1 ;;
+esac
+
 host_os="${RUNNER_OS:-$(uname -s)}"
 host_arch="${RUNNER_ARCH:-$(uname -m)}"
 if [ "$host_os" != "Linux" ] || { [ "$host_arch" != "X64" ] && [ "$host_arch" != "x86_64" ]; }; then
@@ -48,7 +59,9 @@ build_profile() {
     return
   fi
 
-  target_dir="$work_root/target-$profile"
+  # A caller-owned target survives packaging cleanup and can be restored on
+  # another runner. Keep CPU and CUDA/PIC feature builds in separate targets.
+  target_dir="${KAPSL_LLAMA_TARGET_ROOT:-$work_root/targets}/$profile"
   cargo_args=(
     build
     --manifest-path kapsl-runtime/Cargo.toml
@@ -133,6 +146,10 @@ package_profile() {
   if [ ! -f "$library" ]; then
     echo "llama.cpp $profile build did not produce $library" >&2
     exit 1
+  fi
+  if [ "$build_only" = true ]; then
+    echo "Built llama.cpp $profile dependencies for the trusted release cache."
+    return
   fi
   if ! file "$library" | grep -q 'ELF .* shared object'; then
     echo "llama.cpp $profile entrypoint is not an ELF shared object: $library" >&2
@@ -269,5 +286,9 @@ PY
   echo "Packaged $archive"
 }
 
-package_profile cpu cpu cpu "${KAPSL_LLAMA_CPU_LIBRARY:-}" native
-package_profile cuda12 cuda cuda12-shared-pool "${KAPSL_LLAMA_CUDA_LIBRARY:-}" shared_pool
+if [ "$selected_profile" = all ] || [ "$selected_profile" = cpu ]; then
+  package_profile cpu cpu cpu "${KAPSL_LLAMA_CPU_LIBRARY:-}" native
+fi
+if [ "$selected_profile" = all ] || [ "$selected_profile" = cuda12 ]; then
+  package_profile cuda12 cuda cuda12-shared-pool "${KAPSL_LLAMA_CUDA_LIBRARY:-}" shared_pool
+fi

--- a/.github/scripts/preflight_release_environment.py
+++ b/.github/scripts/preflight_release_environment.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Fail early on release configuration errors without provisioning resources."""
+
+import argparse
+import base64
+import importlib.util
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+
+class PreflightError(RuntimeError):
+    pass
+
+
+def require(environ, names):
+    for name in names:
+        if not environ.get(name, "").strip():
+            raise PreflightError(f"Required release setting {name} is empty.")
+
+
+def validate_gpu(environ):
+    require(environ, (
+        "GCP_GPU_PROJECT_ID", "GCP_GPU_ZONE", "GCP_GPU_RUNNER_IMAGE",
+        "GCP_WORKLOAD_IDENTITY_PROVIDER", "GCP_GPU_PROVISIONER_SERVICE_ACCOUNT",
+        "GPU_RUNNER_GITHUB_APP_ID", "KAPSL_VLLM_SDK_REF",
+    ))
+    if not environ.get("GPU_RUNNER_GITHUB_APP_PRIVATE_KEY", "").strip():
+        raise PreflightError(
+            "GPU_RUNNER_GITHUB_APP_PRIVATE_KEY is empty in gcp-gpu-conformance; "
+            "check the environment secret and the caller's secrets: inherit."
+        )
+    for name, default in (("GPU_RUNNER_GITHUB_APP_ID", ""), ("GCP_GPU_RUNNER_GROUP_ID", "1")):
+        if not re.fullmatch(r"[1-9][0-9]*", environ.get(name) or default):
+            raise PreflightError(f"{name} must be a positive integer.")
+    if (environ.get("GCP_GPU_EXTERNAL_IP") or "true") not in ("true", "false"):
+        raise PreflightError("GCP_GPU_EXTERNAL_IP must be true or false.")
+    if not re.fullmatch(r"[0-9a-f]{40}", environ["KAPSL_VLLM_SDK_REF"]):
+        raise PreflightError("KAPSL_VLLM_SDK_REF must be an exact lowercase 40-hex commit.")
+    image = environ["GCP_GPU_RUNNER_IMAGE"].removeprefix(
+        "https://www.googleapis.com/compute/v1/"
+    )
+    if not re.fullmatch(r"projects/[a-z][a-z0-9-]+/global/images/[a-z][a-z0-9-]+", image):
+        raise PreflightError("GCP_GPU_RUNNER_IMAGE must identify an immutable image, not a family.")
+
+
+def validate_signing(environ):
+    require(environ, (
+        "KAPSL_BACKEND_SIGNING_KEY_B64", "KAPSL_BACKEND_PUBLIC_KEYS",
+        "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY",
+    ))
+    spec = importlib.util.spec_from_file_location(
+        "release_index", Path(__file__).with_name("generate-backend-index.py")
+    )
+    assert spec and spec.loader
+    generator = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(generator)
+    try:
+        private_key = base64.b64decode(
+            "".join(environ["KAPSL_BACKEND_SIGNING_KEY_B64"].split()), validate=True
+        )
+        trusted = generator.expected_public_keys([environ["KAPSL_BACKEND_PUBLIC_KEYS"]])
+        with tempfile.TemporaryDirectory(prefix="kapsl-signing-preflight-") as directory:
+            key_file = Path(directory) / "signing.pem"
+            key_file.write_bytes(private_key)
+            key_file.chmod(0o600)
+            if generator.signing_public_key(key_file) not in trusted:
+                raise PreflightError("Backend signing key does not match runtime trust.")
+            generator.sign(key_file, b"kapsl-release-preflight-v1\0")
+    except (ValueError, subprocess.CalledProcessError, SystemExit) as error:
+        # Never echo OpenSSL output or decoded private-key material.
+        raise PreflightError("Backend signing configuration is invalid.") from error
+
+
+def validate_sdk(environ):
+    require(environ, ("KAPSL_VLLM_SDK_REF", "GH_TOKEN"))
+    ref = environ["KAPSL_VLLM_SDK_REF"]
+    if not re.fullmatch(r"[0-9a-f]{40}", ref):
+        raise PreflightError("KAPSL_VLLM_SDK_REF must be an exact lowercase 40-hex commit.")
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/kapsl-runtime/kapsl-sdk/commits/{ref}", "--jq", ".sha"],
+            env=dict(environ), check=True, capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise PreflightError("Could not verify the certified SDK commit before builds.") from error
+    if result.stdout.strip() != ref:
+        raise PreflightError("Certified SDK commit did not resolve to the exact requested revision.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gpu", action="store_true")
+    parser.add_argument("--signing", action="store_true")
+    parser.add_argument("--sdk", action="store_true")
+    args = parser.parse_args()
+    if not args.gpu and not args.signing and not args.sdk:
+        parser.error("select --gpu, --signing or --sdk")
+    try:
+        if args.gpu:
+            validate_gpu(os.environ)
+        if args.signing:
+            validate_signing(os.environ)
+        if args.sdk:
+            validate_sdk(os.environ)
+    except PreflightError as error:
+        raise SystemExit(str(error)) from None
+    print("Release environment configuration passed (no resources provisioned).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/release_build_inputs.py
+++ b/.github/scripts/release_build_inputs.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Plan host-only release builds and validate their same-run artifact handoff."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+
+
+VERSION = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?")
+
+
+def flag(environ, name):
+    value = environ.get(name, "false")
+    if value not in ("true", "false"):
+        raise ValueError(f"{name} must be true or false")
+    return value == "true"
+
+
+def components(stable, cache_only=False):
+    result = [
+        {"component": "engine", "target": "target", "profile": ""},
+        {"component": "llama-cpu", "target": "target-llama/cpu", "profile": "cpu"},
+        {"component": "llama-cuda12", "target": "target-llama/cuda12", "profile": "cuda12"},
+    ]
+    if not cache_only:
+        result.append({"component": "vllm", "target": "", "profile": ""})
+        if not stable:
+            result.append({"component": "ort-cpu", "target": "", "profile": ""})
+    return result
+
+
+def plan(environ, manifest):
+    stable = flag(environ, "STABLE_RELEASE")
+    cache_only = flag(environ, "CACHE_ONLY")
+    if environ.get("RELEASE_CHANNEL") not in ("stable", "beta"):
+        raise ValueError("RELEASE_CHANNEL must be stable or beta")
+    version = environ.get("RELEASE_VERSION", "")
+    cargo_match = re.search(r'^version\s*=\s*"([^"]+)"', manifest.read_text(), re.MULTILINE)
+    if not cargo_match:
+        raise ValueError("Runtime Cargo version is missing")
+    if cache_only:
+        if environ.get("GITHUB_REF") != "refs/heads/main" or stable:
+            raise ValueError("Cache-only builds are restricted to main and cannot qualify a release")
+        version = cargo_match[1]
+    elif not re.fullmatch(r"[0-9a-f]{40}", environ.get("KAPSL_VLLM_SDK_REF", "")):
+        raise ValueError("KAPSL_VLLM_SDK_REF must be an exact lowercase 40-hex commit")
+    if not VERSION.fullmatch(version):
+        raise ValueError("Release version is invalid")
+    if stable and (
+        environ.get("GITHUB_EVENT_NAME") != "push"
+        or environ.get("GITHUB_REF_TYPE") != "tag"
+        or environ.get("GITHUB_REF_NAME") != f"v{version}"
+        or version != cargo_match[1]
+        or "-" in version
+        or environ["RELEASE_CHANNEL"] != "stable"
+    ):
+        raise ValueError("Stable build requires the exact official tag and matching Cargo version")
+    return version, {"include": components(stable, cache_only)}
+
+
+def assemble(root, output, version, commit, stable):
+    if not VERSION.fullmatch(version) or not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise ValueError("Invalid release version or source commit")
+    expected = {f"build-cuda-{item['component']}-{commit}" for item in components(stable)}
+    if {path.name for path in root.iterdir()} != expected:
+        raise ValueError("Downloaded component set does not match the release plan")
+    if output.exists() and (output.is_symlink() or any(output.iterdir())):
+        raise ValueError("Assembly destination must be empty")
+    files = {}
+    for directory in sorted(root.iterdir()):
+        if directory.is_symlink() or not directory.is_dir():
+            raise ValueError("Component must be a real directory")
+        entries = list(directory.iterdir())
+        if not entries:
+            raise ValueError("A release component is empty")
+        for source in entries:
+            if source.is_symlink() or not source.is_file():
+                raise ValueError("Component contains a non-regular file")
+            if source.name in files:
+                raise ValueError(f"Duplicate component output: {source.name}")
+            if f"-{version}-" not in source.name or not source.name.endswith(
+                (".tar.gz", ".tar.gz.sha256", ".tar.gz.manifest.json")
+            ):
+                raise ValueError(f"Unexpected or wrong-version component output: {source.name}")
+            files[source.name] = source
+        for archive in (path for path in entries if path.name.endswith(".tar.gz")):
+            if not directory.name.startswith("build-cuda-engine-"):
+                manifest = archive.with_name(archive.name + ".manifest.json")
+                if not manifest.is_file() or manifest.is_symlink():
+                    raise ValueError(f"Missing backend manifest: {archive.name}")
+            checksum = archive.with_name(archive.name + ".sha256")
+            if not checksum.is_file() or checksum.is_symlink():
+                raise ValueError(f"Missing archive checksum: {archive.name}")
+            match = re.fullmatch(r"([0-9a-f]{64})\s+\*?(?:dist/)?([^/\r\n]+)\s*", checksum.read_text())
+            if not match or match[2] != archive.name:
+                raise ValueError(f"Invalid archive checksum record: {archive.name}")
+            digest = hashlib.sha256()
+            with archive.open("rb") as stream:
+                while block := stream.read(1024 * 1024):
+                    digest.update(block)
+            if digest.hexdigest() != match[1]:
+                raise ValueError(f"Archive checksum mismatch: {archive.name}")
+        if not any(path.name.endswith(".tar.gz") for path in entries):
+            raise ValueError("Component contains no archives")
+    # Validate everything before moving anything. Moving on the same filesystem
+    # avoids doubling the multi-GB payload on disk during assembly.
+    output.mkdir(parents=True, exist_ok=True)
+    for name, source in files.items():
+        source.replace(output / name)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--assemble", type=Path)
+    parser.add_argument("--output", type=Path, default=Path("dist"))
+    args = parser.parse_args()
+    try:
+        if args.assemble:
+            assemble(args.assemble, args.output, os.environ["RELEASE_VERSION"],
+                     os.environ["GITHUB_SHA"], flag(os.environ, "STABLE_RELEASE"))
+        else:
+            version, matrix = plan(os.environ, Path("kapsl-runtime/crates/kapsl-cli/Cargo.toml"))
+            with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+                output.write(f"version={version}\nmatrix={json.dumps(matrix)}\n")
+    except (ValueError, KeyError, OSError) as error:
+        raise SystemExit(str(error)) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-llama-cpp-backend-release-contract.sh
+++ b/.github/scripts/test-llama-cpp-backend-release-contract.sh
@@ -42,14 +42,18 @@ require_literal "$packager" '"entrypoint": "lib/libkapsl_backend_llama_cpp.so"'
 for workflow in \
   .github/workflows/beta-runtime-installers.yml \
   .github/workflows/release-runtime-installers.yml; do
-  require_literal "$workflow" '.github/scripts/package-linux-llama-cpp-backend-packs.sh'
-  require_literal "$workflow" 'Package llama.cpp backend packs from published SDK crates'
-  require_literal "$workflow" 'cargo build --manifest-path kapsl-runtime/Cargo.toml --locked'
-  require_literal "$workflow" 'KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE'
+  require_literal "$workflow" './.github/workflows/build-linux-accelerators.yml'
 done
+
+build_workflow=".github/workflows/build-linux-accelerators.yml"
+require_literal "$build_workflow" '.github/scripts/package-linux-llama-cpp-backend-packs.sh'
+require_literal "$build_workflow" 'Package llama.cpp backend packs from published SDK crates'
+require_literal "$build_workflow" 'cargo build --manifest-path kapsl-runtime/Cargo.toml --locked'
+require_literal "$build_workflow" 'KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE'
 
 if grep -Eq 'KAPSL_LLAMA_SDK_(DIR|REF)|sdk-llama|patch\.crates-io\.kapsl-(llm|engine-api)' \
   "$packager" \
+  "$build_workflow" \
   .github/workflows/beta-runtime-installers.yml \
   .github/workflows/release-runtime-installers.yml; then
   echo "llama.cpp release paths must resolve published SDK crates without path patches." >&2

--- a/.github/scripts/test-managed-vllm-release-contract.sh
+++ b/.github/scripts/test-managed-vllm-release-contract.sh
@@ -71,13 +71,12 @@ require_literal "$index_generator" 'kapsl-backend-index-v1\0'
 require_literal "$index_generator" 'kapsl-backend-artifact-v1\0'
 
 for workflow in \
-  .github/workflows/release-runtime-installers.yml \
-  .github/workflows/beta-runtime-installers.yml \
+  .github/workflows/build-linux-accelerators.yml \
   .github/workflows/vllm-shared-pool-conformance.yml; do
   require_literal "$workflow" 'KAPSL_VLLM_SDK_REF'
   require_literal "$workflow" 'verify-managed-vllm-sdk-checkout.sh'
   if [ "$workflow" != ".github/workflows/vllm-shared-pool-conformance.yml" ]; then
-    require_literal "$workflow" '${{ vars.KAPSL_VLLM_SDK_REF }}'
+    require_literal "$workflow" '${{ inputs.sdk_ref }}'
     require_literal "$workflow" '--expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS"'
   else
     require_literal "$workflow" "EXPECTED_CONNECTOR_VERSION: \"$connector_version\""
@@ -103,6 +102,11 @@ for workflow in \
     require_literal "$workflow" 'llama_owner_usage_bytes'
     require_literal "$workflow" 'general_pool_allocated_bytes'
   fi
+done
+
+for workflow in .github/workflows/release-runtime-installers.yml .github/workflows/beta-runtime-installers.yml; do
+  require_literal "$workflow" './.github/workflows/build-linux-accelerators.yml'
+  require_literal "$workflow" 'sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}'
 done
 
 if grep -Eq 'engine/\.cargo/config\.toml|\[patch\.crates-io\]|patch\.crates-io\.kapsl-' \
@@ -140,6 +144,7 @@ if grep -Fq -- '--index-url "$PYTORCH_INDEX_URL"' \
 fi
 
 if grep -Eq 'KAPSL_VLLM_SDK_REF:-|sdk_ref:.*default:' "$packager" \
+  .github/workflows/build-linux-accelerators.yml \
   .github/workflows/release-runtime-installers.yml \
   .github/workflows/beta-runtime-installers.yml \
   .github/workflows/vllm-shared-pool-conformance.yml; then

--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -29,6 +29,7 @@ gpu_entry_workflow=".github/workflows/gpu-device-pool-integration.yml"
 stable_gpu_workflow=".github/workflows/vllm-shared-pool-conformance.yml"
 installer_workflow=".github/workflows/installer-smoke.yml"
 release_workflow=".github/workflows/release-runtime-installers.yml"
+build_workflow=".github/workflows/build-linux-accelerators.yml"
 runtime_backend="kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs"
 native_host="kapsl-runtime/crates/kapsl-cli/src/backend/native.rs"
 bundle="kapsl-runtime/crates/kapsl-cli/src/backend/bundle.rs"
@@ -216,26 +217,32 @@ for workflow in \
     echo "$workflow must not build legacy ONNX accelerator backend packs." >&2
     exit 1
   fi
-  # Removing legacy backend archives must not remove the embedded rollback's
-  # provider sidecars or the certified CPU adapter used by non-stable builds.
+  require_literal "$workflow" './.github/workflows/build-linux-accelerators.yml'
+  # Portable installers retain explicit embedded rollback provider libraries.
   require_literal "$workflow" '.github/scripts/collect-ort-sidecars.sh'
   require_literal "$workflow" '.github/scripts/package-linux-provider-packs.sh'
-  require_literal "$workflow" '.github/scripts/package-linux-ort-cpu-backend.sh'
-  require_literal "$workflow" '.github/ort-integration.lock'
-  require_literal "$workflow" 'ref: ${{ steps.ort-integrations.outputs.ref }}'
-  require_literal "$workflow" 'repository: kapsl-runtime/kapsl-integrations'
-  require_literal "$workflow" 'verify-ort-integration-checkout.sh'
-  require_literal "$workflow" 'Install certified ORT packaging toolchain'
-  require_literal "$workflow" 'rustup toolchain install "$toolchain" --profile minimal'
-  require_literal "$workflow" '.github/scripts/collect-linux-tensorrt-runtime.sh'
 done
 
-require_literal "$release_workflow" 'name: Import immutable signed ORT backend packs'
+if grep -Fq '.github/scripts/package-linux-onnx-backend-packs.sh' "$build_workflow"; then
+  echo "$build_workflow must not build legacy ONNX accelerator backend packs." >&2
+  exit 1
+fi
+require_literal "$build_workflow" '.github/scripts/collect-ort-sidecars.sh'
+require_literal "$build_workflow" '.github/scripts/package-linux-ort-cpu-backend.sh'
+require_literal "$build_workflow" '.github/ort-integration.lock'
+require_literal "$build_workflow" 'ref: ${{ steps.ort-integrations.outputs.ref }}'
+require_literal "$build_workflow" 'repository: kapsl-runtime/kapsl-integrations'
+require_literal "$build_workflow" 'verify-ort-integration-checkout.sh'
+require_literal "$build_workflow" 'Install certified ORT packaging toolchain'
+require_literal "$build_workflow" 'rustup toolchain install "$toolchain" --profile minimal'
+require_literal "$build_workflow" '.github/scripts/collect-linux-tensorrt-runtime.sh'
+require_literal "$build_workflow" 'name: Import immutable signed ORT backend packs'
+require_literal "$build_workflow" 'if: inputs.stable_release'
+require_literal "$build_workflow" '.github/scripts/import-signed-backend-release.py'
+require_literal "$build_workflow" '--lock .github/ort-release.lock.json'
+require_literal "$build_workflow" '--expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS"'
 require_literal "$release_workflow" "if: needs.prepare-version.outputs.is_stable_release == 'true'"
-require_literal "$release_workflow" '.github/scripts/import-signed-backend-release.py'
-require_literal "$release_workflow" '--lock .github/ort-release.lock.json'
-require_literal "$release_workflow" '--expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS"'
-require_literal "$release_workflow" "if: needs.prepare-version.outputs.is_stable_release != 'true'"
+require_literal "$release_workflow" "needs.prepare-version.outputs.is_stable_release != 'true'"
 require_literal "$release_workflow" 'needs: [prepare-version, build-cuda-runtime]'
 require_literal "$release_workflow" 'candidate_artifact: runtime-cuda-linux-x86_64'
 
@@ -271,6 +278,7 @@ PY
 
 if grep -Eq 'KAPSL_ORT_INTEGRATIONS_REF:-|ref:.*feature/ort|ref:.*(main|develop)' \
   "$cpu_packager" \
+  "$build_workflow" \
   .github/workflows/beta-runtime-installers.yml \
   .github/workflows/release-runtime-installers.yml; then
   echo "ORT release paths must use an exact configured integrations commit without a branch fallback." >&2

--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -246,7 +246,7 @@ require_literal "$release_workflow" "needs.prepare-version.outputs.is_stable_rel
 require_literal "$release_workflow" 'needs: [prepare-version, build-cuda-runtime]'
 require_literal "$release_workflow" 'candidate_artifact: runtime-cuda-linux-x86_64'
 
-require_literal "$parity_workflow" 'name: ORT CPU Conformance'
+require_literal "$parity_workflow" 'name: ORT CPU Smoke and Release Parity'
 require_literal "$parity_workflow" "cancel-in-progress: \${{ github.event_name == 'pull_request' }}"
 require_literal "$parity_workflow" '.github/ort-cpu-parity.lock.json'
 require_literal "$parity_workflow" 'repository: kapsl-runtime/kapsl-sdk'

--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -212,7 +212,14 @@ fi
 for workflow in \
   .github/workflows/beta-runtime-installers.yml \
   "$release_workflow"; do
-  require_literal "$workflow" '.github/scripts/package-linux-onnx-backend-packs.sh'
+  if grep -Fq '.github/scripts/package-linux-onnx-backend-packs.sh' "$workflow"; then
+    echo "$workflow must not build legacy ONNX accelerator backend packs." >&2
+    exit 1
+  fi
+  # Removing legacy backend archives must not remove the embedded rollback's
+  # provider sidecars or the certified CPU adapter used by non-stable builds.
+  require_literal "$workflow" '.github/scripts/collect-ort-sidecars.sh'
+  require_literal "$workflow" '.github/scripts/package-linux-provider-packs.sh'
   require_literal "$workflow" '.github/scripts/package-linux-ort-cpu-backend.sh'
   require_literal "$workflow" '.github/ort-integration.lock'
   require_literal "$workflow" 'ref: ${{ steps.ort-integrations.outputs.ref }}'

--- a/.github/scripts/test_gcp_ephemeral_gpu_runner.py
+++ b/.github/scripts/test_gcp_ephemeral_gpu_runner.py
@@ -208,8 +208,10 @@ class StableGpuReleasePolicyTests(unittest.TestCase):
                 self.assertEqual(requested["id-token"], "write")
                 for permission, level in requested.items():
                     self.assertEqual(caller.get(permission), level)
-        # Do not broaden this fix into an OIDC grant for build/publication jobs.
-        self.assertEqual(release.count("id-token: write"), 1)
+        preflight = job_permissions(release, "stable-release-infrastructure-preflight")
+        self.assertEqual(preflight, {"contents": "read", "id-token": "write"})
+        # OIDC is limited to authentication preflight and GPU setup/teardown.
+        self.assertEqual(release.count("id-token: write"), 2)
 
     def test_github_app_key_is_owned_by_the_protected_environment(self) -> None:
         workflows = MODULE_PATH.parent.parent / "workflows"
@@ -231,11 +233,8 @@ class StableGpuReleasePolicyTests(unittest.TestCase):
         )[1].split("\n\n", 1)[0]
         self.assertIn("required: false", app_key_contract)
         self.assertNotIn("required: true", app_key_contract)
-        self.assertNotIn("secrets: inherit", caller)
-        self.assertIn(
-            "KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}",
-            caller,
-        )
+        self.assertIn("secrets: inherit", caller)
+        self.assertNotIn("GPU_RUNNER_GITHUB_APP_PRIVATE_KEY:", caller)
         for job in ("prepare-vllm-gcp-runner", "cleanup-vllm-gcp-runner"):
             with self.subTest(job=job):
                 block = re.search(

--- a/.github/scripts/test_preflight_ort_release.py
+++ b/.github/scripts/test_preflight_ort_release.py
@@ -80,11 +80,12 @@ class PreflightTests(TestCase):
         self.assertIn("preflight-ort-release.py --require-runtime-trust", prepare)
         for job in ("build-runtime-installers", "build-cuda-runtime", "stable-release-cpu-conformance"):
             block = release.split(f"  {job}:\n", 1)[1].split("    steps:", 1)[0]
-            self.assertIn("needs: prepare-version", block)
+            self.assertIn("needs: [prepare-version, stable-release-infrastructure-preflight]", block)
         workflow = (ROOT / ".github/workflows/release-preflight.yml").read_text()
         self.assertIn("  pull_request:", workflow)
         self.assertIn("preflight-ort-release.py", workflow)
-        self.assertNotIn("secrets.", workflow)
+        pr_job = workflow.split("  ort-release-preflight:\n", 1)[1].split("  live-infrastructure-preflight:\n", 1)[0]
+        self.assertNotIn("secrets.", pr_job)
         self.assertNotIn("self-hosted", workflow)
         self.assertNotIn("gpu-device-pool-integration.yml", workflow)
 

--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -358,7 +358,9 @@ class WorkflowTests(TestCase):
         self.assertNotIn("KAPSL_BACKEND_SIGNING_KEY", block)
         cache = (ROOT / ".github/actions/cache-rust-build/action.yml").read_text()
         self.assertIn("default: kapsl-runtime -> target", cache)
-        self.assertIn("save-if: ${{ github.event_name != 'pull_request' }}", cache)
+        self.assertIn("save-if: ${{ github.event_name != 'pull_request' || inputs.save-pr-cache == 'true' }}", cache)
+        self.assertIn("cache-on-failure: ${{ github.event_name == 'pull_request' && inputs.save-pr-cache == 'true' }}", cache)
+        self.assertRegex(cache, r'save-pr-cache:\n    required: false\n    default: "false"')
         self.assertNotIn("PRIVATE_KEY", cache)
 
     def test_ci_only_changes_do_not_automatically_build_betas(self):
@@ -373,6 +375,105 @@ class WorkflowTests(TestCase):
             self.assertFalse(any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns), path)
         self.assertIn("workflow_dispatch:", source)
         self.assertIn("if: github.ref == 'refs/heads/develop'", source)
+
+
+class CpuSmokeWorkflowTests(TestCase):
+    def setUp(self):
+        self.source = workflow("ort-cpu-conformance")
+        trigger = self.source.split("  pull_request:\n", 1)[1].split("  workflow_call:", 1)[0]
+        self.patterns = re.findall(r'^      - "([^"]+)"', trigger, re.MULTILINE)
+
+    def matches(self, path):
+        return any(fnmatch.fnmatchcase(path, pattern) for pattern in self.patterns)
+
+    def test_runtime_and_real_pack_inputs_still_run_correctness_smoke(self):
+        for path in (
+            "rust-toolchain.toml", ".cargo/config.toml", "kapsl-runtime/Cargo.lock",
+            "kapsl-runtime/Cargo.toml", "kapsl-runtime/crates/kapsl-cli/Cargo.toml",
+            "kapsl-runtime/crates/kapsl-cli/src/backend/native.rs",
+            "kapsl-runtime/crates/kapsl-cli/src/backend/resolver.rs",
+            "kapsl-runtime/crates/kapsl-cli/src/runtime/model/lifecycle.rs",
+            "kapsl-runtime/crates/kapsl-backends/src/onnx.rs",
+            ".github/ort-integration.lock", ".github/ort-cpu-parity.lock.json",
+            ".github/licenses/ONNX-RUNTIME-LICENSE",
+            ".github/scripts/certify-ort-cpu-parity.sh",
+            ".github/scripts/generate-backend-index.py",
+            ".github/scripts/package-linux-ort-cpu-backend.sh",
+            ".github/scripts/verify-ort-integration-checkout.sh",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(self.matches(path))
+
+    def test_ci_authentication_and_test_only_changes_do_not_compile_ort(self):
+        for path in (
+            ".github/workflows/ort-cpu-conformance.yml",
+            ".github/workflows/release-runtime-installers.yml",
+            ".github/workflows/gpu-device-pool-integration.yml",
+            ".github/workflows/release-infrastructure-preflight.yml",
+            ".github/actions/cache-rust-build/action.yml",
+            ".github/scripts/preflight_release_environment.py",
+            ".github/scripts/validate_stable_gpu_release.py",
+            ".github/scripts/test-generate-backend-index.sh",
+            ".github/scripts/test-onnx-backend-release-contract.sh",
+            ".github/scripts/test-package-linux-ort-cpu-backend.sh",
+            ".github/scripts/test-verify-ort-integration-checkout.sh",
+            ".github/scripts/test_release_pipeline.py", "docs/architecture.md",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(self.matches(path))
+
+    def test_removed_triggers_remain_covered_by_lightweight_checks(self):
+        installer = workflow("installer-smoke")
+        triggers, steps = installer.split("\njobs:\n", 1)
+        for path in (
+            ".github/scripts/test-generate-backend-index.sh",
+            ".github/scripts/test-onnx-backend-release-contract.sh",
+            ".github/scripts/test-package-linux-ort-cpu-backend.sh",
+            ".github/scripts/test-verify-ort-integration-checkout.sh",
+            ".github/scripts/validate_stable_gpu_release.py",
+            ".github/workflows/ort-cpu-conformance.yml",
+        ):
+            with self.subTest(path=path):
+                self.assertIn(f'      - "{path}"', triggers)
+                if path.endswith(".sh"):
+                    self.assertIn(f"run: {path}", steps)
+        self.assertIn("python3 .github/scripts/test_release_pipeline.py", steps)
+        self.assertIn("python3 .github/scripts/test_gcp_ephemeral_gpu_runner.py", steps)
+        self.assertNotIn("run: .github/scripts/certify-ort-cpu-parity.sh", steps)
+
+    def test_cache_covers_actual_engine_and_adapter_targets_but_no_packs_or_keys(self):
+        block = job(self.source, "ort-cpu-release-handoff")
+        cache = block.split("      - name: Cache engine", 1)[1].split("      - name:", 1)[0]
+        self.assertIn("uses: ./.github/actions/cache-rust-build", cache)
+        self.assertIn("ort-cpu-ubuntu22.04-${{ steps.release-inputs.outputs.integrations_ref }}", cache)
+        self.assertIn('save-pr-cache: "true"', cache)
+        mappings = re.findall(r'^            ([\w-]+) -> (.+)$', cache, re.MULTILINE)
+        targets = {root: (ROOT / root / target).resolve() for root, target in mappings}
+        self.assertEqual(targets["kapsl-runtime"], ROOT / "kapsl-runtime/target")
+        build_root = re.search(r'KAPSL_ORT_PACK_BUILD_DIR: \$\{\{ github.workspace \}\}/(.+)', block)
+        self.assertIsNotNone(build_root)
+        self.assertEqual(targets["kapsl-integrations-ort"], ROOT / build_root[1] / "target")
+        self.assertFalse(targets["kapsl-integrations-ort"].is_relative_to(ROOT / "kapsl-integrations-ort"))
+        self.assertLess(block.index("Cache engine"), block.index("Build and validate release handoff"))
+        self.assertLess(block.index("Install exact ORT packaging toolchain"), block.index("Cache engine"))
+        for forbidden in ("dist/", ".pem", "evidence", "cache-all-crates: true"):
+            self.assertNotIn(forbidden, "\n".join(line for line in cache.splitlines() if not line.lstrip().startswith("#")))
+        # All other callers retain the default read-only behavior on PRs.
+        for path in WORKFLOWS.glob("*.yml"):
+            if path.name != "ort-cpu-conformance.yml":
+                self.assertNotIn("save-pr-cache:", path.read_text(), path.name)
+
+    def test_modes_and_unconditional_evidence_remain_intact(self):
+        self.assertIn("name: ORT CPU Smoke and Release Parity", self.source)
+        self.assertIn("correctness smoke (PR)", self.source)
+        self.assertIn('if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then\n            mode=smoke', self.source)
+        self.assertIn('elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then\n            mode=performance', self.source)
+        self.assertIn("python3 .github/scripts/validate_stable_gpu_release.py", self.source)
+        self.assertIn("if: always()", self.source)
+        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", self.source)
+        self.assertNotIn("self-hosted", self.source)
+        self.assertNotIn("secrets.", self.source)
+        self.assertNotIn("gpu-device-pool-integration.yml", self.source)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Host-only regression tests for fast preflight and parallel release builds."""
+
+import base64
+import fnmatch
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from unittest import TestCase, main, mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github/workflows"
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, Path(__file__).with_name(name + ".py"))
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+environment = load("preflight_release_environment")
+build = load("release_build_inputs")
+
+
+def workflow(name):
+    return (WORKFLOWS / (name + ".yml")).read_text()
+
+
+def job(source, name):
+    match = re.search(rf"(?ms)^  {re.escape(name)}:\n(.*?)(?=^  [\w-]+:|\Z)", source)
+    if not match:
+        raise AssertionError(f"Job {name} is missing")
+    return match[1]
+
+
+class EnvironmentTests(TestCase):
+    def test_sdk_ref_must_resolve_before_build_fanout(self):
+        values = {"KAPSL_VLLM_SDK_REF": "a" * 40, "GH_TOKEN": "fixture-token"}
+        with mock.patch.object(environment.subprocess, "run") as request:
+            request.return_value.stdout = "a" * 40 + "\n"
+            environment.validate_sdk(values)
+            self.assertEqual(request.call_args.kwargs["timeout"], 30)
+            request.return_value.stdout = "b" * 40
+            with self.assertRaisesRegex(environment.PreflightError, "exact requested revision"):
+                environment.validate_sdk(values)
+            request.reset_mock()
+            with self.assertRaises(environment.PreflightError):
+                environment.validate_sdk(values | {"KAPSL_VLLM_SDK_REF": "main"})
+            request.assert_not_called()
+
+    def gpu_env(self):
+        return {
+            "GCP_GPU_PROJECT_ID": "fixture-project",
+            "GCP_GPU_ZONE": "us-central1-a",
+            "GCP_GPU_RUNNER_IMAGE": "projects/fixture-project/global/images/immutable-image",
+            "GCP_WORKLOAD_IDENTITY_PROVIDER": "fixture-provider",
+            "GCP_GPU_PROVISIONER_SERVICE_ACCOUNT": "fixture-service-account",
+            "GPU_RUNNER_GITHUB_APP_ID": "123",
+            "GPU_RUNNER_GITHUB_APP_PRIVATE_KEY": "fixture-private-key",
+            "KAPSL_VLLM_SDK_REF": "a" * 40,
+        }
+
+    def test_valid_gpu_configuration_and_empty_optional_defaults(self):
+        values = self.gpu_env()
+        values.update(GCP_GPU_RUNNER_GROUP_ID="", GCP_GPU_EXTERNAL_IP="")
+        environment.validate_gpu(values)
+
+    def test_missing_secret_explains_inheritance_without_revealing_values(self):
+        values = self.gpu_env()
+        values["GPU_RUNNER_GITHUB_APP_PRIVATE_KEY"] = " "
+        with self.assertRaisesRegex(environment.PreflightError, "secrets: inherit") as error:
+            environment.validate_gpu(values)
+        self.assertNotIn("fixture-private-key", str(error.exception))
+
+    def test_bad_configuration_fails_before_any_external_actions(self):
+        bad = {
+            "GCP_GPU_PROJECT_ID": "",
+            "GCP_GPU_RUNNER_IMAGE": "projects/fixture-project/global/images/family/latest",
+            "GPU_RUNNER_GITHUB_APP_ID": "invalid-sensitive-value",
+            "GCP_GPU_RUNNER_GROUP_ID": "0",
+            "GCP_GPU_EXTERNAL_IP": "yes",
+            "KAPSL_VLLM_SDK_REF": "develop",
+        }
+        for name, value in bad.items():
+            with self.subTest(name=name):
+                values = self.gpu_env() | {name: value}
+                with self.assertRaises(environment.PreflightError) as error:
+                    environment.validate_gpu(values)
+                self.assertNotIn("invalid-sensitive-value", str(error.exception))
+
+    def test_signing_requires_matching_trust_and_publication_credentials(self):
+        with tempfile.TemporaryDirectory() as directory:
+            key = Path(directory) / "fixture.pem"
+            subprocess.run(["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(key)],
+                           check=True, capture_output=True)
+            public = subprocess.check_output(["openssl", "pkey", "-in", str(key),
+                                               "-pubout", "-outform", "DER"])[-32:]
+            values = {
+                "KAPSL_BACKEND_SIGNING_KEY_B64": base64.b64encode(key.read_bytes()).decode(),
+                "KAPSL_BACKEND_PUBLIC_KEYS": base64.b64encode(public).decode(),
+                "R2_ACCESS_KEY_ID": "fixture-access-id",
+                "R2_SECRET_ACCESS_KEY": "fixture-access-secret",
+            }
+            environment.validate_signing(values)
+            for name in values:
+                with self.subTest(missing=name), self.assertRaises(environment.PreflightError):
+                    environment.validate_signing(values | {name: ""})
+            with self.assertRaisesRegex(environment.PreflightError, "does not match"):
+                environment.validate_signing(values | {
+                    "KAPSL_BACKEND_PUBLIC_KEYS": base64.b64encode(bytes(32)).decode()
+                })
+            secret = "malformed-sensitive-material"
+            result = subprocess.run(
+                [sys.executable, str(Path(environment.__file__)), "--signing"],
+                env=os.environ | values | {"KAPSL_BACKEND_SIGNING_KEY_B64": secret},
+                capture_output=True, text=True, check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn(secret, result.stdout + result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+
+class BuildPlanTests(TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.manifest = Path(temporary.name) / "Cargo.toml"
+        self.manifest.write_text('[package]\nversion = "0.2.7"\n')
+        self.values = {
+            "RELEASE_VERSION": "0.2.7", "RELEASE_CHANNEL": "stable",
+            "STABLE_RELEASE": "true", "CACHE_ONLY": "false",
+            "KAPSL_VLLM_SDK_REF": "a" * 40,
+            "GITHUB_REF": "refs/tags/v0.2.7", "GITHUB_REF_TYPE": "tag",
+            "GITHUB_REF_NAME": "v0.2.7", "GITHUB_EVENT_NAME": "push",
+        }
+
+    def test_stable_parallelizes_engine_and_backend_builds_without_rebuilding_ort(self):
+        version, matrix = build.plan(self.values, self.manifest)
+        self.assertEqual(version, "0.2.7")
+        self.assertEqual([item["component"] for item in matrix["include"]],
+                         ["engine", "llama-cpu", "llama-cuda12", "vllm"])
+        targets = [item["target"] for item in matrix["include"] if item["target"]]
+        self.assertEqual(len(targets), len(set(targets)))
+
+    def test_beta_includes_certified_cpu_but_never_legacy_accelerator_components(self):
+        version, matrix = build.plan(self.values | {
+            "STABLE_RELEASE": "false", "RELEASE_CHANNEL": "beta",
+            "RELEASE_VERSION": "0.2.7-beta.20260907.abcdef12",
+            "GITHUB_REF": "refs/heads/develop", "GITHUB_REF_TYPE": "branch",
+        }, self.manifest)
+        self.assertIn("beta", version)
+        self.assertEqual(matrix["include"][-1]["component"], "ort-cpu")
+        self.assertFalse(any("onnx" in item["component"] for item in matrix["include"]))
+
+    def test_cache_warming_is_main_only_and_produces_no_vllm_or_ort_release_parts(self):
+        values = self.values | {"CACHE_ONLY": "true", "STABLE_RELEASE": "false",
+                                "GITHUB_REF": "refs/heads/main", "KAPSL_VLLM_SDK_REF": ""}
+        self.assertEqual(len(build.plan(values, self.manifest)[1]["include"]), 3)
+        with self.assertRaisesRegex(ValueError, "restricted to main"):
+            build.plan(values | {"GITHUB_REF": "refs/heads/develop"}, self.manifest)
+
+    def test_invalid_stable_context_version_and_sdk_are_rejected(self):
+        for name, value in (
+            ("GITHUB_EVENT_NAME", "workflow_dispatch"), ("GITHUB_EVENT_NAME", "pull_request"),
+            ("GITHUB_REF_TYPE", "branch"), ("GITHUB_REF_NAME", "v0.2.7-beta.1"),
+            ("RELEASE_VERSION", "0.2.8"), ("RELEASE_CHANNEL", "beta"),
+            ("RELEASE_VERSION", "0.2.7/../../invalid"), ("KAPSL_VLLM_SDK_REF", "main"),
+            ("CACHE_ONLY", "yes"), ("STABLE_RELEASE", "yes"),
+        ):
+            with self.subTest(name=name, value=value), self.assertRaises(ValueError):
+                build.plan(self.values | {name: value}, self.manifest)
+
+
+class AssemblyTests(TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name) / "parts"
+        self.root.mkdir()
+        self.output = self.root.parent / "dist"
+        self.commit = "a" * 40
+        self.version = "0.2.7"
+        for item in build.components(True):
+            directory = self.root / f"build-cuda-{item['component']}-{self.commit}"
+            directory.mkdir()
+            archive = directory / f"kapsl-{item['component']}-{self.version}-linux-x86_64.tar.gz"
+            archive.write_bytes(item["component"].encode())
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            archive.with_name(archive.name + ".sha256").write_text(f"{digest}  dist/{archive.name}\n")
+            if item["component"] != "engine":
+                archive.with_name(archive.name + ".manifest.json").write_text("{}\n")
+
+    def assemble(self):
+        build.assemble(self.root, self.output, self.version, self.commit, True)
+
+    def test_complete_component_set_is_moved_without_duplicate_disk_usage(self):
+        self.assemble()
+        self.assertEqual(len(list(self.output.iterdir())), 11)
+        self.assertTrue(all(not list(directory.iterdir()) for directory in self.root.iterdir()))
+
+    def test_missing_component_fails_without_moving_existing_outputs(self):
+        next(self.root.iterdir()).rename(self.root.parent / "missing-component")
+        with self.assertRaisesRegex(ValueError, "component set"):
+            self.assemble()
+        self.assertFalse(self.output.exists())
+
+    def test_wrong_commit_cannot_be_substituted(self):
+        with self.assertRaisesRegex(ValueError, "component set"):
+            build.assemble(self.root, self.output, self.version, "b" * 40, True)
+
+    def test_checksum_tampering_is_rejected_before_any_move(self):
+        next(self.root.glob("*/*.tar.gz")).write_bytes(b"tampered")
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            self.assemble()
+        self.assertFalse(self.output.exists())
+
+    def test_missing_backend_manifest_is_rejected(self):
+        next(self.root.glob("*/*.manifest.json")).unlink()
+        with self.assertRaisesRegex(ValueError, "Missing backend manifest"):
+            self.assemble()
+
+    def test_duplicate_output_and_symlinks_are_rejected(self):
+        directories = list(self.root.iterdir())
+        original = next(directories[0].glob("*.tar.gz"))
+        duplicate = directories[1] / original.name
+        duplicate.write_bytes(original.read_bytes())
+        with self.assertRaises(ValueError):
+            self.assemble()
+        duplicate.unlink()
+        target = self.root.parent / "outside"
+        original.replace(target)
+        original.symlink_to(target)
+        with self.assertRaisesRegex(ValueError, "non-regular"):
+            self.assemble()
+
+
+class NativeCacheTests(TestCase):
+    def test_cpu_and_cuda_build_targets_survive_packaging_cleanup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = root / "repo"
+            for relative in (".github/scripts", ".github/licenses", "kapsl-runtime/include"):
+                (repo / relative).mkdir(parents=True, exist_ok=True)
+            for relative in (".github/scripts/package-linux-llama-cpp-backend-packs.sh",
+                             ".github/licenses/LLAMA-CPP-LICENSE", "LICENSE", "NOTICE",
+                             "kapsl-runtime/include/kapsl_llama_cpp_backend.h", "kapsl-runtime/Cargo.toml"):
+                shutil.copyfile(ROOT / relative, repo / relative)
+            binary = root / "bin"
+            binary.mkdir()
+            for name in ("file", "ldd", "nm", "patchelf", "sha256sum", "tar"):
+                stub = binary / name
+                stub.write_text("#!/bin/sh\nexit 0\n")
+                stub.chmod(0o755)
+            cargo = binary / "cargo"
+            cargo.write_text(f"#!{sys.executable}\n" + '''import json, os, pathlib, sys
+target = pathlib.Path(sys.argv[sys.argv.index("--target-dir") + 1])
+(target / "release").mkdir(parents=True, exist_ok=True)
+(target / "release/libkapsl_backend_llama_cpp.so").write_bytes(b"fixture")
+with open(os.environ["CARGO_FIXTURE_LOG"], "a") as stream:
+    stream.write(json.dumps({"args": sys.argv[1:], "pic": os.environ.get("CMAKE_POSITION_INDEPENDENT_CODE")}) + "\\n")
+''')
+            cargo.chmod(0o755)
+            scratch = root / "scratch"
+            scratch.mkdir()
+            cache = root / "cache"
+            log = root / "cargo.jsonl"
+            values = os.environ | {
+                "PATH": str(binary) + os.pathsep + os.environ["PATH"],
+                "RUNNER_OS": "Linux", "RUNNER_ARCH": "X64", "RUNNER_TEMP": str(scratch),
+                "KAPSL_VERSION": "0.2.7", "KAPSL_LLAMA_BUILD_ONLY": "true",
+                "KAPSL_LLAMA_TARGET_ROOT": str(cache), "CARGO_FIXTURE_LOG": str(log),
+                "KAPSL_LLAMA_CPU_LIBRARY": "", "KAPSL_LLAMA_CUDA_LIBRARY": "",
+            }
+            for profile in ("cpu", "cuda12"):
+                result = subprocess.run(["bash", ".github/scripts/package-linux-llama-cpp-backend-packs.sh"],
+                                        cwd=repo, env=values | {"KAPSL_LLAMA_PACK_PROFILE": profile},
+                                        capture_output=True, text=True, check=False)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertTrue((cache / profile / "release/libkapsl_backend_llama_cpp.so").is_file())
+                self.assertEqual(list(scratch.iterdir()), [])
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            self.assertEqual(len(calls), 2)
+            for call in calls:
+                self.assertIn("--locked", call["args"])
+                self.assertEqual(call["pic"], "ON")
+            self.assertIn("cuda12-shared-pool", calls[1]["args"])
+            self.assertEqual(list((repo / "dist").iterdir()), [])
+
+
+class WorkflowTests(TestCase):
+    def test_all_expensive_stable_builds_wait_for_authentication(self):
+        source = workflow("release-runtime-installers")
+        for name in ("build-runtime-installers", "build-cuda-runtime", "stable-release-cpu-conformance"):
+            block = job(source, name)
+            self.assertIn("needs: [prepare-version, stable-release-infrastructure-preflight]", block)
+            if name.startswith("build-"):
+                self.assertIn("!cancelled()", block)
+                self.assertIn("needs.prepare-version.result == 'success'", block)
+                self.assertIn("needs.stable-release-infrastructure-preflight.result == 'success'", block)
+        for name in ("stable-release-infrastructure-preflight", "stable-release-gpu-conformance"):
+            self.assertIn("secrets: inherit", job(source, name))
+        self.assertIn("INFRASTRUCTURE_RESULT", job(source, "release-conformance-gate"))
+        self.assertIn("if: always()", job(source, "release-conformance-gate"))
+
+    def test_live_preflight_is_main_only_and_cannot_provision(self):
+        source = workflow("release-preflight")
+        for name in ("live-infrastructure-preflight", "live-signing-preflight"):
+            block = job(source, name)
+            self.assertIn("github.ref == 'refs/heads/main'", block)
+            self.assertIn("github.event_name == 'push' || github.event_name == 'workflow_dispatch'", block)
+        self.assertNotIn("secrets.", job(source, "ort-release-preflight"))
+        infrastructure = workflow("release-infrastructure-preflight")
+        self.assertIn("environment: gcp-gpu-conformance", infrastructure)
+        self.assertIn("permission-administration: write", infrastructure)
+        self.assertIn("actions/runners?per_page=1", infrastructure)
+        for forbidden in ("generate-jitconfig", " provision", "gcloud compute instances create",
+                          "gcp_ephemeral_gpu_runner.py", "runs-on: [self-hosted"):
+            self.assertNotIn(forbidden, infrastructure)
+
+    def test_parallel_builds_are_host_only_and_preserve_retryable_artifacts(self):
+        source = workflow("build-linux-accelerators")
+        block = job(source, "components")
+        self.assertIn("needs: prepare", block)
+        self.assertIn("matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}", block)
+        self.assertIn("fail-fast: false", block)
+        self.assertNotIn("cargo clean", source)
+        self.assertNotIn("package-linux-onnx-backend-packs.sh", source)
+        self.assertNotIn("gpu-device-pool-integration.yml", source)
+        self.assertNotIn("id-token: write", source)
+        self.assertIn("build-cuda-${{ matrix.component }}-${{ github.sha }}", block)
+        assemble_job = job(source, "assemble")
+        self.assertIn("needs: [prepare, components]", assemble_job)
+        self.assertIn("pattern: build-cuda-*-${{ github.sha }}", assemble_job)
+        self.assertIn("merge-multiple: false", assemble_job)
+        self.assertIn("name: runtime-cuda-linux-x86_64", assemble_job)
+        for caller in ("release-runtime-installers", "beta-runtime-installers"):
+            caller_source = workflow(caller)
+            self.assertIn("uses: ./.github/workflows/build-linux-accelerators.yml", job(caller_source, "build-cuda-runtime"))
+            self.assertNotIn("cache_only:", job(caller_source, "build-cuda-runtime"))
+            self.assertIn("preflight_release_environment.py --signing --sdk", job(caller_source, "prepare-version"))
+            self.assertEqual(caller_source.count("pattern: runtime-*"),
+                             caller_source.count("name: Download installer artifacts"))
+
+    def test_cache_warming_does_not_publish_or_qualify(self):
+        block = job(workflow("release-build-cache"), "warm")
+        self.assertIn("github.ref == 'refs/heads/main'", block)
+        self.assertIn("cache_only: true", block)
+        self.assertNotIn("KAPSL_BACKEND_SIGNING_KEY", block)
+        cache = (ROOT / ".github/actions/cache-rust-build/action.yml").read_text()
+        self.assertIn("default: kapsl-runtime -> target", cache)
+        self.assertIn("save-if: ${{ github.event_name != 'pull_request' }}", cache)
+        self.assertNotIn("PRIVATE_KEY", cache)
+
+    def test_ci_only_changes_do_not_automatically_build_betas(self):
+        source = workflow("beta-runtime-installers")
+        paths = source.split("    paths:\n", 1)[1].split("\npermissions:", 1)[0]
+        patterns = re.findall(r'^      - "([^"]+)"', paths, re.MULTILINE)
+        for path in ("kapsl-runtime/crates/kapsl-cli/src/main.rs", "rust-toolchain.toml",
+                     "installers/install.sh", ".github/scripts/package-linux-cuda-runtime.sh"):
+            self.assertTrue(any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns), path)
+        for path in (".github/workflows/gpu-device-pool-integration.yml",
+                     ".github/scripts/preflight_release_environment.py", "docs/architecture.md"):
+            self.assertFalse(any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns), path)
+        self.assertIn("workflow_dispatch:", source)
+        self.assertIn("if: github.ref == 'refs/heads/develop'", source)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -1,9 +1,27 @@
 name: Beta Runtime Installers
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop
+    # CI/authentication-only changes use host-only checks. Full beta packaging
+    # remains available deliberately through workflow_dispatch on develop.
+    paths:
+      - "kapsl-runtime/**"
+      - "rust-toolchain.toml"
+      - ".cargo/**"
+      - "installers/**"
+      - ".github/licenses/**"
+      - ".github/ort*.lock*"
+      - ".github/ort-release-public-key.txt"
+      - ".github/scripts/package-*"
+      - ".github/scripts/collect-*"
+      - ".github/scripts/bootstrap-vllm-backend.sh"
+      - ".github/scripts/managed-vllm-cu130.lock"
+      - ".github/scripts/generate-backend-index.py"
+      - "LICENSE"
+      - "NOTICE"
 
 permissions:
   contents: write
@@ -25,6 +43,7 @@ env:
 jobs:
   prepare-version:
     name: Resolve beta version
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -61,6 +80,16 @@ jobs:
           echo "numeric_version=$numeric_version" >> "$GITHUB_OUTPUT"
           echo "deb_version=$deb_version" >> "$GITHUB_OUTPUT"
 
+      - name: Validate signing and publication configuration before builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}
+          KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
+          KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: python3 .github/scripts/preflight_release_environment.py --signing --sdk
+
   build-runtime-installers:
     name: Build runtime installer (${{ matrix.os }})
     needs: prepare-version
@@ -70,6 +99,8 @@ jobs:
       KAPSL_NUMERIC_VERSION: ${{ needs.prepare-version.outputs.numeric_version }}
       KAPSL_DEB_VERSION: ${{ needs.prepare-version.outputs.deb_version }}
       KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
+      RUSTFLAGS: ${{ matrix.os == 'windows-latest' && '-C debuginfo=0 -C link-arg=/DEBUG:NONE' || '' }}
+      CARGO_INCREMENTAL: "0"
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +115,11 @@ jobs:
 
       - name: Install Rust
         uses: ./.github/actions/setup-rust
+
+      - name: Cache release compiler dependencies
+        uses: ./.github/actions/cache-rust-build
+        with:
+          key: release-portable-${{ matrix.os }}
 
       - name: Set up Python for accelerator dependency collection
         if: runner.os == 'Windows'
@@ -287,150 +323,15 @@ jobs:
   build-cuda-runtime:
     name: Build CUDA runtime (linux-x86_64)
     needs: prepare-version
-    runs-on: ubuntu-22.04
-    container:
-      # Match the stable release: this image supplies the CUDA/cuDNN libraries
-      # folded into the one GGUF + ONNX accelerator archive.
-      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
-    env:
-      CARGO_BUILD_JOBS: "2"
-      CMAKE_BUILD_PARALLEL_LEVEL: "2"
-      CUDA_PATH: /usr/local/cuda
-      KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE
-      KAPSL_VERSION: ${{ needs.prepare-version.outputs.version }}
+    uses: ./.github/workflows/build-linux-accelerators.yml
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+      channel: beta
+      stable_release: false
+      sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
+    secrets:
       KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
-      KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}
-      LIBRARY_PATH: /usr/local/cuda/lib64/stubs:/usr/local/cuda/targets/x86_64-linux/lib/stubs
-    steps:
-      - name: Install CUDA build dependencies
-        run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            binutils build-essential ca-certificates clang cmake curl file git libclang-dev libssl-dev openssl patchelf pkg-config python3 python3-pip
-          rm -rf /var/lib/apt/lists/*
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve certified ORT integrations commit
-        id: ort-integrations
-        shell: bash
-        run: |
-          set -euo pipefail
-          ref="$(tr -d '\r\n' < .github/ort-integration.lock)"
-          if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
-            echo ".github/ort-integration.lock must contain one exact lowercase 40-hex commit." >&2
-            exit 1
-          fi
-          echo "KAPSL_ORT_INTEGRATIONS_REF=$ref" >> "$GITHUB_ENV"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout certified ORT adapter
-        uses: actions/checkout@v4
-        with:
-          repository: kapsl-runtime/kapsl-integrations
-          ref: ${{ steps.ort-integrations.outputs.ref }}
-          path: kapsl-integrations-ort
-
-      - name: Verify certified ORT integrations checkout
-        shell: bash
-        run: .github/scripts/verify-ort-integration-checkout.sh kapsl-integrations-ort "$KAPSL_ORT_INTEGRATIONS_REF"
-
-      - name: Validate certified vLLM SDK commit
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "$KAPSL_VLLM_SDK_REF" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Protected KAPSL_VLLM_SDK_REF must be an exact lowercase 40-hex commit." >&2
-            exit 1
-          fi
-
-      - name: Checkout certified vLLM connector
-        uses: actions/checkout@v4
-        with:
-          repository: kapsl-runtime/kapsl-sdk
-          ref: ${{ env.KAPSL_VLLM_SDK_REF }}
-          path: sdk-vllm
-
-      - name: Verify certified vLLM SDK checkout
-        shell: bash
-        run: .github/scripts/verify-managed-vllm-sdk-checkout.sh sdk-vllm "$KAPSL_VLLM_SDK_REF"
-
-      - name: Install Rust
-        uses: ./.github/actions/setup-rust
-
-      - name: Install certified ORT packaging toolchain
-        shell: bash
-        run: |
-          set -euo pipefail
-          toolchain="$(sed -nE 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' kapsl-integrations-ort/rust-toolchain.toml | head -n 1)"
-          rustup toolchain install "$toolchain" --profile minimal
-
-      - name: Build kapsl with statically compiled GGUF CUDA
-        run: cargo build --manifest-path kapsl-runtime/Cargo.toml --locked -p kapsl --release --no-default-features --features cuda
-
-      - name: Collect ONNX Runtime sidecars
-        shell: bash
-        run: .github/scripts/collect-ort-sidecars.sh
-
-      - name: Collect TensorRT 10 user-space runtime
-        shell: bash
-        run: .github/scripts/collect-linux-tensorrt-runtime.sh
-
-      - name: Package CUDA runtime bundle
-        shell: bash
-        run: .github/scripts/package-linux-cuda-runtime.sh
-
-      - name: Package certified ORT CPU adapter
-        shell: bash
-        run: .github/scripts/package-linux-ort-cpu-backend.sh
-
-      - name: Package llama.cpp backend packs from published SDK crates
-        shell: bash
-        run: .github/scripts/package-linux-llama-cpp-backend-packs.sh
-
-      - name: Reclaim CUDA build scratch before backend packaging
-        shell: bash
-        run: cargo clean --manifest-path kapsl-runtime/Cargo.toml
-
-      - name: Package certified managed-vLLM backend
-        shell: bash
-        env:
-          KAPSL_VLLM_SDK_DIR: sdk-vllm
-        run: .github/scripts/package-linux-vllm-backend.sh
-
-      - name: Generate signed backend index
-        shell: bash
-        env:
-          KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
-        run: |
-          set -euo pipefail
-          if [ -z "$KAPSL_BACKEND_SIGNING_KEY_B64" ] || [ -z "$KAPSL_BACKEND_PUBLIC_KEYS" ]; then
-            echo "Backend signing key and embedded public key are required." >&2
-            exit 1
-          fi
-          key_file="${RUNNER_TEMP}/kapsl-backend-signing-key.pem"
-          printf '%s' "$KAPSL_BACKEND_SIGNING_KEY_B64" | base64 --decode > "$key_file"
-          chmod 600 "$key_file"
-          trap 'rm -f "$key_file"' EXIT
-          .github/scripts/generate-backend-index.py \
-            --version "$KAPSL_VERSION" \
-            --artifacts-dir dist \
-            --output dist/backend-index.json \
-            --signing-key "$key_file" \
-            --expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS" \
-            --channel beta
-          rm -f "$key_file" dist/*.manifest.json
-          trap - EXIT
-
-      - name: Upload CUDA runtime artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: runtime-cuda-linux-x86_64
-          path: dist/*
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 1
+      KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
 
   publish-beta-release:
     needs: [prepare-version, build-runtime-installers, build-cuda-runtime]
@@ -442,6 +343,7 @@ jobs:
       - name: Download installer artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: runtime-*
           path: release-assets
           merge-multiple: true
 

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -385,10 +385,6 @@ jobs:
         shell: bash
         run: .github/scripts/package-linux-ort-cpu-backend.sh
 
-      - name: Package legacy ONNX accelerator packs
-        shell: bash
-        run: .github/scripts/package-linux-onnx-backend-packs.sh
-
       - name: Package llama.cpp backend packs from published SDK crates
         shell: bash
         run: .github/scripts/package-linux-llama-cpp-backend-packs.sh

--- a/.github/workflows/build-linux-accelerators.yml
+++ b/.github/workflows/build-linux-accelerators.yml
@@ -1,0 +1,247 @@
+name: Build Linux accelerator artifacts (host only)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: false
+        default: ""
+      channel:
+        type: string
+        required: false
+        default: stable
+      stable_release:
+        type: boolean
+        required: false
+        default: false
+      cache_only:
+        type: boolean
+        required: false
+        default: false
+      sdk_ref:
+        type: string
+        required: false
+        default: ""
+    secrets:
+      KAPSL_BACKEND_PUBLIC_KEYS:
+        required: true
+      KAPSL_BACKEND_SIGNING_KEY_B64:
+        required: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.inputs.outputs.version }}
+      matrix: ${{ steps.inputs.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Validate build inputs and select independent components
+        id: inputs
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
+          STABLE_RELEASE: ${{ inputs.stable_release }}
+          CACHE_ONLY: ${{ inputs.cache_only }}
+          KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+        run: python3 .github/scripts/release_build_inputs.py
+
+      - name: Verify certified SDK availability before fan-out
+        if: '!inputs.cache_only'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+        run: python3 .github/scripts/preflight_release_environment.py --sdk
+
+  components:
+    name: Build ${{ matrix.component }}
+    needs: prepare
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    container:
+      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
+    env:
+      CARGO_BUILD_JOBS: "2"
+      CMAKE_BUILD_PARALLEL_LEVEL: "2"
+      CUDA_PATH: /usr/local/cuda
+      KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE
+      KAPSL_VERSION: ${{ needs.prepare.outputs.version }}
+      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
+      KAPSL_VLLM_SDK_REF: ${{ inputs.sdk_ref }}
+      LIBRARY_PATH: /usr/local/cuda/lib64/stubs:/usr/local/cuda/targets/x86_64-linux/lib/stubs
+    steps:
+      - name: Install CUDA build dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            binutils build-essential ca-certificates clang cmake curl file git libclang-dev libssl-dev openssl patchelf pkg-config python3 python3-pip
+          rm -rf /var/lib/apt/lists/*
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust
+        if: matrix.component != 'vllm'
+        uses: ./.github/actions/setup-rust
+
+      - name: Cache engine and native backend dependencies
+        if: matrix.component == 'engine' || startsWith(matrix.component, 'llama-')
+        uses: ./.github/actions/cache-rust-build
+        with:
+          key: release-linux-x86_64-cuda1263-ubuntu2204-${{ matrix.component }}
+          workspaces: kapsl-runtime -> ${{ matrix.target }}
+
+      - name: Build kapsl with statically compiled GGUF CUDA
+        if: matrix.component == 'engine'
+        run: cargo build --manifest-path kapsl-runtime/Cargo.toml --locked -p kapsl --release --no-default-features --features cuda
+
+      - name: Collect ONNX Runtime sidecars
+        if: matrix.component == 'engine' && !inputs.cache_only
+        run: .github/scripts/collect-ort-sidecars.sh
+
+      - name: Collect TensorRT 10 user-space runtime
+        if: matrix.component == 'engine' && !inputs.cache_only
+        run: .github/scripts/collect-linux-tensorrt-runtime.sh
+
+      - name: Package CUDA runtime bundle
+        if: matrix.component == 'engine' && !inputs.cache_only
+        run: .github/scripts/package-linux-cuda-runtime.sh
+
+      - name: Package llama.cpp backend packs from published SDK crates
+        if: startsWith(matrix.component, 'llama-')
+        env:
+          KAPSL_LLAMA_PACK_PROFILE: ${{ matrix.profile }}
+          KAPSL_LLAMA_TARGET_ROOT: ${{ github.workspace }}/kapsl-runtime/target-llama
+          KAPSL_LLAMA_BUILD_ONLY: ${{ inputs.cache_only }}
+          CMAKE_POSITION_INDEPENDENT_CODE: "ON"
+        run: .github/scripts/package-linux-llama-cpp-backend-packs.sh
+
+      - name: Checkout certified vLLM connector
+        if: matrix.component == 'vllm'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: kapsl-runtime/kapsl-sdk
+          ref: ${{ env.KAPSL_VLLM_SDK_REF }}
+          path: sdk-vllm
+
+      - name: Verify certified vLLM SDK checkout
+        if: matrix.component == 'vllm'
+        run: .github/scripts/verify-managed-vllm-sdk-checkout.sh sdk-vllm "$KAPSL_VLLM_SDK_REF"
+
+      - name: Package certified managed-vLLM backend
+        if: matrix.component == 'vllm'
+        env:
+          KAPSL_VLLM_SDK_DIR: sdk-vllm
+        run: .github/scripts/package-linux-vllm-backend.sh
+
+      - name: Resolve certified ORT integrations commit
+        if: matrix.component == 'ort-cpu'
+        id: ort-integrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          ref="$(tr -d '\r\n' < .github/ort-integration.lock)"
+          [[ "$ref" =~ ^[0-9a-f]{40}$ ]]
+          echo "KAPSL_ORT_INTEGRATIONS_REF=$ref" >> "$GITHUB_ENV"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout certified ORT adapter
+        if: matrix.component == 'ort-cpu'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: kapsl-runtime/kapsl-integrations
+          ref: ${{ steps.ort-integrations.outputs.ref }}
+          path: kapsl-integrations-ort
+
+      - name: Verify certified ORT integrations checkout
+        if: matrix.component == 'ort-cpu'
+        run: .github/scripts/verify-ort-integration-checkout.sh kapsl-integrations-ort "$KAPSL_ORT_INTEGRATIONS_REF"
+
+      - name: Install certified ORT packaging toolchain
+        if: matrix.component == 'ort-cpu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -nE 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' kapsl-integrations-ort/rust-toolchain.toml | head -n 1)"
+          rustup toolchain install "$toolchain" --profile minimal
+
+      - name: Package certified ORT CPU adapter
+        if: matrix.component == 'ort-cpu'
+        run: .github/scripts/package-linux-ort-cpu-backend.sh
+
+      - name: Upload independently retryable build component
+        if: '!inputs.cache_only'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: build-cuda-${{ matrix.component }}-${{ github.sha }}
+          path: dist/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: ${{ inputs.stable_release && 7 || 1 }}
+          overwrite: true
+
+  assemble:
+    name: Assemble and sign the CUDA release candidate
+    needs: [prepare, components]
+    if: '!inputs.cache_only'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      KAPSL_VERSION: ${{ needs.prepare.outputs.version }}
+      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Download only this run's component artifacts for this commit
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-cuda-*-${{ github.sha }}
+          path: release-parts
+          merge-multiple: false
+
+      - name: Verify component set and assemble without duplicate filenames
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          STABLE_RELEASE: ${{ inputs.stable_release }}
+        run: python3 .github/scripts/release_build_inputs.py --assemble release-parts --output dist
+
+      - name: Import immutable signed ORT backend packs
+        if: inputs.stable_release
+        run: |
+          python3 .github/scripts/import-signed-backend-release.py \
+            --version "$KAPSL_VERSION" --lock .github/ort-release.lock.json \
+            --artifacts-dir dist --expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS"
+
+      - name: Generate signed backend index
+        env:
+          KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
+          RELEASE_CHANNEL: ${{ inputs.channel }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          key_file="${RUNNER_TEMP}/kapsl-backend-signing-key.pem"
+          trap 'rm -f "$key_file"' EXIT
+          umask 077
+          printf '%s' "$KAPSL_BACKEND_SIGNING_KEY_B64" | base64 --decode > "$key_file"
+          python3 .github/scripts/generate-backend-index.py \
+            --version "$KAPSL_VERSION" --artifacts-dir dist --output dist/backend-index.json \
+            --signing-key "$key_file" --expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS" \
+            --channel "$RELEASE_CHANNEL"
+          rm -f dist/*.manifest.json
+
+      - name: Upload CUDA runtime artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runtime-cuda-linux-x86_64
+          path: dist/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: ${{ inputs.stable_release && 7 || 1 }}
+          overwrite: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
           git config --global core.longpaths true
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/cache-rust-build
+        with:
+          key: ci-check-${{ matrix.os }}
 
       - name: Check runtime workspace
         if: runner.os != 'Windows'
@@ -87,9 +89,9 @@ jobs:
           msrv: true
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/cache-rust-build
         with:
-          shared-key: msrv
+          key: ci-msrv
 
       - name: Check runtime workspace on its minimum Rust version
         run: cargo check --manifest-path kapsl-runtime/Cargo.toml --workspace --locked
@@ -121,7 +123,9 @@ jobs:
           git config --global core.longpaths true
 
       - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/cache-rust-build
+        with:
+          key: ci-test-${{ matrix.os }}
 
       - name: Test runtime workspace
         if: runner.os != 'Windows'

--- a/.github/workflows/gpu-device-pool-integration.yml
+++ b/.github/workflows/gpu-device-pool-integration.yml
@@ -194,6 +194,7 @@ jobs:
           private-key: ${{ secrets.GPU_RUNNER_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-administration: write
 
       - name: Create one-job JIT runner registration
         id: jit
@@ -262,7 +263,7 @@ jobs:
             --runner-id "${{ steps.jit.outputs.runner_id }}" \
             --expected-name "${{ steps.identity.outputs.runner_name }}" \
             --timeout-seconds 900 \
-            --interval-seconds 10
+            --interval-seconds 30
 
       - name: Delete a VM whose provisioning job failed
         if: failure() && steps.identity.outputs.instance_name != ''
@@ -376,6 +377,7 @@ jobs:
           private-key: ${{ secrets.GPU_RUNNER_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-administration: write
 
       - name: Remove the completed JIT runner registration
         if: needs.prepare-vllm-gcp-runner.outputs.runner_id != ''

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -59,6 +59,13 @@ on:
       - ".github/workflows/gpu-device-pool-integration.yml"
       - ".github/workflows/release-runtime-installers.yml"
       - ".github/workflows/beta-runtime-installers.yml"
+      - ".github/workflows/build-linux-accelerators.yml"
+      - ".github/workflows/release-infrastructure-preflight.yml"
+      - ".github/workflows/release-build-cache.yml"
+      - ".github/actions/cache-rust-build/**"
+      - ".github/scripts/release_build_inputs.py"
+      - ".github/scripts/preflight_release_environment.py"
+      - ".github/scripts/test_release_pipeline.py"
       - ".github/scripts/gcp_ephemeral_gpu_runner.py"
       - ".github/scripts/github_jit_runner.py"
       - ".github/scripts/validate_stable_gpu_release.py"
@@ -243,6 +250,9 @@ jobs:
 
       - name: Test ONNX backend release contract
         run: .github/scripts/test-onnx-backend-release-contract.sh
+
+      - name: Test fast release preflight, build isolation and artifact assembly
+        run: python3 .github/scripts/test_release_pipeline.py
 
       - name: Test native llama.cpp backend packs
         run: .github/scripts/test-package-linux-llama-cpp-backend-packs.sh

--- a/.github/workflows/ort-cpu-conformance.yml
+++ b/.github/workflows/ort-cpu-conformance.yml
@@ -1,7 +1,10 @@
-name: ORT CPU Conformance
+name: ORT CPU Smoke and Release Parity
 
 on:
   pull_request:
+    # Only runtime and actual pack/harness inputs need compilation. Workflow,
+    # authentication and contract-test edits are covered by host-only preflight
+    # and installer smoke checks instead, including edits to this workflow.
     paths:
       - ".github/ort-integration.lock"
       - ".github/ort-cpu-parity.lock.json"
@@ -9,24 +12,10 @@ on:
       - ".github/scripts/certify-ort-cpu-parity.sh"
       - ".github/scripts/generate-backend-index.py"
       - ".github/scripts/package-linux-ort-cpu-backend.sh"
-      - ".github/scripts/test-generate-backend-index.sh"
-      - ".github/scripts/test-onnx-backend-release-contract.sh"
-      - ".github/scripts/test-package-linux-ort-cpu-backend.sh"
-      - ".github/scripts/test-verify-ort-integration-checkout.sh"
-      - ".github/scripts/validate_stable_gpu_release.py"
       - ".github/scripts/verify-ort-integration-checkout.sh"
-      - ".github/workflows/ort-cpu-conformance.yml"
-      - "kapsl-runtime/Cargo.lock"
-      - "kapsl-runtime/Cargo.toml"
-      - "kapsl-runtime/crates/kapsl-backends/**"
-      - "kapsl-runtime/crates/kapsl-cli/Cargo.toml"
-      - "kapsl-runtime/crates/kapsl-cli/src/backend/bundle.rs"
-      - "kapsl-runtime/crates/kapsl-cli/src/backend/manager.rs"
-      - "kapsl-runtime/crates/kapsl-cli/src/backend/native.rs"
-      - "kapsl-runtime/crates/kapsl-cli/src/backend/onnx.rs"
-      - "kapsl-runtime/crates/kapsl-cli/src/http/models/**"
-      - "kapsl-runtime/crates/kapsl-cli/src/runtime/model/**"
-      - "kapsl-runtime/crates/kapsl-cli/src/runtime/serving/**"
+      - "rust-toolchain.toml"
+      - ".cargo/**"
+      - "kapsl-runtime/**"
   workflow_call:
   workflow_dispatch:
 
@@ -39,9 +28,11 @@ concurrency:
 
 jobs:
   ort-cpu-release-handoff:
-    name: ORT CPU release handoff and ${{ github.event_name == 'pull_request' && 'correctness smoke' || 'performance parity' }}
+    name: ORT CPU ${{ github.event_name == 'pull_request' && 'correctness smoke (PR)' || 'performance parity' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    env:
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout engine
         uses: actions/checkout@v4
@@ -178,7 +169,20 @@ jobs:
           toolchain="$(sed -nE 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' kapsl-integrations-ort/rust-toolchain.toml | head -n 1)"
           rustup toolchain install "$toolchain" --profile minimal
 
+      - name: Cache engine and exact ORT adapter build dependencies
+        uses: ./.github/actions/cache-rust-build
+        with:
+          key: ort-cpu-ubuntu22.04-${{ steps.release-inputs.outputs.integrations_ref }}
+          save-pr-cache: "true"
+          # Keep targets outside the verified-clean integrations checkout. Only
+          # compilation dependencies are cached, not packs, test keys or evidence.
+          workspaces: |
+            kapsl-runtime -> target
+            kapsl-integrations-ort -> ../kapsl-runtime/target-ort-cpu/target
+
       - name: Build and validate release handoff
+        env:
+          KAPSL_ORT_PACK_BUILD_DIR: ${{ github.workspace }}/kapsl-runtime/target-ort-cpu
         run: .github/scripts/package-linux-ort-cpu-backend.sh
 
       - name: Validate handoff through the signed index publisher

--- a/.github/workflows/release-build-cache.yml
+++ b/.github/workflows/release-build-cache.yml
@@ -1,0 +1,27 @@
+name: Warm release build caches (no GPU)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "kapsl-runtime/**"
+      - "rust-toolchain.toml"
+      - ".cargo/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: release-build-cache-main
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/build-linux-accelerators.yml
+    with:
+      cache_only: true
+    secrets:
+      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }} ${{ vars.KAPSL_ORT_BACKEND_PUBLIC_KEY }}

--- a/.github/workflows/release-infrastructure-preflight.yml
+++ b/.github/workflows/release-infrastructure-preflight.yml
@@ -1,0 +1,89 @@
+name: Release Infrastructure Preflight (host only)
+
+on:
+  workflow_call:
+    secrets:
+      # Environment-owned: requiring this at the caller rejects valid callers
+      # before the protected environment can supply it.
+      GPU_RUNNER_GITHUB_APP_PRIVATE_KEY:
+        required: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  infrastructure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: gcp-gpu-conformance
+    env:
+      GCP_GPU_PROJECT_ID: ${{ vars.GCP_GPU_PROJECT_ID }}
+      GCP_GPU_ZONE: ${{ vars.GCP_GPU_ZONE }}
+      GCP_GPU_RUNNER_IMAGE: ${{ vars.GCP_GPU_RUNNER_IMAGE }}
+      GCP_GPU_SUBNET: ${{ vars.GCP_GPU_SUBNET }}
+      GCP_GPU_EXTERNAL_IP: ${{ vars.GCP_GPU_EXTERNAL_IP }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_GPU_PROVISIONER_SERVICE_ACCOUNT: ${{ vars.GCP_GPU_PROVISIONER_SERVICE_ACCOUNT }}
+      GCP_GPU_RUNNER_GROUP_ID: ${{ vars.GCP_GPU_RUNNER_GROUP_ID }}
+      GPU_RUNNER_GITHUB_APP_ID: ${{ vars.GPU_RUNNER_GITHUB_APP_ID }}
+      KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Validate configuration without revealing credentials
+        env:
+          GPU_RUNNER_GITHUB_APP_PRIVATE_KEY: ${{ secrets.GPU_RUNNER_GITHUB_APP_PRIVATE_KEY }}
+        run: python3 .github/scripts/preflight_release_environment.py --gpu
+
+      - name: Validate GitHub App authentication and administration grant
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ env.GPU_RUNNER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GPU_RUNNER_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-administration: write
+
+      - name: Verify runner API access without registering a runner
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh api "repos/$GITHUB_REPOSITORY/actions/runners?per_page=1" --jq .total_count
+
+      - name: Verify the exact certified SDK commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/preflight_release_environment.py --sdk
+
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ env.GCP_GPU_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_GPU_PROVISIONER_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Verify GCE zone, immutable image and subnet (read only)
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud compute zones describe "$GCP_GPU_ZONE" \
+            --project "$GCP_GPU_PROJECT_ID" --format='value(name)' | grep -Fx "$GCP_GPU_ZONE"
+          image_ref=${GCP_GPU_RUNNER_IMAGE#https://www.googleapis.com/compute/v1/}
+          image_project=${image_ref#projects/}
+          image_project=${image_project%%/*}
+          gcloud compute images describe "${image_ref##*/}" \
+            --project "$image_project" --format='value(status)' | grep -Fx READY
+          if [[ -n "$GCP_GPU_SUBNET" ]]; then
+            subnet_ref=${GCP_GPU_SUBNET#https://www.googleapis.com/compute/v1/}
+            if [[ ! "$subnet_ref" =~ ^projects/([^/]+)/regions/([^/]+)/subnetworks/([^/]+)$ ]]; then
+              echo "GCP_GPU_SUBNET must be a project/region-qualified subnet." >&2
+              exit 1
+            fi
+            gcloud compute networks subnets describe "${BASH_REMATCH[3]}" \
+              --project "${BASH_REMATCH[1]}" --region "${BASH_REMATCH[2]}" --format='value(name)'
+          fi
+
+      - name: Record preflight scope
+        run: echo "Authentication and read access passed; no VM, disk, firewall or JIT registration was created." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -24,5 +24,36 @@ jobs:
         run: |
           python3 .github/scripts/test_import_signed_backend_release.py
           python3 .github/scripts/test_preflight_ort_release.py
+          python3 .github/scripts/test_release_pipeline.py
       - name: Verify published ORT metadata, signatures, compatibility and availability
         run: python3 .github/scripts/preflight-ort-release.py
+
+  live-infrastructure-preflight:
+    name: Live authentication readiness (main only, no GPU)
+    needs: ort-release-preflight
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release-infrastructure-preflight.yml
+    secrets: inherit
+
+  live-signing-preflight:
+    name: Live signing readiness (main only)
+    needs: ort-release-preflight
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Validate release signer and publication settings without uploading
+        env:
+          KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }} ${{ vars.KAPSL_ORT_BACKEND_PUBLIC_KEY }}
+          KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: python3 .github/scripts/preflight_release_environment.py --signing

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -529,11 +529,6 @@ jobs:
         shell: bash
         run: .github/scripts/package-linux-ort-cpu-backend.sh
 
-      - name: Package legacy ONNX accelerator packs
-        if: needs.prepare-version.outputs.is_stable_release != 'true'
-        shell: bash
-        run: .github/scripts/package-linux-onnx-backend-packs.sh
-
       - name: Package llama.cpp backend packs from published SDK crates
         shell: bash
         run: .github/scripts/package-linux-llama-cpp-backend-packs.sh

--- a/.github/workflows/release-runtime-installers.yml
+++ b/.github/workflows/release-runtime-installers.yml
@@ -50,6 +50,10 @@ jobs:
             fi
             is_release=true
             if [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+              if [[ "$GITHUB_EVENT_NAME" != "push" ]]; then
+                echo "Official stable releases require their original tag-push event." >&2
+                exit 1
+              fi
               is_stable_release=true
             fi
           else
@@ -73,6 +77,25 @@ jobs:
         if: steps.version.outputs.is_stable_release == 'true'
         run: python3 .github/scripts/preflight-ort-release.py --require-runtime-trust
 
+      - name: Validate signing and publication configuration before builds
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}
+          KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: python3 .github/scripts/preflight_release_environment.py --signing --sdk
+
+  stable-release-infrastructure-preflight:
+    name: Authenticate release infrastructure before builds (no GPU)
+    needs: prepare-version
+    if: needs.prepare-version.outputs.is_stable_release == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/release-infrastructure-preflight.yml
+    secrets: inherit
+
   publish-docker:
     name: Publish Docker images after qualified installers
     needs: [prepare-version, upload-release-assets, upload-r2]
@@ -88,7 +111,7 @@ jobs:
 
   stable-release-cpu-conformance:
     name: Stable release CPU performance parity
-    needs: prepare-version
+    needs: [prepare-version, stable-release-infrastructure-preflight]
     if: needs.prepare-version.outputs.is_stable_release == 'true'
     uses: ./.github/workflows/ort-cpu-conformance.yml
 
@@ -108,13 +131,15 @@ jobs:
       candidate_artifact: runtime-cuda-linux-x86_64
       sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
       cuda_visible_devices: "0"
-    secrets:
-      KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }}
+    # Keep the App key environment-owned and optional in workflow_call. Secret
+    # inheritance is also needed for environment-secret resolution by runners.
+    secrets: inherit
 
   release-conformance-gate:
     name: Gate publication on stable conformance and teardown
     needs:
       - prepare-version
+      - stable-release-infrastructure-preflight
       - stable-release-cpu-conformance
       - stable-release-gpu-conformance
     if: always()
@@ -125,6 +150,7 @@ jobs:
         env:
           PREPARE_RESULT: ${{ needs.prepare-version.result }}
           IS_STABLE_RELEASE: ${{ needs.prepare-version.outputs.is_stable_release }}
+          INFRASTRUCTURE_RESULT: ${{ needs.stable-release-infrastructure-preflight.result }}
           CPU_CONFORMANCE_RESULT: ${{ needs.stable-release-cpu-conformance.result }}
           GPU_CONFORMANCE_AND_TEARDOWN_RESULT: ${{ needs.stable-release-gpu-conformance.result }}
         run: |
@@ -134,6 +160,10 @@ jobs:
             exit 1
           fi
           if [[ "$IS_STABLE_RELEASE" == "true" ]]; then
+            if [[ "$INFRASTRUCTURE_RESULT" != "success" ]]; then
+              echo "Stable release infrastructure authentication did not succeed." >&2
+              exit 1
+            fi
             if [[ "$CPU_CONFORMANCE_RESULT" != "success" ]]; then
               echo "Stable CPU performance parity did not succeed." >&2
               exit 1
@@ -151,12 +181,18 @@ jobs:
 
   build-runtime-installers:
     name: Build runtime installer (${{ matrix.os }})
-    needs: prepare-version
+    needs: [prepare-version, stable-release-infrastructure-preflight]
+    if: >-
+      !cancelled() && needs.prepare-version.result == 'success' &&
+      (needs.prepare-version.outputs.is_stable_release != 'true' ||
+      needs.stable-release-infrastructure-preflight.result == 'success')
     runs-on: ${{ matrix.os }}
     env:
       KAPSL_VERSION: ${{ needs.prepare-version.outputs.version }}
       KAPSL_NUMERIC_VERSION: ${{ needs.prepare-version.outputs.numeric_version }}
       KAPSL_DEB_VERSION: ${{ needs.prepare-version.outputs.deb_version }}
+      RUSTFLAGS: ${{ matrix.os == 'windows-latest' && '-C debuginfo=0 -C link-arg=/DEBUG:NONE' || '' }}
+      CARGO_INCREMENTAL: "0"
     strategy:
       fail-fast: false
       matrix:
@@ -172,6 +208,11 @@ jobs:
 
       - name: Install Rust
         uses: ./.github/actions/setup-rust
+
+      - name: Cache release compiler dependencies
+        uses: ./.github/actions/cache-rust-build
+        with:
+          key: release-portable-${{ matrix.os }}
 
       - name: Set up Python for accelerator dependency collection
         if: runner.os == 'Windows'
@@ -424,166 +465,20 @@ jobs:
 
   build-cuda-runtime:
     name: Build CUDA runtime (linux-x86_64)
-    needs: prepare-version
-    runs-on: ubuntu-22.04
-    container:
-      # The CUDA archive carries the complete GGUF + ONNX GPU runtime, like a
-      # Triton GPU image. Use the cuDNN build image so the packager can collect
-      # every user-space library; only the NVIDIA driver stays host-provided.
-      image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
-    env:
-      CARGO_BUILD_JOBS: "2"
-      CMAKE_BUILD_PARALLEL_LEVEL: "2"
-      CUDA_PATH: /usr/local/cuda
-      KAPSL_NVIDIA_LICENSE_FILE: /NGC-DL-CONTAINER-LICENSE
-      KAPSL_VERSION: ${{ needs.prepare-version.outputs.version }}
+    needs: [prepare-version, stable-release-infrastructure-preflight]
+    if: >-
+      !cancelled() && needs.prepare-version.result == 'success' &&
+      (needs.prepare-version.outputs.is_stable_release != 'true' ||
+      needs.stable-release-infrastructure-preflight.result == 'success')
+    uses: ./.github/workflows/build-linux-accelerators.yml
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+      channel: stable
+      stable_release: ${{ needs.prepare-version.outputs.is_stable_release == 'true' }}
+      sdk_ref: ${{ vars.KAPSL_VLLM_SDK_REF }}
+    secrets:
       KAPSL_BACKEND_PUBLIC_KEYS: ${{ secrets.KAPSL_BACKEND_PUBLIC_KEYS }} ${{ vars.KAPSL_ORT_BACKEND_PUBLIC_KEY }}
-      KAPSL_VLLM_SDK_REF: ${{ vars.KAPSL_VLLM_SDK_REF }}
-      LIBRARY_PATH: /usr/local/cuda/lib64/stubs:/usr/local/cuda/targets/x86_64-linux/lib/stubs
-    steps:
-      - name: Install CUDA build dependencies
-        run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            binutils build-essential ca-certificates clang cmake curl file git libclang-dev libssl-dev openssl patchelf pkg-config python3 python3-pip
-          rm -rf /var/lib/apt/lists/*
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve certified ORT integrations commit
-        if: needs.prepare-version.outputs.is_stable_release != 'true'
-        id: ort-integrations
-        shell: bash
-        run: |
-          set -euo pipefail
-          ref="$(tr -d '\r\n' < .github/ort-integration.lock)"
-          if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
-            echo ".github/ort-integration.lock must contain one exact lowercase 40-hex commit." >&2
-            exit 1
-          fi
-          echo "KAPSL_ORT_INTEGRATIONS_REF=$ref" >> "$GITHUB_ENV"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout certified ORT adapter
-        if: needs.prepare-version.outputs.is_stable_release != 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: kapsl-runtime/kapsl-integrations
-          ref: ${{ steps.ort-integrations.outputs.ref }}
-          path: kapsl-integrations-ort
-
-      - name: Verify certified ORT integrations checkout
-        if: needs.prepare-version.outputs.is_stable_release != 'true'
-        shell: bash
-        run: .github/scripts/verify-ort-integration-checkout.sh kapsl-integrations-ort "$KAPSL_ORT_INTEGRATIONS_REF"
-
-      - name: Validate certified vLLM SDK commit
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "$KAPSL_VLLM_SDK_REF" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Protected KAPSL_VLLM_SDK_REF must be an exact lowercase 40-hex commit." >&2
-            exit 1
-          fi
-
-      - name: Checkout certified vLLM connector
-        uses: actions/checkout@v4
-        with:
-          repository: kapsl-runtime/kapsl-sdk
-          ref: ${{ env.KAPSL_VLLM_SDK_REF }}
-          path: sdk-vllm
-
-      - name: Verify certified vLLM SDK checkout
-        shell: bash
-        run: .github/scripts/verify-managed-vllm-sdk-checkout.sh sdk-vllm "$KAPSL_VLLM_SDK_REF"
-
-      - name: Install Rust
-        uses: ./.github/actions/setup-rust
-
-      - name: Install certified ORT packaging toolchain
-        if: needs.prepare-version.outputs.is_stable_release != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          toolchain="$(sed -nE 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' kapsl-integrations-ort/rust-toolchain.toml | head -n 1)"
-          rustup toolchain install "$toolchain" --profile minimal
-
-      - name: Build kapsl with statically compiled GGUF CUDA
-        run: cargo build --manifest-path kapsl-runtime/Cargo.toml --locked -p kapsl --release --no-default-features --features cuda
-
-      - name: Collect ONNX Runtime sidecars
-        shell: bash
-        run: .github/scripts/collect-ort-sidecars.sh
-
-      - name: Collect TensorRT 10 user-space runtime
-        shell: bash
-        run: .github/scripts/collect-linux-tensorrt-runtime.sh
-
-      - name: Package CUDA runtime bundle
-        shell: bash
-        run: .github/scripts/package-linux-cuda-runtime.sh
-
-      - name: Package certified ORT CPU adapter
-        if: needs.prepare-version.outputs.is_stable_release != 'true'
-        shell: bash
-        run: .github/scripts/package-linux-ort-cpu-backend.sh
-
-      - name: Package llama.cpp backend packs from published SDK crates
-        shell: bash
-        run: .github/scripts/package-linux-llama-cpp-backend-packs.sh
-
-      - name: Reclaim CUDA build scratch before backend packaging
-        shell: bash
-        run: cargo clean --manifest-path kapsl-runtime/Cargo.toml
-
-      - name: Package certified managed-vLLM backend
-        shell: bash
-        env:
-          KAPSL_VLLM_SDK_DIR: sdk-vllm
-        run: .github/scripts/package-linux-vllm-backend.sh
-
-      - name: Import immutable signed ORT backend packs
-        if: needs.prepare-version.outputs.is_stable_release == 'true'
-        shell: bash
-        run: |
-          .github/scripts/import-signed-backend-release.py \
-            --version "$KAPSL_VERSION" \
-            --lock .github/ort-release.lock.json \
-            --artifacts-dir dist \
-            --expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS"
-
-      - name: Generate signed backend index
-        shell: bash
-        env:
-          KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
-        run: |
-          set -euo pipefail
-          if [ -z "$KAPSL_BACKEND_SIGNING_KEY_B64" ] || [ -z "$KAPSL_BACKEND_PUBLIC_KEYS" ]; then
-            echo "Backend signing key and embedded public key are required." >&2
-            exit 1
-          fi
-          key_file="${RUNNER_TEMP}/kapsl-backend-signing-key.pem"
-          printf '%s' "$KAPSL_BACKEND_SIGNING_KEY_B64" | base64 --decode > "$key_file"
-          chmod 600 "$key_file"
-          trap 'rm -f "$key_file"' EXIT
-          .github/scripts/generate-backend-index.py \
-            --version "$KAPSL_VERSION" \
-            --artifacts-dir dist \
-            --output dist/backend-index.json \
-            --signing-key "$key_file" \
-            --expected-public-key "$KAPSL_BACKEND_PUBLIC_KEYS" \
-            --channel stable
-          rm -f "$key_file" dist/*.manifest.json
-          trap - EXIT
-
-      - name: Upload CUDA runtime artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: runtime-cuda-linux-x86_64
-          path: dist/*
-          if-no-files-found: error
-          compression-level: 0
+      KAPSL_BACKEND_SIGNING_KEY_B64: ${{ secrets.KAPSL_BACKEND_SIGNING_KEY_B64 }}
 
   upload-release-assets:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -593,6 +488,7 @@ jobs:
       - name: Download installer artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: runtime-*
           path: release-assets
           merge-multiple: true
 
@@ -665,6 +561,7 @@ jobs:
       - name: Download installer artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: runtime-*
           path: release-assets
           merge-multiple: true
 


### PR DESCRIPTION
## Summary

Combined authentication/preflight and release-time reduction PR, including the original legacy ONNX packaging removal. CPU/GPU qualification and unconditional teardown remain mandatory for stable publication.

### Fail before long builds

- Restore `secrets: inherit` at the GPU reusable-workflow caller, while keeping the App private key environment-owned and optional in `workflow_call`.
- Request the repository-administration grant explicitly for preflight, JIT setup and cleanup tokens.
- Add a protected, host-only infrastructure preflight before all stable installer builds and CPU performance qualification: validate secret/config presence, mint/revoke the App token, read the runner API without registration, verify the exact SDK commit, authenticate GCP, and describe the pinned zone/image/subnet.
- Validate the backend signing key against runtime trust and check publication settings/SDK availability before beta or stable builds. R2 checks here verify setting presence, not a test upload.
- Extend Release Preflight with live checks on trusted main pushes or deliberate main dispatches. PRs run only fixtures/metadata validation and cannot access the protected live jobs.

The empty environment key matches the reported reusable-workflow behavior in https://github.com/actions/runner/issues/4453. The inheritance fix still needs the protected main live preflight; no production credential value was read or exposed locally.

### Shorten the critical path and make retries smaller

- Replace duplicate sequential CUDA jobs with one shared host-only workflow that independently builds the engine, llama.cpp CPU, llama.cpp CUDA, vLLM, and (non-stable only) certified ORT CPU components.
- Retain same-run component artifacts named with the source SHA. Assembly rejects missing/unexpected components, wrong versions, symlinks, duplicate filenames, missing backend manifests and checksum mismatches before moving files.
- Sign/upload one final `runtime-cuda-linux-x86_64` candidate. GPU qualification still consumes that exact artifact from its official stable release run. Publication downloads only final `runtime-*` artifacts, not intermediate parts or test evidence.
- Keep successful component jobs/artifacts when another component fails. Configuration-only failures can use failed-job retries; rerunning an old tag does not pick up workflow-code changes.
- Avoid duplicating multi-GB files on disk during assembly. Retain intermediate/final CUDA artifacts for 7 days for stable qualification and 1 day for beta.

### Cache and avoid unnecessary full beta builds

- Cache actual `kapsl-runtime` targets and ORT download sidecars in CI and installer builds; cache keys separate platforms and feature profiles, and PR writes are disabled unless a host-only check explicitly opts into its isolated merge-ref cache.
- Give llama.cpp builds persistent, separate CPU/CUDA targets instead of deleting their compilation outputs with temporary packaging scratch.
- Remove the CUDA job's blanket `cargo clean`; isolated component jobs no longer contend for the same packaging/build disk.
- Add trusted main cache warming on runtime/toolchain changes, or by manual dispatch. It compiles only, publishes nothing and provisions no GPU.
- Gate automatic beta packaging on runtime/installer/packaging input changes. CI/authentication-only changes keep host checks and can deliberately request a beta build on develop.

### Keep PR CPU smoke focused and cached

- Remove workflow, authentication-validator and contract-test-only edits from expensive ORT CPU compilation triggers. Those edits retain host-only preflight, policy and installer contract checks.
- Keep CPU correctness smoke for runtime, toolchain, integration/model pins, and actual pack/signature/harness input changes. Full CPU performance parity remains stable qualification or deliberate manual dispatch only.
- Cache both the engine and exact pinned ORT adapter compilation dependencies, with adapter targets outside the verified-clean integrations checkout. No packs, signing keys or conformance evidence are cached.
- Opt this unprivileged CPU check into PR-scoped cache saves, including after a failed smoke test so fixes can reuse dependencies. Other PR checks remain restore-only. GitHub's [merge-ref cache boundary](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache) prevents branch/tag jobs from consuming PR caches.
- Rename the workflow to `ORT CPU Smoke and Release Parity` and clearly label the PR job `ORT CPU correctness smoke (PR)`. Required cross-platform Cargo checks/tests are unchanged.

### Preserved behavior and limits

- Real GPU conformance remains official stable-tag-push-only with exact Cargo/tag matching. No PR, beta, branch or manually dispatched real GPU run is enabled.
- CPU performance qualification, GPU conformance, unconditional teardown and the publication gate remain in place. JIT polling is now 30 seconds.
- Embedded ORT, provider sidecars/archives and explicit rollback remain. No SDK dependencies, version pins or runtime behavior were changed; no Cargo patches/path dependencies were introduced.
- Legacy ONNX accelerator production is removed from beta/release pipelines. Beta indexes will not include those legacy profiles; signed accelerator import for beta is still separate, and this PR does not enable silent fallback.
- The prior run spent 62m50s in CUDA engine compilation and 59m43s in sequential llama.cpp packaging. The new graph overlaps these builds; actual cold/warm timing must be measured, not assumed. Cache-only main builds are themselves host compilation work, not qualification.

## Validation

- 26 new release pipeline/environment/cache/assembly/CPU-smoke gating regression tests
- 24 GCP policy/lifecycle unit tests; 6 JIT runner unit tests
- 6 ORT preflight tests; 10 immutable signed-release import tests
- ORT, llama.cpp and managed-vLLM release-contract shell tests
- Signed backend-index/tamper/publication fixture tests
- actionlint v1.7.7 on all changed/new workflows
- shell syntax, cargo fmt and git diff checks

Linux ELF packaging fixture coverage is delegated to the existing host-only Installer Smoke CI job. Full CUDA compilation, production credential access and real GPU qualification were not run locally.

## Rollout

Merge through develop and the normal main promotion PR. Let the main Release Preflight prove live authentication before creating the next official stable tag. Existing published tags remain immutable; this PR does not bump versions or create a release.