### PR TITLE
chore(release): promote engine v0.2.8 to main

### DIFF
--- a/.github/ort-release.lock.json
+++ b/.github/ort-release.lock.json
@@ -1,17 +1,17 @@
 {
   "backend": "onnx",
   "catalog": {
-    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7-linux-x86_64.release.json",
-    "sha256": "b76ba4052ad7c0ae3b1caec70c621a1d4bde23d07134fa789e7c09c849c1bc67",
-    "signature": "ed25519:u7cHF6IM8JCQ7PFK6PN2UkFXnkZllW9iplLTUZ/ospo+hhjmJAfL96Aei9YalcSaVJ7vtKIW58tZzg0OTcW8Ag==",
+    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.8-linux-x86_64.release.json",
+    "sha256": "b764f99af0ed75275297112e23ced66a3895e6e472cd67b6497ec8e7dbd8b546",
+    "signature": "ed25519:Iu93fEb1Hwdidr5o+DN2PL+hllbkDLFbSPBgRAbnXHLMluZEvjTexzmfaRVUoXp4C7WNaUtJcwCPd3byh9s3Ag==",
     "signature_asset": {
-      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7-linux-x86_64.release.json.sig",
-      "sha256": "5f483740472d5653dbc5ae33bf94534fe5f2a455259ff44ee60c5cd2adab7aa2",
+      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.8-linux-x86_64.release.json.sig",
+      "sha256": "6234acf1744f861c06c61d0315405881f492dc582b8b540fa17451573759a00a",
       "size": 97
     },
     "size": 6755
   },
-  "compatible_kapsl": "=0.2.7",
+  "compatible_kapsl": "=0.2.8",
   "pack_version": "0.2.0",
   "platform": "linux-x86_64",
   "profiles": [
@@ -19,7 +19,7 @@
     "cuda12",
     "tensorrt10"
   ],
-  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.7",
+  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.8",
   "repository": "kapsl-runtime/kapsl-integrations",
   "schema_version": 1,
   "source_commit": "0b7a10f4ffcc8347f161c1fa3015802d9acd2695"

--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -351,6 +351,33 @@ class WorkflowTests(TestCase):
             self.assertEqual(caller_source.count("pattern: runtime-*"),
                              caller_source.count("name: Download installer artifacts"))
 
+    def test_reusable_build_callers_grant_the_requested_permissions(self):
+        # GitHub rejects the whole workflow before jobs start if a reusable
+        # workflow asks for a permission omitted by its caller. actionlint's
+        # syntax checks alone do not catch this cross-workflow contract.
+        required = dict(re.findall(
+            r"^  ([\w-]+): (read|write|none)$",
+            workflow("build-linux-accelerators").split("\njobs:", 1)[0], re.MULTILINE,
+        ))
+        self.assertEqual(required, {"contents": "read", "actions": "read"})
+        levels = {"none": 0, "read": 1, "write": 2}
+        for caller, name in (
+            ("beta-runtime-installers", "build-cuda-runtime"),
+            ("release-runtime-installers", "build-cuda-runtime"),
+            ("release-build-cache", "warm"),
+        ):
+            source = workflow(caller)
+            block = job(source, name)
+            self.assertIn("uses: ./.github/workflows/build-linux-accelerators.yml", block)
+            if "    permissions:\n" in block:
+                grants = dict(re.findall(r"^      ([\w-]+): (read|write|none)$", block, re.MULTILINE))
+            else:
+                grants = dict(re.findall(r"^  ([\w-]+): (read|write|none)$",
+                                         source.split("\njobs:", 1)[0], re.MULTILINE))
+            for scope, permission in required.items():
+                with self.subTest(caller=caller, scope=scope):
+                    self.assertGreaterEqual(levels[grants.get(scope, "none")], levels[permission])
+
     def test_cache_warming_does_not_publish_or_qualify(self):
         block = job(workflow("release-build-cache"), "warm")
         self.assertIn("github.ref == 'refs/heads/main'", block)

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -323,6 +323,11 @@ jobs:
   build-cuda-runtime:
     name: Build CUDA runtime (linux-x86_64)
     needs: prepare-version
+    # The reusable build must be allowed to read its same-run artifacts.
+    # Keep this grant scoped to the caller, not every beta/publication job.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/build-linux-accelerators.yml
     with:
       version: ${{ needs.prepare-version.outputs.version }}

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Release promotion

Promote the reviewed `0.2.8` preparation from #217 into `main` through the required separate PR.

- Engine CLI/Cargo lock version: `0.2.8`.
- Published, signed ORT CPU/CUDA12/TensorRT10 pack lock: `kapsl-ort-packs-v0.2.0-kapsl-v0.2.8`.
- Scoped beta reusable-build artifact-read permission and regression test.
- No backend removal, SDK dependency changes, or conformance-gate relaxation.

## Verification

- #217 merged into develop at `776d6a2eff1e4f9b2b61f1a853c148bec632b7af`.
- Its PR checks passed, including CPU correctness smoke; develop CI and signed-release preflight also passed.
- [ORT release packaging](https://github.com/kapsl-runtime/kapsl-integrations/actions/runs/34086365069) completed successfully and all three signed profiles are published.
- Signed metadata and artifact availability were verified against the pinned public key before the engine lock update.
- 73 local unit tests, release-contract tests, locked Cargo metadata, workflow lint, formatting and whitespace checks passed during preparation.

## After merge

Wait for main's CI and protected live preflight, inspect cache-warming progress, then recheck that no `v0.2.8` tag or equivalent stable run exists. Create the official stable tag on the verified main commit, allowing full CPU performance parity and real GPU conformance to run.

Publication must wait for conformance and unconditional teardown. Embedded ORT rollback stays until stable qualification passes. Do not move or reuse an existing stable tag.

No engine release tag or GPU workflow was started by creating this PR.