### PR TITLE
chore(release): prepare engine v0.2.8

### DIFF
--- a/.github/ort-release.lock.json
+++ b/.github/ort-release.lock.json
@@ -1,17 +1,17 @@
 {
   "backend": "onnx",
   "catalog": {
-    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7-linux-x86_64.release.json",
-    "sha256": "b76ba4052ad7c0ae3b1caec70c621a1d4bde23d07134fa789e7c09c849c1bc67",
-    "signature": "ed25519:u7cHF6IM8JCQ7PFK6PN2UkFXnkZllW9iplLTUZ/ospo+hhjmJAfL96Aei9YalcSaVJ7vtKIW58tZzg0OTcW8Ag==",
+    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.8-linux-x86_64.release.json",
+    "sha256": "b764f99af0ed75275297112e23ced66a3895e6e472cd67b6497ec8e7dbd8b546",
+    "signature": "ed25519:Iu93fEb1Hwdidr5o+DN2PL+hllbkDLFbSPBgRAbnXHLMluZEvjTexzmfaRVUoXp4C7WNaUtJcwCPd3byh9s3Ag==",
     "signature_asset": {
-      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7-linux-x86_64.release.json.sig",
-      "sha256": "5f483740472d5653dbc5ae33bf94534fe5f2a455259ff44ee60c5cd2adab7aa2",
+      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.8-linux-x86_64.release.json.sig",
+      "sha256": "6234acf1744f861c06c61d0315405881f492dc582b8b540fa17451573759a00a",
       "size": 97
     },
     "size": 6755
   },
-  "compatible_kapsl": "=0.2.7",
+  "compatible_kapsl": "=0.2.8",
   "pack_version": "0.2.0",
   "platform": "linux-x86_64",
   "profiles": [
@@ -19,7 +19,7 @@
     "cuda12",
     "tensorrt10"
   ],
-  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7",
+  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.8",
   "repository": "kapsl-runtime/kapsl-integrations",
   "schema_version": 1,
   "source_commit": "0b7a10f4ffcc8347f161c1fa3015802d9acd2695"

--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -351,6 +351,33 @@ class WorkflowTests(TestCase):
             self.assertEqual(caller_source.count("pattern: runtime-*"),
                              caller_source.count("name: Download installer artifacts"))
 
+    def test_reusable_build_callers_grant_the_requested_permissions(self):
+        # GitHub rejects the whole workflow before jobs start if a reusable
+        # workflow asks for a permission omitted by its caller. actionlint's
+        # syntax checks alone do not catch this cross-workflow contract.
+        required = dict(re.findall(
+            r"^  ([\w-]+): (read|write|none)$",
+            workflow("build-linux-accelerators").split("\njobs:", 1)[0], re.MULTILINE,
+        ))
+        self.assertEqual(required, {"contents": "read", "actions": "read"})
+        levels = {"none": 0, "read": 1, "write": 2}
+        for caller, name in (
+            ("beta-runtime-installers", "build-cuda-runtime"),
+            ("release-runtime-installers", "build-cuda-runtime"),
+            ("release-build-cache", "warm"),
+        ):
+            source = workflow(caller)
+            block = job(source, name)
+            self.assertIn("uses: ./.github/workflows/build-linux-accelerators.yml", block)
+            if "    permissions:\n" in block:
+                grants = dict(re.findall(r"^      ([\w-]+): (read|write|none)$", block, re.MULTILINE))
+            else:
+                grants = dict(re.findall(r"^  ([\w-]+): (read|write|none)$",
+                                         source.split("\njobs:", 1)[0], re.MULTILINE))
+            for scope, permission in required.items():
+                with self.subTest(caller=caller, scope=scope):
+                    self.assertGreaterEqual(levels[grants.get(scope, "none")], levels[permission])
+
     def test_cache_warming_does_not_publish_or_qualify(self):
         block = job(workflow("release-build-cache"), "warm")
         self.assertIn("github.ref == 'refs/heads/main'", block)

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -323,6 +323,11 @@ jobs:
   build-cuda-runtime:
     name: Build CUDA runtime (linux-x86_64)
     needs: prepare-version
+    # The reusable build must be allowed to read its same-run artifacts.
+    # Keep this grant scoped to the caller, not every beta/publication job.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/build-linux-accelerators.yml
     with:
       version: ${{ needs.prepare-version.outputs.version }}

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

- Bump the engine CLI and its Cargo lock entry from `0.2.7` to `0.2.8`; no SDK dependency changes.
- Pin the published signed ORT CPU, CUDA 12 and TensorRT 10 packs for exact engine compatibility `=0.2.8`.
- Keep adapter version `0.2.0`, reviewed integrations source `0b7a10f4ffcc8347f161c1fa3015802d9acd2695`, and the existing trusted public key unchanged.
- Fix the beta reusable-build caller's missing `actions: read` grant, scoped to that job with `contents: read`. Add a regression test checking permission compatibility for beta, stable and cache-warming callers.

## Published ORT handoff

[ORT 0.2.8 packaging run](https://github.com/kapsl-runtime/kapsl-integrations/actions/runs/34086365069) passed and [all three profiles are published](https://github.com/kapsl-runtime/kapsl-integrations/releases/tag/kapsl-ort-packs-v0.2.0-kapsl-v0.2.8). The lock pins the actual catalog SHA-256, signature and signature-asset digest; it does not reference a future or draft release.

This was host-only packaging and reproducibility validation, not real GPU qualification.

## Beta startup correction

[The prior beta run](https://github.com/kapsl-runtime/kapsl-engine/actions/runs/34078768318) was rejected before jobs started because the shared build requested `actions: read` while beta allowed `actions: none`. The new test reproduced this failure before the caller grant was added and now passes. Existing stable and cache-warming callers already supply the required permission.

## Validation

- Published-release preflight: authenticated catalog/profile signatures and manifests, exact compatibility/source identity, and archive-part availability for CPU/CUDA12/TensorRT10. Full binary-integrity verification remains mandatory during release import.
- 73 unit tests: release pipeline (27), GCP policy/lifecycle (24), JIT runner (6), ORT preflight (6), signed-release import (10).
- ORT, llama.cpp and managed-vLLM release-contract shell tests.
- `cargo metadata --locked --no-deps`: engine resolves to `0.2.8`.
- `cargo fmt --all -- --check`, actionlint v1.7.7 and `git diff --check`.

## Rollout

1. Merge this PR into `develop` after review and host-only checks. CPU correctness smoke is expected here because the Cargo version changes; PR performance thresholds remain disabled.
2. Promote `develop` to `main` through a separate PR.
3. Confirm main's live preflight passes, inspect existing release/cache-warming runs, then create the unused official `v0.2.8` engine tag.
4. Let full CPU performance parity, stable-only real GPU conformance and unconditional teardown gate publication.

No engine release tag or GPU run was created for this PR. Embedded ORT rollback remains; existing stable tags will not be moved or reused.