### PR TITLE
chore(release): prepare engine 0.2.10 with published ORT packs

### DIFF
--- a/.github/ort-release.lock.json
+++ b/.github/ort-release.lock.json
@@ -1,17 +1,17 @@
 {
   "backend": "onnx",
   "catalog": {
-    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.9-linux-x86_64.release.json",
-    "sha256": "063621df34969f8b36b592e523281f257e4e63aeb5fec344794eb2785ca4e22f",
-    "signature": "ed25519:fQuQCM1/LZt4aH3bd3rHNO6yhLuWis5L209bG+d5t+s/QtatIvsKajEJKFwddZlUK9z4r9PqfzB3sTVzs/03AA==",
+    "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.10-linux-x86_64.release.json",
+    "sha256": "77730495c6ef388b64a4dc0e91ed022cba455cac3c4f9baf71454aab1a51e709",
+    "signature": "ed25519:u+2LdEbgkzUVrCljah+Aab38sYmLdO6htZdklow+85F6wAicaKGA+OGPtm35Zu1zFtcU3c97Znik9C1/9DBwBQ==",
     "signature_asset": {
-      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.9-linux-x86_64.release.json.sig",
-      "sha256": "d1615195ef08a027668e044e9507d4ed9b994cfabdca419fb44b9d6f71d5d054",
+      "name": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.10-linux-x86_64.release.json.sig",
+      "sha256": "d0a397d441abf3c04601d65bf2c86db12e745e15052c4ba7ca090c628d1d9a8c",
       "size": 97
     },
-    "size": 6755
+    "size": 6790
   },
-  "compatible_kapsl": "=0.2.9",
+  "compatible_kapsl": "=0.2.10",
   "pack_version": "0.2.0",
   "platform": "linux-x86_64",
   "profiles": [
@@ -19,7 +19,7 @@
     "cuda12",
     "tensorrt10"
   ],
-  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.9",
+  "release_tag": "kapsl-ort-packs-v0.2.0-kapsl-v0.2.10",
   "repository": "kapsl-runtime/kapsl-integrations",
   "schema_version": 1,
   "source_commit": "3ec64f84489046c44892ab9c0ea5b46b3c7d6811"

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "kapsl"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kapsl"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Summary

- Prepare engine `0.2.10` from current `develop`, including the merged `jq` installation and early tooling check from #222.
- Update only the CLI version, its Cargo.lock package entry, and the immutable ORT release lock.
- Pin the already-published CPU, CUDA12 and TensorRT10 packs for exactly `=0.2.10`. ORT adapter version remains `0.2.0`; integration source remains `3ec64f84489046c44892ab9c0ea5b46b3c7d6811`.

The failed `v0.2.9` tag remains unchanged. No SDK changes, dependency patches, runtime changes, embedded ORT removal, or performance-threshold changes are included.

## Published artifact evidence

- [Successful host-only pack publication](https://github.com/kapsl-runtime/kapsl-integrations/actions/runs/34418399065)
- [Immutable ORT release for engine 0.2.10](https://github.com/kapsl-runtime/kapsl-integrations/releases/tag/kapsl-ort-packs-v0.2.0-kapsl-v0.2.10)
- Verified the index and all profile signatures against the existing pinned Ed25519 public key, exact source and compatibility, and all 21 uploaded assets. Signed archive-part sizes and digests match GitHub's uploaded-asset inventory.
- Public preflight verified signed catalogs/manifests and availability of every archive part.
- Downloaded and verified the complete CPU archive, all nine packaged file hashes, native descriptor and source provenance without executing backend code. Multi-GB GPU binaries were not downloaded locally; full binary integrity remains mandatory during release import.

## Validation

- 88 Python tests passed: release pipeline (42), GCP runner (24), JIT runner (6), immutable release import (10), ORT preflight (6).
- Managed-vLLM, ONNX and llama.cpp release-contract shell tests passed; ORT integration checkout verifier tests passed.
- `python3 .github/scripts/preflight-ort-release.py`
- `python3 .github/scripts/verify_published_sdk.py --lockfile kapsl-runtime/Cargo.lock`
- Locked offline Cargo metadata checked against published SDK versions for both CPU and CUDA feature configurations; no compilation or GPU execution.
- `cargo fmt --manifest-path kapsl-runtime/Cargo.toml --all -- --check`
- `git diff --check`

## Promotion

After this PR passes and merges, promote `develop` to `main` through a separate PR. Create the new official engine `v0.2.10` tag only after promotion and readiness checks pass. Real GPU conformance remains stable-tag-only; conformance, teardown and the unchanged 1.5x startup threshold still gate publication. Embedded ORT stays available until packaged accelerator qualification succeeds.
