### PR TITLE
refactor(backend): remove ORT tuning from the generic native host

### DIFF
--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -63,7 +63,12 @@ require_literal "$native_allocator" 'GpuDevicePool'
 require_literal "$native_allocator" 'KapslBackendHostScopedAllocatorV1'
 require_literal "$native_allocator" 'allocate_device_scoped'
 require_literal "$native_host" '"pack_root": pack.root'
-require_literal "$native_host" '"onnx_tuning": tuning.map'
+require_literal "$activator" 'pub(crate) fn onnx_adapter_options('
+require_literal "$runtime_backend" '&onnx_adapter_options(tuning)'
+if grep -Eq 'kapsl_backends|OnnxRuntimeTuning|onnx_tuning' "$native_host"; then
+  echo "$native_host must not depend on ONNX configuration types or translation" >&2
+  exit 1
+fi
 require_literal "$native_host" 'pointer.cast::<KapslBackendApiPrefixV1>().read()'
 require_literal "$native_host" 'pack.api.shutdown'
 require_literal "$cli_manifest" 'kapsl-backend-abi = "=0.2.0"'

--- a/.github/scripts/test-onnx-backend-release-contract.sh
+++ b/.github/scripts/test-onnx-backend-release-contract.sh
@@ -32,6 +32,7 @@ release_workflow=".github/workflows/release-runtime-installers.yml"
 build_workflow=".github/workflows/build-linux-accelerators.yml"
 runtime_backend="kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs"
 native_host="kapsl-runtime/crates/kapsl-cli/src/backend/native.rs"
+native_allocator="kapsl-runtime/crates/kapsl-cli/src/backend/native/allocator.rs"
 bundle="kapsl-runtime/crates/kapsl-cli/src/backend/bundle.rs"
 cli_manifest="kapsl-runtime/crates/kapsl-cli/Cargo.toml"
 
@@ -57,7 +58,10 @@ require_literal "$native_host" 'KAPSL_BACKEND_ENTRYPOINT_SYMBOL'
 require_literal "$native_host" 'KAPSL_BACKEND_CAP_GOVERNED_DEVICE_ALLOCATOR'
 require_literal "$native_host" 'KAPSL_BACKEND_CAP_SCOPED_DEVICE_ALLOCATOR'
 require_literal "$native_host" 'KAPSL_BACKEND_DESCRIPTOR_SCHEMA_V1'
-require_literal "$native_host" 'GpuDevicePool'
+require_literal "$native_host" 'mod allocator;'
+require_literal "$native_allocator" 'GpuDevicePool'
+require_literal "$native_allocator" 'KapslBackendHostScopedAllocatorV1'
+require_literal "$native_allocator" 'allocate_device_scoped'
 require_literal "$native_host" '"pack_root": pack.root'
 require_literal "$native_host" '"onnx_tuning": tuning.map'
 require_literal "$native_host" 'pointer.cast::<KapslBackendApiPrefixV1>().read()'

--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2309,6 +2309,7 @@ dependencies = [
  "kapsl-llm",
  "kapsl-loader",
  "kapsl-monitor",
+ "kapsl-native-test-adapter",
  "kapsl-rag",
  "kapsl-rag-sdk",
  "kapsl-scheduler",
@@ -2592,6 +2593,15 @@ dependencies = [
  "prometheus",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "kapsl-native-test-adapter"
+version = "0.0.0"
+dependencies = [
+ "kapsl-backend-abi",
+ "kapsl-engine-api",
+ "serde_json",
 ]
 
 [[package]]

--- a/kapsl-runtime/Cargo.toml
+++ b/kapsl-runtime/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 ]
 exclude = [
     "patches/esaxx-rs",
+    "tests/native-adapter",
 ]
 
 resolver = "2"

--- a/kapsl-runtime/DEVELOPER_GUIDE.md
+++ b/kapsl-runtime/DEVELOPER_GUIDE.md
@@ -1152,6 +1152,9 @@ RUST_LOG=debug cargo run -p kapsl -- --model model.aimod
 
 ---
 
+Native adapter changes must pass the [host allocator regression tests](docs/native-host-tests.md),
+which load a test adapter through the production ABI with a fake device pool.
+
 **Document Version**: 1.0  
 **Maintained by**: kapsl-runtime development team  
 **Last Review**: December 4, 2025

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -85,3 +85,6 @@ semver = "1.0"
 tempfile = "3.10"
 libloading = "0.8"
 ort = { version = "=2.0.0-rc.11", default-features = false, features = ["cuda", "tensorrt"] }
+
+[dev-dependencies]
+kapsl-native-test-adapter = { path = "../../tests/native-adapter" }

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native.rs
@@ -22,14 +22,8 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-#[cfg(feature = "gpu-device-pool")]
-use kapsl_hal::gpu_arena::{
-    GpuAllocation, GpuDevicePool, PoolAllocationClass, PoolBackend, PoolOwner,
-};
-#[cfg(feature = "gpu-device-pool")]
-use std::collections::HashMap;
-#[cfg(feature = "gpu-device-pool")]
-use std::panic::{catch_unwind, AssertUnwindSafe};
+mod allocator;
+use allocator::{GovernedDeviceHost, NativeBackendHost};
 
 pub(crate) const GENERIC_NATIVE_PACKS_ENV: &str = "KAPSL_GENERIC_NATIVE_PACKS";
 const MAX_JSON_BUFFER_BYTES: usize = 8 * 1024 * 1024;
@@ -158,6 +152,14 @@ pub(crate) fn activate_native_backend_pack(
         return Ok(());
     }
 
+    active.push(load_native_backend_pack(manifest, root)?);
+    Ok(())
+}
+
+fn load_native_backend_pack(
+    manifest: &BackendPackManifest,
+    root: &Path,
+) -> Result<Arc<ActiveNativePack>, String> {
     let root = root
         .canonicalize()
         .map_err(|error| format!("resolve native pack {}: {error}", root.display()))?;
@@ -200,15 +202,14 @@ pub(crate) fn activate_native_backend_pack(
         manifest.pack_version,
         root.display()
     );
-    active.push(Arc::new(ActiveNativePack {
+    Ok(Arc::new(ActiveNativePack {
         manifest: manifest.clone(),
         api,
         descriptor,
         root,
         entrypoint,
         library,
-    }));
-    Ok(())
+    }))
 }
 
 fn validate_native_backend_api(
@@ -448,6 +449,7 @@ struct NativePackInstance {
     cancel_target: Arc<NativeCancelTarget>,
     next_request_id: AtomicU64,
     loaded: AtomicBool,
+    cleanup_required: AtomicBool,
     call_lock: RwLock<()>,
 }
 
@@ -471,11 +473,13 @@ struct LiveNativeCancelTarget {
 
 struct NativeCancelTarget {
     live: RwLock<Option<LiveNativeCancelTarget>>,
+    allocator: Option<Arc<GovernedDeviceHost>>,
 }
 
 impl NativeCancelTarget {
     fn new(handle: *mut c_void, function: Option<KapslBackendCancelFn>) -> Self {
         Self {
+            allocator: None,
             live: RwLock::new(function.map(|function| LiveNativeCancelTarget {
                 handle: handle as usize,
                 function,
@@ -489,6 +493,9 @@ impl NativeCancelTarget {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let target = *live.as_ref()?;
+        if let Some(allocator) = &self.allocator {
+            allocator.cancel(request_id);
+        }
         // SAFETY: the read guard prevents instance shutdown from invalidating
         // the adapter handle until this cancellation call returns.
         Some(unsafe { (target.function)(target.handle as *mut c_void, request_id) })
@@ -548,6 +555,7 @@ impl Drop for NativeCancellationWatches {
 }
 
 struct NativeStreamCallbackContext {
+    request_id: u64,
     sender: async_channel::Sender<Result<BinaryTensorPacket, EngineError>>,
     callback_error: Option<EngineError>,
     consumer_closed: bool,
@@ -555,7 +563,7 @@ struct NativeStreamCallbackContext {
 
 unsafe extern "C" fn native_stream_chunk(
     user_data: *mut c_void,
-    _request_id: u64,
+    request_id: u64,
     result: *const KapslInferenceResultV1,
 ) -> i32 {
     if user_data.is_null() {
@@ -571,7 +579,11 @@ unsafe extern "C" fn native_stream_chunk(
     }
 
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let packet = if result.is_null() {
+        let packet = if request_id != context.request_id {
+            Err(EngineError::backend(
+                "native stream chunk belongs to a different request",
+            ))
+        } else if result.is_null() {
             Err(EngineError::backend(
                 "native backend stream callback received a null result",
             ))
@@ -649,10 +661,6 @@ impl NativePackInstance {
     ) -> Result<Arc<Self>, String> {
         let requires_governed_memory =
             pack.api.capabilities & KAPSL_BACKEND_CAP_GOVERNED_DEVICE_ALLOCATOR != 0;
-        let supports_cancellation = pack.api.capabilities & KAPSL_BACKEND_CAP_CANCELLATION != 0;
-        let cancellation_runtime = supports_cancellation
-            .then(native_bridge_runtime)
-            .transpose()?;
         let host = NativeBackendHost::new(
             resources,
             &pack.manifest.backend,
@@ -660,7 +668,30 @@ impl NativePackInstance {
             model_id,
             replica_id,
             requires_governed_memory,
+            pack.api.capabilities & KAPSL_BACKEND_CAP_SCOPED_DEVICE_ALLOCATOR != 0,
         )?;
+        Self::initialize_with_host(
+            pack, manifest, provider, host, device_id, model_id, replica_id, tuning,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn initialize_with_host(
+        pack: Arc<ActiveNativePack>,
+        manifest: &Manifest,
+        provider: &str,
+        host: NativeBackendHost,
+        device_id: usize,
+        model_id: u32,
+        replica_id: u32,
+        tuning: Option<&OnnxRuntimeTuning>,
+    ) -> Result<Arc<Self>, String> {
+        let requires_governed_memory =
+            pack.api.capabilities & KAPSL_BACKEND_CAP_GOVERNED_DEVICE_ALLOCATOR != 0;
+        let supports_cancellation = pack.api.capabilities & KAPSL_BACKEND_CAP_CANCELLATION != 0;
+        let cancellation_runtime = supports_cancellation
+            .then(native_bridge_runtime)
+            .transpose()?;
         let profile = pack.manifest.profile.as_bytes();
         let manifest_json = serde_json::to_vec(manifest)
             .map_err(|error| format!("encode model manifest for native backend: {error}"))?;
@@ -699,6 +730,7 @@ impl NativePackInstance {
         // SAFETY: the table was validated and all borrowed config storage lives
         // through this synchronous call. The host table itself is boxed and is
         // retained until adapter shutdown.
+        let allocation_call = host.begin_model_call()?;
         let status = unsafe {
             pack.api.initialize.expect("validated initialize function")(
                 &config,
@@ -706,7 +738,9 @@ impl NativePackInstance {
                 &mut error,
             )
         };
+        drop(allocation_call);
         if status != KAPSL_STATUS_OK || handle.is_null() {
+            host.stop_allocating();
             let message = read_ffi_error(&pack.api, status, error);
             if !handle.is_null() {
                 // SAFETY: an adapter that published a handle transferred it
@@ -730,14 +764,17 @@ impl NativePackInstance {
         } else {
             None
         };
+        let mut cancel_target = NativeCancelTarget::new(handle, cancel_function);
+        cancel_target.allocator = host.allocator.clone();
         Ok(Arc::new(Self {
             pack,
             handle,
             host,
             cancellation_runtime,
-            cancel_target: Arc::new(NativeCancelTarget::new(handle, cancel_function)),
+            cancel_target: Arc::new(cancel_target),
             next_request_id: AtomicU64::new(1),
             loaded: AtomicBool::new(false),
+            cleanup_required: AtomicBool::new(false),
             call_lock: RwLock::new(()),
         }))
     }
@@ -886,6 +923,10 @@ impl NativePackInstance {
         let mut bridge = RequestBridge::new(request)?;
         let wire = bridge.wire(request_id);
         let _guard = self.inference_guard();
+        self.require_loaded()?;
+        let _allocation_call = self
+            .host
+            .begin_requests([(request_id, request.cancellation.clone())])?;
         let _cancellation_watches = self.watch_cancellations(
             request
                 .cancellation
@@ -985,13 +1026,21 @@ impl NativePackInstance {
             let mut bridge = RequestBridge::new(request)?;
             let wire = bridge.wire(request_id);
             let _guard = self.inference_guard();
+            self.require_loaded()?;
+            let _allocation_call = self
+                .host
+                .begin_requests([(request_id, request.cancellation.clone())])?;
             let _cancellation_watches = self.watch_cancellations(
                 request
                     .cancellation
                     .clone()
                     .map(|cancellation| (request_id, cancellation)),
             );
+            if sender.is_closed() {
+                return Ok(());
+            }
             let mut context = NativeStreamCallbackContext {
+                request_id,
                 sender: sender.clone(),
                 callback_error: None,
                 consumer_closed: false,
@@ -1092,6 +1141,13 @@ impl NativePackInstance {
             requests: wires.as_ptr(),
         };
         let _guard = self.inference_guard();
+        self.require_loaded()?;
+        let _allocation_call = self.host.begin_requests(
+            request_ids
+                .iter()
+                .zip(requests)
+                .map(|(id, request)| (*id, request.cancellation.clone())),
+        )?;
         let _cancellation_watches =
             self.watch_cancellations(requests.iter().zip(&request_ids).filter_map(
                 |(request, request_id)| {
@@ -1138,28 +1194,51 @@ impl NativePackInstance {
         copy_batch_results(&result, requests.len())
     }
 
-    fn unload(&self) -> Result<(), EngineError> {
-        if !self.loaded.swap(false, Ordering::AcqRel) {
-            return Ok(());
+    fn require_loaded(&self) -> Result<(), EngineError> {
+        if self.loaded.load(Ordering::Acquire) && !self.cleanup_required.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            Err(EngineError::backend(
+                "native backend model is not loaded or requires cleanup",
+            ))
         }
+    }
+
+    fn unload(&self) -> Result<(), EngineError> {
         let _guard = self.exclusive_guard();
         let _cancel_pause = self.cancel_target.pause();
+        self.unload_locked()
+    }
+
+    fn unload_locked(&self) -> Result<(), EngineError> {
+        self.host.stop_allocating();
+        if !self.loaded.load(Ordering::Acquire)
+            && !self.cleanup_required.load(Ordering::Acquire)
+            && self.host.live_allocations() == 0
+        {
+            return self.host.reclaim().map_err(EngineError::backend);
+        }
+        self.cleanup_required.store(true, Ordering::Release);
         let mut error = KapslOwnedBuffer::empty();
-        // SAFETY: lifecycle ownership guarantees no request is active here.
+        // SAFETY: the exclusive call guard has drained every native request.
         let status = unsafe {
             self.pack.api.unload.expect("validated unload function")(self.handle, &mut error)
         };
-        if status == KAPSL_STATUS_OK {
-            if !error.ptr.is_null() {
-                let _ = take_owned_buffer(&self.pack.api, error, "unexpected unload error");
-            }
-            Ok(())
-        } else {
-            Err(status_engine_error(
+        if status != KAPSL_STATUS_OK {
+            // A failed unload may still retain pointers. Reclaim only after a
+            // successful retry or terminal adapter shutdown.
+            return Err(status_engine_error(
                 status,
                 read_ffi_error(&self.pack.api, status, error),
-            ))
+            ));
         }
+        if !error.ptr.is_null() {
+            let _ = take_owned_buffer(&self.pack.api, error, "unexpected unload error");
+        }
+        self.loaded.store(false, Ordering::Release);
+        self.host.reclaim().map_err(EngineError::backend)?;
+        self.cleanup_required.store(false, Ordering::Release);
+        Ok(())
     }
 }
 
@@ -1169,7 +1248,8 @@ impl Drop for NativePackInstance {
         // once terminal lifecycle teardown begins. Any call already in flight
         // completes before this write lock is acquired.
         self.cancel_target.deactivate();
-        if self.loaded.load(Ordering::Acquire) {
+        self.host.stop_allocating();
+        if self.loaded.load(Ordering::Acquire) || self.cleanup_required.load(Ordering::Acquire) {
             if let Err(error) = self.unload() {
                 log::error!("native backend unload during shutdown failed: {error}");
             }
@@ -1180,6 +1260,9 @@ impl Drop for NativePackInstance {
                 self.pack.api.shutdown.expect("validated shutdown function")(self.handle);
             }
             self.handle = std::ptr::null_mut();
+        }
+        if let Err(error) = self.host.reclaim() {
+            log::error!("native allocator cleanup after shutdown failed: {error}");
         }
         if self.host.live_allocations() != 0 {
             log::error!(
@@ -1236,6 +1319,18 @@ impl Engine for NativePackedEngine {
         })?;
         let _guard = self.instance.exclusive_guard();
         let _cancel_pause = self.instance.cancel_target.pause();
+        if self.instance.loaded.load(Ordering::Acquire)
+            || self.instance.cleanup_required.load(Ordering::Acquire)
+        {
+            return Err(EngineError::backend(
+                "native backend must unload successfully before loading again",
+            ));
+        }
+        let allocation_call = self
+            .instance
+            .host
+            .begin_model_call()
+            .map_err(EngineError::backend)?;
         let mut error = KapslOwnedBuffer::empty();
         // SAFETY: path bytes remain valid through this synchronous call.
         let status = unsafe {
@@ -1249,6 +1344,7 @@ impl Engine for NativePackedEngine {
                 &mut error,
             )
         };
+        drop(allocation_call);
         if status == KAPSL_STATUS_OK {
             self.instance.loaded.store(true, Ordering::Release);
             if !error.ptr.is_null() {
@@ -1256,15 +1352,25 @@ impl Engine for NativePackedEngine {
             }
             Ok(())
         } else {
-            Err(status_engine_error(
+            let load_error = status_engine_error(
                 status,
                 read_ffi_error(&self.instance.pack.api, status, error),
-            ))
+            );
+            self.instance
+                .cleanup_required
+                .store(true, Ordering::Release);
+            if let Err(cleanup_error) = self.instance.unload_locked() {
+                return Err(EngineError::backend(format!(
+                    "{load_error}; native load cleanup failed: {cleanup_error}"
+                )));
+            }
+            Err(load_error)
         }
     }
 
     fn actual_memory(&self) -> MemoryReport {
-        self.instance
+        let report = self
+            .instance
             .call_json_report(
                 self.instance
                     .pack
@@ -1275,7 +1381,8 @@ impl Engine for NativePackedEngine {
             .unwrap_or_else(|error| {
                 log::error!("native backend actual-memory report failed: {error}");
                 MemoryReport::default()
-            })
+            });
+        self.instance.host.actual_memory(report)
     }
 
     fn planned_request_memory(&self, request: &InferenceRequest) -> MemoryReport {
@@ -1329,7 +1436,8 @@ impl Engine for NativePackedEngine {
     }
 
     fn metrics(&self) -> EngineMetrics {
-        self.instance
+        let mut metrics = self
+            .instance
             .call_json_report(
                 self.instance
                     .pack
@@ -1340,7 +1448,9 @@ impl Engine for NativePackedEngine {
             .unwrap_or_else(|error| {
                 log::error!("native backend metrics failed: {error}");
                 EngineMetrics::new()
-            })
+            });
+        metrics.memory_usage = metrics.memory_usage.max(self.instance.host.live_bytes());
+        metrics
     }
 
     fn model_info(&self) -> Option<EngineModelInfo> {
@@ -1353,6 +1463,7 @@ impl Engine for NativePackedEngine {
 
     fn health_check(&self) -> Result<(), EngineError> {
         let _guard = self.instance.exclusive_guard();
+        self.instance.require_loaded()?;
         let mut error = KapslOwnedBuffer::empty();
         // SAFETY: the validated health function borrows the live handle only.
         let status = unsafe {
@@ -1771,366 +1882,6 @@ unsafe extern "C" fn host_log(_user_data: *mut c_void, level: u32, message: Kaps
     }));
 }
 
-struct NativeBackendHost {
-    table: Box<KapslBackendHostV1>,
-    #[cfg(feature = "gpu-device-pool")]
-    allocator: Option<Box<GovernedDeviceHost>>,
-}
-
-impl NativeBackendHost {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        resources: &RuntimeResources,
-        backend: &str,
-        device_id: usize,
-        model_id: u32,
-        replica_id: u32,
-        require_governed: bool,
-    ) -> Result<Self, String> {
-        #[cfg(feature = "gpu-device-pool")]
-        {
-            let mut allocator = if require_governed {
-                let pool = resources.device_pool(device_id).ok_or_else(|| {
-                    format!(
-                        "native {backend} pack requires governed device memory, but device {device_id} has no runtime-owned pool"
-                    )
-                })?;
-                Some(Box::new(GovernedDeviceHost::new(
-                    pool,
-                    pool_backend(backend),
-                    device_id,
-                    model_id,
-                    replica_id,
-                )))
-            } else {
-                None
-            };
-            let user_data = allocator
-                .as_mut()
-                .map(|host| (&mut **host as *mut GovernedDeviceHost).cast())
-                .unwrap_or(std::ptr::null_mut());
-            let table = Box::new(KapslBackendHostV1 {
-                struct_size: std::mem::size_of::<KapslBackendHostV1>() as u32,
-                abi_version: KAPSL_BACKEND_ABI_VERSION,
-                user_data,
-                log: Some(host_log),
-                allocate_device: allocator
-                    .as_ref()
-                    .map(|_| allocate_device as KapslDeviceAllocateFn),
-                free_device: allocator.as_ref().map(|_| free_device as KapslDeviceFreeFn),
-                synchronize_device: allocator
-                    .as_ref()
-                    .map(|_| synchronize_device as KapslDeviceSynchronizeFn),
-            });
-            Ok(Self { table, allocator })
-        }
-        #[cfg(not(feature = "gpu-device-pool"))]
-        {
-            let _ = (resources, backend, device_id, model_id, replica_id);
-            if require_governed {
-                return Err(
-                    "native pack requires governed device memory, but this runtime was built without GPU pool authority"
-                        .to_string(),
-                );
-            }
-            Ok(Self {
-                table: Box::new(KapslBackendHostV1 {
-                    struct_size: std::mem::size_of::<KapslBackendHostV1>() as u32,
-                    abi_version: KAPSL_BACKEND_ABI_VERSION,
-                    user_data: std::ptr::null_mut(),
-                    log: Some(host_log),
-                    allocate_device: None,
-                    free_device: None,
-                    synchronize_device: None,
-                }),
-            })
-        }
-    }
-
-    fn table(&self) -> *const KapslBackendHostV1 {
-        self.table.as_ref()
-    }
-
-    fn live_allocations(&self) -> usize {
-        #[cfg(feature = "gpu-device-pool")]
-        {
-            self.allocator
-                .as_ref()
-                .map(|allocator| allocator.live_allocations())
-                .unwrap_or(0)
-        }
-        #[cfg(not(feature = "gpu-device-pool"))]
-        {
-            0
-        }
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-fn pool_backend(backend: &str) -> PoolBackend {
-    match backend.trim().to_ascii_lowercase().as_str() {
-        "onnx" | "ort" | "onnxruntime" => PoolBackend::Onnx,
-        "llama.cpp" | "llama_cpp" | "llama-cpp" => PoolBackend::Gguf,
-        _ => PoolBackend::Native,
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-struct GovernedDeviceHost {
-    pool: Arc<GpuDevicePool>,
-    backend: PoolBackend,
-    device_id: usize,
-    model_id: u32,
-    replica_id: u32,
-    next_allocation_id: AtomicU64,
-    allocations: Mutex<HashMap<u64, GpuAllocation>>,
-}
-
-#[cfg(feature = "gpu-device-pool")]
-impl GovernedDeviceHost {
-    fn new(
-        pool: Arc<GpuDevicePool>,
-        backend: PoolBackend,
-        device_id: usize,
-        model_id: u32,
-        replica_id: u32,
-    ) -> Self {
-        Self {
-            pool,
-            backend,
-            device_id,
-            model_id,
-            replica_id,
-            next_allocation_id: AtomicU64::new(1),
-            allocations: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn allocate(
-        &self,
-        request: KapslDeviceAllocationRequestV1,
-    ) -> Result<KapslDeviceAllocationV1, String> {
-        if request.struct_size < std::mem::size_of::<KapslDeviceAllocationRequestV1>() as u32 {
-            return Err("device allocation request struct is truncated".to_string());
-        }
-        if request.reserved != 0 || request.flags != 0 {
-            return Err("device allocation request uses unsupported flags".to_string());
-        }
-        if request.memory_kind != KAPSL_MEMORY_CUDA {
-            return Err(format!(
-                "governed device allocator supports CUDA memory, not kind {}",
-                request.memory_kind
-            ));
-        }
-        if request.device_id as usize != self.device_id
-            || request.model_id != self.model_id
-            || request.replica_id != self.replica_id
-        {
-            return Err(
-                "device allocation identity does not match its backend instance".to_string(),
-            );
-        }
-        let bytes = usize::try_from(request.bytes)
-            .map_err(|_| "device allocation byte count exceeds this platform".to_string())?;
-        let alignment = usize::try_from(request.alignment)
-            .map_err(|_| "device allocation alignment exceeds this platform".to_string())?;
-        if bytes == 0 || alignment == 0 || !alignment.is_power_of_two() {
-            return Err(
-                "device allocation requires non-zero bytes and power-of-two alignment".to_string(),
-            );
-        }
-        let class = match request.allocation_class {
-            KAPSL_ALLOCATION_CLASS_WEIGHTS => PoolAllocationClass::PersistentWeights,
-            KAPSL_ALLOCATION_CLASS_WORKSPACE => PoolAllocationClass::TransientWorkspace,
-            KAPSL_ALLOCATION_CLASS_KV => PoolAllocationClass::KvCache,
-            KAPSL_ALLOCATION_CLASS_REQUEST => PoolAllocationClass::RequestTransient,
-            KAPSL_ALLOCATION_CLASS_OTHER => PoolAllocationClass::ExternallyOwned,
-            other => return Err(format!("unknown device allocation class {other}")),
-        };
-        let owner = PoolOwner::new(self.backend, self.model_id, self.replica_id, class);
-        let allocation = self
-            .pool
-            .alloc(owner, bytes, alignment)
-            .map_err(|error| format!("runtime device-pool allocation failed: {error}"))?;
-        let pointer = self.pool.allocation_ptr(&allocation);
-        let granted_bytes = allocation.bytes() as u64;
-        let allocation_id = match self.next_allocation_id.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |next| next.checked_add(1),
-        ) {
-            Ok(allocation_id) => allocation_id,
-            Err(_) => {
-                let _ = self.pool.free(allocation);
-                return Err("native device allocation ID space exhausted".to_string());
-            }
-        };
-        self.allocations
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(allocation_id, allocation);
-        Ok(KapslDeviceAllocationV1 {
-            struct_size: std::mem::size_of::<KapslDeviceAllocationV1>() as u32,
-            reserved: 0,
-            allocation_id,
-            device_ptr: pointer,
-            granted_bytes,
-        })
-    }
-
-    fn free(&self, returned: KapslDeviceAllocationV1) -> Result<(), String> {
-        if returned.struct_size < std::mem::size_of::<KapslDeviceAllocationV1>() as u32
-            || returned.reserved != 0
-            || returned.allocation_id == 0
-        {
-            return Err("device free contains an invalid allocation identity".to_string());
-        }
-        let mut allocations = self
-            .allocations
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let stored = allocations
-            .get(&returned.allocation_id)
-            .ok_or_else(|| "device free references an unknown allocation ID".to_string())?;
-        if self.pool.allocation_ptr(stored) != returned.device_ptr
-            || stored.bytes() as u64 != returned.granted_bytes
-        {
-            return Err(
-                "device free pointer or byte count does not match its allocation ID".to_string(),
-            );
-        }
-        let allocation = allocations
-            .remove(&returned.allocation_id)
-            .expect("allocation checked above");
-        drop(allocations);
-        self.pool
-            .free(allocation)
-            .map_err(|error| format!("runtime device-pool free failed: {error}"))
-    }
-
-    fn synchronize(&self, device_id: u32) -> Result<(), String> {
-        if device_id as usize != self.device_id {
-            return Err(format!(
-                "backend requested synchronization for device {device_id}, expected {}",
-                self.device_id
-            ));
-        }
-        self.pool
-            .device()
-            .bind_to_thread()
-            .map_err(|error| format!("bind CUDA device before synchronize: {error}"))?;
-        self.pool
-            .device()
-            .synchronize()
-            .map_err(|error| format!("synchronize governed CUDA device: {error}"))
-    }
-
-    fn live_allocations(&self) -> usize {
-        self.allocations
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .len()
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-impl Drop for GovernedDeviceHost {
-    fn drop(&mut self) {
-        let allocations = self
-            .allocations
-            .get_mut()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .drain()
-            .map(|(_, allocation)| allocation)
-            .collect::<Vec<_>>();
-        if allocations.is_empty() {
-            return;
-        }
-        log::error!(
-            "native backend leaked {} governed allocations; reclaiming after shutdown",
-            allocations.len()
-        );
-        if let Err(error) = self.pool.device().synchronize() {
-            log::error!("synchronize before reclaiming leaked native allocations: {error}");
-        }
-        for allocation in allocations {
-            if let Err(error) = self.pool.free(allocation) {
-                log::error!("reclaim leaked native allocation: {error}");
-            }
-        }
-    }
-}
-
-#[cfg(feature = "gpu-device-pool")]
-unsafe extern "C" fn allocate_device(
-    user_data: *mut c_void,
-    request: *const KapslDeviceAllocationRequestV1,
-    allocation_out: *mut KapslDeviceAllocationV1,
-) -> i32 {
-    catch_unwind(AssertUnwindSafe(|| {
-        if user_data.is_null() || request.is_null() || allocation_out.is_null() {
-            return KAPSL_STATUS_INVALID_ARGUMENT;
-        }
-        // SAFETY: non-null callback pointers are borrowed for this invocation.
-        let host = unsafe { &*(user_data as *const GovernedDeviceHost) };
-        let request = unsafe { *request };
-        match host.allocate(request) {
-            Ok(allocation) => {
-                // SAFETY: the caller provided a writable output slot.
-                unsafe { *allocation_out = allocation };
-                KAPSL_STATUS_OK
-            }
-            Err(error) => {
-                log::error!("native backend governed allocation rejected: {error}");
-                KAPSL_STATUS_BACKEND_ERROR
-            }
-        }
-    }))
-    .unwrap_or(KAPSL_STATUS_PANIC)
-}
-
-#[cfg(feature = "gpu-device-pool")]
-unsafe extern "C" fn free_device(
-    user_data: *mut c_void,
-    allocation: *const KapslDeviceAllocationV1,
-) -> i32 {
-    catch_unwind(AssertUnwindSafe(|| {
-        if user_data.is_null() || allocation.is_null() {
-            return KAPSL_STATUS_INVALID_ARGUMENT;
-        }
-        // SAFETY: non-null callback pointers are borrowed for this invocation.
-        let host = unsafe { &*(user_data as *const GovernedDeviceHost) };
-        let allocation = unsafe { *allocation };
-        match host.free(allocation) {
-            Ok(()) => KAPSL_STATUS_OK,
-            Err(error) => {
-                log::error!("native backend governed free rejected: {error}");
-                KAPSL_STATUS_INVALID_ARGUMENT
-            }
-        }
-    }))
-    .unwrap_or(KAPSL_STATUS_PANIC)
-}
-
-#[cfg(feature = "gpu-device-pool")]
-unsafe extern "C" fn synchronize_device(user_data: *mut c_void, device_id: u32) -> i32 {
-    catch_unwind(AssertUnwindSafe(|| {
-        if user_data.is_null() {
-            return KAPSL_STATUS_INVALID_ARGUMENT;
-        }
-        // SAFETY: user_data points to the retained governed host.
-        let host = unsafe { &*(user_data as *const GovernedDeviceHost) };
-        match host.synchronize(device_id) {
-            Ok(()) => KAPSL_STATUS_OK,
-            Err(error) => {
-                log::error!("native backend device synchronize rejected: {error}");
-                KAPSL_STATUS_BACKEND_ERROR
-            }
-        }
-    }))
-    .unwrap_or(KAPSL_STATUS_PANIC)
-}
-
 fn take_owned_buffer(
     api: &KapslBackendApiV1,
     buffer: KapslOwnedBuffer,
@@ -2344,7 +2095,10 @@ mod tests {
         }
     }
 
-    fn test_manifest(accelerator_profile: &str, capabilities: u64) -> BackendPackManifest {
+    pub(super) fn test_manifest(
+        accelerator_profile: &str,
+        capabilities: u64,
+    ) -> BackendPackManifest {
         let profile = match accelerator_profile {
             "cpu" => crate::backend::ONNX_CPU_PACK_PROFILE,
             "cuda" => crate::backend::ONNX_CUDA12_PACK_PROFILE,
@@ -2665,6 +2419,7 @@ mod tests {
     fn stream_callback_copies_borrowed_chunks_into_the_bounded_bridge() {
         let (sender, receiver) = async_channel::bounded(1);
         let mut context = NativeStreamCallbackContext {
+            request_id: 9,
             sender,
             callback_error: None,
             consumer_closed: false,
@@ -2721,6 +2476,7 @@ mod tests {
             .unwrap();
         let producer = std::thread::spawn(move || {
             let mut context = NativeStreamCallbackContext {
+                request_id: 10,
                 sender,
                 callback_error: None,
                 consumer_closed: false,
@@ -2783,6 +2539,7 @@ mod tests {
         let (sender, receiver) = async_channel::bounded(1);
         drop(receiver);
         let mut context = NativeStreamCallbackContext {
+            request_id: 10,
             sender,
             callback_error: None,
             consumer_closed: false,
@@ -2861,3 +2618,6 @@ mod tests {
         assert!(result.is_err());
     }
 }
+
+#[cfg(test)]
+mod boundary_tests;

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native.rs
@@ -8,7 +8,6 @@
 use super::{BackendExecutionMode, BackendPackManifest};
 use crate::runtime::RuntimeResources;
 use kapsl_backend_abi::*;
-use kapsl_backends::OnnxRuntimeTuning;
 use kapsl_core::Manifest;
 use kapsl_engine_api::{
     BatchingMode, BatchingPolicy, BinaryTensorPacket, CancellationToken, Engine, EngineError,
@@ -416,7 +415,7 @@ pub(crate) fn create_native_backend_pack_engine(
     device_id: usize,
     model_id: u32,
     replica_id: u32,
-    tuning: Option<&OnnxRuntimeTuning>,
+    adapter_options: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<Box<dyn Engine>, String> {
     let pack = active_native_pack(identity).ok_or_else(|| {
         format!(
@@ -436,7 +435,7 @@ pub(crate) fn create_native_backend_pack_engine(
         device_id,
         model_id,
         replica_id,
-        tuning,
+        adapter_options,
     )?;
     Ok(Box::new(NativePackedEngine { instance }))
 }
@@ -657,7 +656,7 @@ impl NativePackInstance {
         device_id: usize,
         model_id: u32,
         replica_id: u32,
-        tuning: Option<&OnnxRuntimeTuning>,
+        adapter_options: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<Arc<Self>, String> {
         let requires_governed_memory =
             pack.api.capabilities & KAPSL_BACKEND_CAP_GOVERNED_DEVICE_ALLOCATOR != 0;
@@ -671,7 +670,14 @@ impl NativePackInstance {
             pack.api.capabilities & KAPSL_BACKEND_CAP_SCOPED_DEVICE_ALLOCATOR != 0,
         )?;
         Self::initialize_with_host(
-            pack, manifest, provider, host, device_id, model_id, replica_id, tuning,
+            pack,
+            manifest,
+            provider,
+            host,
+            device_id,
+            model_id,
+            replica_id,
+            adapter_options,
         )
     }
 
@@ -684,7 +690,7 @@ impl NativePackInstance {
         device_id: usize,
         model_id: u32,
         replica_id: u32,
-        tuning: Option<&OnnxRuntimeTuning>,
+        adapter_options: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<Arc<Self>, String> {
         let requires_governed_memory =
             pack.api.capabilities & KAPSL_BACKEND_CAP_GOVERNED_DEVICE_ALLOCATOR != 0;
@@ -695,23 +701,25 @@ impl NativePackInstance {
         let profile = pack.manifest.profile.as_bytes();
         let manifest_json = serde_json::to_vec(manifest)
             .map_err(|error| format!("encode model manifest for native backend: {error}"))?;
-        let options_json = serde_json::to_vec(&serde_json::json!({
+        let mut options = serde_json::json!({
             "provider": provider,
             "accelerator_profile": pack.manifest.accelerator_profile,
             "pack_version": pack.manifest.pack_version,
             "descriptor": pack.descriptor,
             "pack_root": pack.root,
             "entrypoint": pack.entrypoint,
-            "onnx_tuning": tuning.map(|tuning| serde_json::json!({
-                "memory_pattern": tuning.memory_pattern,
-                "disable_cpu_mem_arena": tuning.disable_cpu_mem_arena,
-                "session_buckets": tuning.session_buckets,
-                "bucket_dim_granularity": tuning.bucket_dim_granularity,
-                "bucket_max_dims": tuning.bucket_max_dims,
-                "peak_concurrency_hint": tuning.peak_concurrency_hint,
-            })),
-        }))
-        .map_err(|error| format!("encode native backend options: {error}"))?;
+        });
+        let options_object = options.as_object_mut().expect("host options are an object");
+        for (key, value) in adapter_options {
+            if options_object.contains_key(key) {
+                return Err(format!(
+                    "adapter option `{key}` conflicts with engine-owned native configuration"
+                ));
+            }
+            options_object.insert(key.clone(), value.clone());
+        }
+        let options_json = serde_json::to_vec(&options)
+            .map_err(|error| format!("encode native backend options: {error}"))?;
         let config = KapslBackendConfigV1 {
             struct_size: std::mem::size_of::<KapslBackendConfigV1>() as u32,
             device_id: u32::try_from(device_id)

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native/allocator.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native/allocator.rs
@@ -1,0 +1,908 @@
+//! Engine-owned allocation governance. Only the physical pool is replaceable
+//! in host-only tests; ABI validation, attribution and lifecycle are shared.
+
+use super::*;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+// Allocation handles must not alias across instances, even if a pool later
+// reuses the same address and size for another model or replica.
+static NEXT_ALLOCATION_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(super) trait DeviceAllocation: Send {
+    fn pointer(&self) -> usize;
+    fn bytes(&self) -> usize;
+    // Failure retains ownership and accounting so the caller can retry.
+    fn free(&self) -> Result<(), String>;
+}
+
+pub(super) trait DeviceAllocator: Send + Sync {
+    // Implementations must enforce the instance's admission and aggregate
+    // quota across allocation classes, including competing pool owners.
+    fn allocate(
+        &self,
+        class: u32,
+        bytes: usize,
+        alignment: usize,
+    ) -> Result<Box<dyn DeviceAllocation>, String>;
+    fn synchronize(&self) -> Result<(), String>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AllocationScope {
+    kind: u32,
+    id: u64,
+    model_id: u32,
+    replica_id: u32,
+    request_ids: Vec<u64>,
+    operation: u64,
+}
+
+struct LiveAllocation {
+    storage: Box<dyn DeviceAllocation>,
+    class: u32,
+    scope: Arc<AllocationScope>,
+}
+
+struct ActiveRequest {
+    operation: u64,
+    cancellation: Option<CancellationToken>,
+    cancelled: bool,
+}
+
+#[derive(Default)]
+struct AllocationLedger {
+    enabled: bool,
+    cleanup_pending: bool,
+    model_operation: Option<u64>,
+    next_operation: u64,
+    requests: HashMap<u64, ActiveRequest>,
+    scopes: HashMap<u64, Arc<AllocationScope>>,
+    // Inclusive intervals compact sequential retired scope IDs, without
+    // keeping per-request metadata forever or permitting ID reuse on reload.
+    used_scope_ids: BTreeMap<u64, u64>,
+    allocations: HashMap<u64, LiveAllocation>,
+}
+
+impl AllocationLedger {
+    fn next_operation(&mut self) -> Result<u64, String> {
+        self.next_operation = self
+            .next_operation
+            .checked_add(1)
+            .ok_or("native allocation operation IDs exhausted")?;
+        Ok(self.next_operation)
+    }
+
+    fn remember_scope_id(&mut self, id: u64) -> Result<(), String> {
+        let mut start = id;
+        let mut end = id;
+        if let Some((&left, &right)) = self.used_scope_ids.range(..=id).next_back() {
+            if id <= right {
+                return Err("native allocation scope ID was already retired".into());
+            }
+            if right.checked_add(1) == Some(id) {
+                start = left;
+                self.used_scope_ids.remove(&left);
+            }
+        }
+        if let Some((&left, &right)) = self.used_scope_ids.range(id..).next() {
+            if id.checked_add(1) == Some(left) {
+                end = right;
+                self.used_scope_ids.remove(&left);
+            }
+        }
+        self.used_scope_ids.insert(start, end);
+        Ok(())
+    }
+}
+
+pub(super) struct GovernedDeviceHost {
+    allocator: Arc<dyn DeviceAllocator>,
+    device_id: u32,
+    model_id: u32,
+    replica_id: u32,
+    require_scoped: bool,
+    ledger: Mutex<AllocationLedger>,
+}
+
+pub(super) struct NativeAllocationCall<'a> {
+    host: Option<&'a GovernedDeviceHost>,
+    operation: u64,
+}
+
+impl Drop for NativeAllocationCall<'_> {
+    fn drop(&mut self) {
+        if let Some(host) = self.host {
+            let mut ledger = host.ledger.lock().unwrap_or_else(|p| p.into_inner());
+            ledger
+                .requests
+                .retain(|_, request| request.operation != self.operation);
+            ledger
+                .scopes
+                .retain(|_, scope| scope.operation != self.operation);
+            if ledger.model_operation == Some(self.operation) {
+                ledger.model_operation = None;
+            }
+            // Request completion retires attribution authority, not memory.
+            // Adapters may retain arenas until their matching free or unload.
+        }
+    }
+}
+
+pub(super) struct NativeBackendHost {
+    table: Box<KapslBackendHostScopedAllocatorV1>,
+    pub(super) allocator: Option<Arc<GovernedDeviceHost>>,
+}
+
+impl NativeBackendHost {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        resources: &RuntimeResources,
+        backend: &str,
+        device_id: usize,
+        model_id: u32,
+        replica_id: u32,
+        require_governed: bool,
+        require_scoped: bool,
+    ) -> Result<Self, String> {
+        let device_id = u32::try_from(device_id).map_err(|_| "device ID exceeds native ABI")?;
+        if !require_governed {
+            return Ok(Self::from_allocator(None));
+        }
+        #[cfg(feature = "gpu-device-pool")]
+        {
+            let pool = resources.device_pool(device_id as usize).ok_or_else(|| format!(
+                "native {backend} pack requires governed device memory, but device {device_id} has no runtime-owned pool"
+            ))?;
+            let allocator = Arc::new(GpuAllocator {
+                pool,
+                backend: pool_backend(backend),
+                model_id,
+                replica_id,
+            });
+            Ok(Self::with_allocator(
+                allocator,
+                device_id,
+                model_id,
+                replica_id,
+                require_scoped,
+            ))
+        }
+        #[cfg(not(feature = "gpu-device-pool"))]
+        {
+            let _ = (
+                resources,
+                backend,
+                device_id,
+                model_id,
+                replica_id,
+                require_scoped,
+            );
+            Err("native pack requires governed device memory, but this runtime was built without GPU pool authority".into())
+        }
+    }
+
+    #[cfg_attr(not(any(test, feature = "gpu-device-pool")), allow(dead_code))]
+    pub(super) fn with_allocator(
+        allocator: Arc<dyn DeviceAllocator>,
+        device_id: u32,
+        model_id: u32,
+        replica_id: u32,
+        require_scoped: bool,
+    ) -> Self {
+        Self::from_allocator(Some(Arc::new(GovernedDeviceHost {
+            allocator,
+            device_id,
+            model_id,
+            replica_id,
+            require_scoped,
+            ledger: Mutex::new(AllocationLedger::default()),
+        })))
+    }
+
+    fn from_allocator(allocator: Option<Arc<GovernedDeviceHost>>) -> Self {
+        let base = KapslBackendHostV1 {
+            struct_size: std::mem::size_of::<KapslBackendHostV1>() as u32,
+            abi_version: KAPSL_BACKEND_ABI_VERSION,
+            user_data: allocator
+                .as_ref()
+                .map_or(std::ptr::null_mut(), |a| Arc::as_ptr(a) as *mut c_void),
+            log: Some(host_log),
+            allocate_device: allocator
+                .as_ref()
+                .map(|_| allocate_device as KapslDeviceAllocateFn),
+            free_device: allocator.as_ref().map(|_| free_device as KapslDeviceFreeFn),
+            synchronize_device: allocator
+                .as_ref()
+                .map(|_| synchronize_device as KapslDeviceSynchronizeFn),
+        };
+        let table = if allocator.is_some() {
+            KapslBackendHostScopedAllocatorV1::new(base, allocate_device_scoped)
+        } else {
+            KapslBackendHostScopedAllocatorV1 {
+                base,
+                scoped_allocator_version: 0,
+                reserved: 0,
+                allocate_device_scoped: None,
+            }
+        };
+        Self {
+            table: Box::new(table),
+            allocator,
+        }
+    }
+
+    pub(super) fn table(&self) -> *const KapslBackendHostV1 {
+        &self.table.base
+    }
+
+    pub(super) fn begin_model_call(&self) -> Result<NativeAllocationCall<'_>, String> {
+        let Some(host) = self.allocator.as_deref() else {
+            return Ok(NativeAllocationCall {
+                host: None,
+                operation: 0,
+            });
+        };
+        let mut ledger = host.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        if ledger.model_operation.is_some() || !ledger.requests.is_empty() || ledger.cleanup_pending
+        {
+            return Err(
+                "native model lifecycle started with outstanding calls or incomplete cleanup"
+                    .into(),
+            );
+        }
+        ledger.enabled = true;
+        let operation = ledger.next_operation()?;
+        ledger.model_operation = Some(operation);
+        Ok(NativeAllocationCall {
+            host: Some(host),
+            operation,
+        })
+    }
+
+    pub(super) fn begin_requests(
+        &self,
+        requests: impl IntoIterator<Item = (u64, Option<CancellationToken>)>,
+    ) -> Result<NativeAllocationCall<'_>, EngineError> {
+        let requests: Vec<_> = requests.into_iter().collect();
+        if requests
+            .iter()
+            .any(|(_, token)| token.as_ref().is_some_and(CancellationToken::is_cancelled))
+        {
+            return Err(EngineError::cancelled(
+                "native request was cancelled before allocation admission",
+            ));
+        }
+        let Some(host) = self.allocator.as_deref() else {
+            return Ok(NativeAllocationCall {
+                host: None,
+                operation: 0,
+            });
+        };
+        let mut ledger = host.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        if !ledger.enabled || ledger.model_operation.is_some() {
+            return Err(EngineError::backend(
+                "native allocator is outside the loaded lifecycle",
+            ));
+        }
+        let mut unique = HashSet::new();
+        if requests.is_empty()
+            || requests
+                .iter()
+                .any(|(id, _)| *id == 0 || !unique.insert(*id) || ledger.requests.contains_key(id))
+        {
+            return Err(EngineError::backend(
+                "invalid native request ownership registration",
+            ));
+        }
+        let operation = ledger.next_operation().map_err(EngineError::backend)?;
+        for (id, cancellation) in requests {
+            ledger.requests.insert(
+                id,
+                ActiveRequest {
+                    operation,
+                    cancellation,
+                    cancelled: false,
+                },
+            );
+        }
+        Ok(NativeAllocationCall {
+            host: Some(host),
+            operation,
+        })
+    }
+
+    pub(super) fn stop_allocating(&self) {
+        if let Some(host) = &self.allocator {
+            let mut ledger = host.ledger.lock().unwrap_or_else(|p| p.into_inner());
+            ledger.enabled = false;
+            ledger.cleanup_pending = true;
+        }
+    }
+
+    pub(super) fn reclaim(&self) -> Result<(), String> {
+        self.allocator
+            .as_ref()
+            .map_or(Ok(()), |host| host.reclaim())
+    }
+
+    pub(super) fn live_allocations(&self) -> usize {
+        self.allocator.as_ref().map_or(0, |host| {
+            host.ledger
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .allocations
+                .len()
+        })
+    }
+
+    pub(super) fn live_bytes(&self) -> usize {
+        self.allocator.as_ref().map_or(0, |host| {
+            host.ledger
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .allocations
+                .values()
+                .fold(0usize, |bytes, allocation| {
+                    bytes.saturating_add(allocation.storage.bytes())
+                })
+        })
+    }
+
+    pub(super) fn actual_memory(&self, mut report: MemoryReport) -> MemoryReport {
+        use kapsl_engine_api::{MemoryAllocationClass as Class, MemoryDomain};
+        let Some(host) = &self.allocator else {
+            return report;
+        };
+        let domain = MemoryDomain::Cuda {
+            device_id: host.device_id as usize,
+        };
+        // Governed device bytes come from the engine's live ledger. Adapter
+        // reports remain authoritative for its other memory domains.
+        report
+            .allocations
+            .retain(|allocation| allocation.domain != domain);
+        let ledger = host.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        let mut allocations: Vec<_> = ledger.allocations.iter().collect();
+        allocations.sort_by_key(|(id, _)| **id);
+        for (id, allocation) in allocations {
+            let scope = &allocation.scope;
+            let class = match allocation.class {
+                KAPSL_ALLOCATION_CLASS_WEIGHTS => Class::PersistentWeights,
+                KAPSL_ALLOCATION_CLASS_WORKSPACE => Class::TransientWorkspace,
+                KAPSL_ALLOCATION_CLASS_KV => Class::KvCache,
+                KAPSL_ALLOCATION_CLASS_REQUEST => Class::RequestTransient,
+                _ => Class::ExternallyOwned,
+            };
+            report.extend(MemoryReport::runtime(
+                format!("native/device-{}/model-{}/replica-{}/scope-{}-{}/requests-{:?}/allocation-{id}", host.device_id, scope.model_id, scope.replica_id, scope.kind, scope.id, scope.request_ids),
+                domain.clone(), class, allocation.storage.bytes(),
+            ));
+        }
+        report
+    }
+}
+
+impl GovernedDeviceHost {
+    pub(super) fn cancel(&self, id: u64) {
+        if let Some(request) = self
+            .ledger
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .requests
+            .get_mut(&id)
+        {
+            request.cancelled = true;
+        }
+    }
+
+    unsafe fn allocate_scoped(
+        &self,
+        request: KapslScopedDeviceAllocationRequestV1,
+    ) -> Result<KapslDeviceAllocationV1, String> {
+        if !request.is_well_formed() {
+            return Err("malformed scoped device allocation request".into());
+        }
+        if request.device_id != self.device_id
+            || request.scope.model_id != self.model_id
+            || request.scope.replica_id != self.replica_id
+        {
+            return Err("device allocation ownership does not match its backend instance".into());
+        }
+        let mut ledger = self.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        if !ledger.enabled {
+            return Err("native allocator is closed for this lifecycle".into());
+        }
+        // Bound the borrowed array before dereferencing it, including on
+        // 32-bit hosts. The adapter owns readable storage for this callback.
+        if request.scope.request_count as usize > ledger.requests.len() {
+            return Err("allocation references requests not owned by this instance".into());
+        }
+        if !request.scope.request_ids.is_null()
+            && !(request.scope.request_ids as usize).is_multiple_of(std::mem::align_of::<u64>())
+        {
+            return Err("allocation request IDs are misaligned".into());
+        }
+        // SAFETY: cardinality/alignment checked; storage lifetime is the ABI caller's contract.
+        let ids =
+            unsafe { request.scope.request_ids() }.ok_or("missing allocation request ownership")?;
+        let operation = if ids.is_empty() {
+            ledger
+                .model_operation
+                .ok_or("model/replica allocations require an active model lifecycle call")?
+        } else {
+            let mut unique = HashSet::new();
+            let mut operation = None;
+            for id in ids {
+                if *id == 0 || !unique.insert(*id) {
+                    return Err("allocation request IDs must be non-zero and distinct".into());
+                }
+                let active = ledger
+                    .requests
+                    .get(id)
+                    .ok_or("allocation request is not active in this instance")?;
+                if active.cancelled
+                    || active
+                        .cancellation
+                        .as_ref()
+                        .is_some_and(CancellationToken::is_cancelled)
+                {
+                    return Err("allocation request has been cancelled".into());
+                }
+                if operation.is_some_and(|operation| operation != active.operation) {
+                    return Err("allocation batch combines unrelated native dispatches".into());
+                }
+                operation = Some(active.operation);
+            }
+            operation.expect("nonempty validated request IDs")
+        };
+        let scope = AllocationScope {
+            kind: request.scope.scope_kind,
+            id: request.scope.scope_id,
+            model_id: self.model_id,
+            replica_id: self.replica_id,
+            request_ids: ids.to_vec(),
+            operation,
+        };
+        let scope = if let Some(existing) = ledger.scopes.get(&scope.id) {
+            if **existing != scope {
+                return Err("allocation scope ID was rebound to different ownership".into());
+            }
+            Arc::clone(existing)
+        } else {
+            ledger.remember_scope_id(scope.id)?;
+            let scope = Arc::new(scope);
+            ledger.scopes.insert(scope.id, Arc::clone(&scope));
+            scope
+        };
+        self.allocate_locked(
+            &mut ledger,
+            scope,
+            request.memory_kind,
+            request.allocation_class,
+            request.bytes,
+            request.alignment,
+        )
+    }
+
+    fn allocate_legacy(
+        &self,
+        request: KapslDeviceAllocationRequestV1,
+    ) -> Result<KapslDeviceAllocationV1, String> {
+        if self.require_scoped {
+            return Err(
+                "backend requires scoped allocation; the legacy callback cannot bypass ownership"
+                    .into(),
+            );
+        }
+        if request.reserved != 0
+            || request.flags != 0
+            || request.device_id != self.device_id
+            || request.model_id != self.model_id
+            || request.replica_id != self.replica_id
+        {
+            return Err("invalid legacy device allocation ownership or flags".into());
+        }
+        let mut ledger = self.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        if !ledger.enabled {
+            return Err("native allocator is closed for this lifecycle".into());
+        }
+        let (operation, ids) = if let Some(operation) = ledger.model_operation {
+            (operation, Vec::new())
+        } else {
+            let mut operations = ledger.requests.values().map(|r| r.operation);
+            let first = operations
+                .next()
+                .ok_or("legacy allocation has no active owner")?;
+            if operations.any(|operation| operation != first) {
+                return Err("legacy allocation has ambiguous request ownership".into());
+            }
+            if ledger.requests.values().any(|r| {
+                r.cancelled
+                    || r.cancellation
+                        .as_ref()
+                        .is_some_and(CancellationToken::is_cancelled)
+            }) {
+                return Err("legacy allocation request has been cancelled".into());
+            }
+            (first, ledger.requests.keys().copied().collect::<Vec<_>>())
+        };
+        let kind = match ids.len() {
+            0 => KAPSL_ALLOCATION_SCOPE_REPLICA,
+            1 => KAPSL_ALLOCATION_SCOPE_REQUEST,
+            _ => KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH,
+        };
+        // Scope ID zero is diagnostic-only for the legacy ABI. It never enters
+        // the adapter's scoped-ID namespace or relaxes the scoped contract.
+        let scope = Arc::new(AllocationScope {
+            kind,
+            id: 0,
+            model_id: self.model_id,
+            replica_id: self.replica_id,
+            request_ids: ids,
+            operation,
+        });
+        self.allocate_locked(
+            &mut ledger,
+            scope,
+            request.memory_kind,
+            request.allocation_class,
+            request.bytes,
+            request.alignment,
+        )
+    }
+
+    fn allocate_locked(
+        &self,
+        ledger: &mut AllocationLedger,
+        scope: Arc<AllocationScope>,
+        memory_kind: u32,
+        class: u32,
+        bytes: u64,
+        alignment: u64,
+    ) -> Result<KapslDeviceAllocationV1, String> {
+        if memory_kind != KAPSL_MEMORY_CUDA
+            || !matches!(
+                class,
+                KAPSL_ALLOCATION_CLASS_WEIGHTS
+                    | KAPSL_ALLOCATION_CLASS_WORKSPACE
+                    | KAPSL_ALLOCATION_CLASS_KV
+                    | KAPSL_ALLOCATION_CLASS_REQUEST
+                    | KAPSL_ALLOCATION_CLASS_OTHER
+            )
+        {
+            return Err("unsupported device memory kind or allocation class".into());
+        }
+        let bytes = usize::try_from(bytes).map_err(|_| "allocation bytes exceed this platform")?;
+        let alignment =
+            usize::try_from(alignment).map_err(|_| "allocation alignment exceeds this platform")?;
+        if bytes == 0 || !alignment.is_power_of_two() || bytes.checked_add(alignment - 1).is_none()
+        {
+            return Err("invalid device allocation size or alignment".into());
+        }
+        let id = NEXT_ALLOCATION_ID
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_add(1))
+            .map_err(|_| "native allocation IDs exhausted")?;
+        let storage = self
+            .allocator
+            .allocate(class, bytes, alignment)
+            .map_err(|error| format!("device {} scope {scope:?}: {error}", self.device_id))?;
+        let allocation = KapslDeviceAllocationV1 {
+            struct_size: std::mem::size_of::<KapslDeviceAllocationV1>() as u32,
+            reserved: 0,
+            allocation_id: id,
+            device_ptr: storage.pointer() as *mut c_void,
+            granted_bytes: storage.bytes() as u64,
+        };
+        log::debug!(
+            "native governed allocate id={id} device={} class={class} bytes={} scope={scope:?}",
+            self.device_id,
+            allocation.granted_bytes
+        );
+        ledger.allocations.insert(
+            id,
+            LiveAllocation {
+                storage,
+                class,
+                scope,
+            },
+        );
+        Ok(allocation)
+    }
+
+    fn free(&self, returned: KapslDeviceAllocationV1) -> Result<(), String> {
+        if returned.reserved != 0 || returned.allocation_id == 0 {
+            return Err("invalid device free identity".into());
+        }
+        let mut ledger = self.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        let allocation = ledger
+            .allocations
+            .get(&returned.allocation_id)
+            .ok_or("device free references an unknown allocation ID")?;
+        if allocation.storage.pointer() != returned.device_ptr as usize
+            || allocation.storage.bytes() as u64 != returned.granted_bytes
+        {
+            return Err("device free pointer or bytes do not match its allocation ID".into());
+        }
+        // A successful free makes the range immediately reusable by another
+        // model. Never rely on an adapter's declaration that it synchronized.
+        self.allocator.synchronize()?;
+        allocation.storage.free()?;
+        log::debug!(
+            "native governed free id={} device={} class={} bytes={} scope={:?}",
+            returned.allocation_id,
+            self.device_id,
+            allocation.class,
+            returned.granted_bytes,
+            allocation.scope
+        );
+        ledger.allocations.remove(&returned.allocation_id);
+        Ok(())
+    }
+
+    fn reclaim(&self) -> Result<(), String> {
+        let mut ledger = self.ledger.lock().unwrap_or_else(|p| p.into_inner());
+        ledger.enabled = false;
+        ledger.cleanup_pending = true;
+        if !ledger.requests.is_empty() || ledger.model_operation.is_some() {
+            return Err("cannot reclaim memory while native calls are active".into());
+        }
+        if ledger.allocations.is_empty() {
+            ledger.cleanup_pending = false;
+            return Ok(());
+        }
+        self.allocator.synchronize()?;
+        let ids: Vec<_> = ledger.allocations.keys().copied().collect();
+        let mut failure = None;
+        for id in ids {
+            let allocation = &ledger.allocations[&id];
+            log::warn!(
+                "reclaim native allocation id={id} device={} class={} bytes={} scope={:?}",
+                self.device_id,
+                allocation.class,
+                allocation.storage.bytes(),
+                allocation.scope
+            );
+            match allocation.storage.free() {
+                Ok(()) => {
+                    ledger.allocations.remove(&id);
+                }
+                Err(error) => {
+                    failure = Some(error);
+                }
+            }
+        }
+        ledger.cleanup_pending = failure.is_some();
+        failure.map_or(Ok(()), Err)
+    }
+}
+
+impl Drop for GovernedDeviceHost {
+    fn drop(&mut self) {
+        if let Err(error) = self.reclaim() {
+            log::error!("native allocation cleanup failed; unreclaimed ranges remain charged and unavailable: {error}");
+            // Retain the pool and allocation tokens when synchronization or a
+            // free failed. Reusing or dropping potentially busy storage would
+            // violate isolation; process teardown is the terminal boundary.
+            let ledger = self.ledger.get_mut().unwrap_or_else(|p| p.into_inner());
+            for (_, allocation) in ledger.allocations.drain() {
+                std::mem::forget(allocation);
+            }
+        }
+    }
+}
+
+// Read only the size prefix until the caller proves a complete ABI object.
+unsafe fn read_sized<T: Copy>(pointer: *const T) -> Result<T, String> {
+    if pointer.is_null() || !(pointer as usize).is_multiple_of(std::mem::align_of::<T>()) {
+        return Err("null or misaligned native allocator argument".into());
+    }
+    // SAFETY: non-null input storage includes its u32 size prefix by ABI contract.
+    if unsafe { pointer.cast::<u32>().read() } < std::mem::size_of::<T>() as u32 {
+        return Err("truncated native allocator argument".into());
+    }
+    // SAFETY: the advertised size covers the complete object.
+    Ok(unsafe { pointer.read() })
+}
+
+unsafe extern "C" fn allocate_device_scoped(
+    user_data: *mut c_void,
+    request: *const KapslScopedDeviceAllocationRequestV1,
+    out: *mut KapslDeviceAllocationV1,
+) -> i32 {
+    allocation_callback(user_data, out, |host| {
+        // SAFETY: pointers are borrowed for the synchronous host callback.
+        unsafe { host.allocate_scoped(read_sized(request)?) }
+    })
+}
+
+unsafe extern "C" fn allocate_device(
+    user_data: *mut c_void,
+    request: *const KapslDeviceAllocationRequestV1,
+    out: *mut KapslDeviceAllocationV1,
+) -> i32 {
+    allocation_callback(user_data, out, |host| {
+        // SAFETY: request remains borrowed for this callback.
+        host.allocate_legacy(unsafe { read_sized(request)? })
+    })
+}
+
+fn allocation_callback(
+    user_data: *mut c_void,
+    out: *mut KapslDeviceAllocationV1,
+    allocate: impl FnOnce(&GovernedDeviceHost) -> Result<KapslDeviceAllocationV1, String>,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if user_data.is_null()
+            || out.is_null()
+            || !(out as usize).is_multiple_of(std::mem::align_of::<KapslDeviceAllocationV1>())
+        {
+            return KAPSL_STATUS_INVALID_ARGUMENT;
+        }
+        // SAFETY: caller supplies a writable output slot and the retained host context.
+        unsafe {
+            *out = KapslDeviceAllocationV1::empty();
+        }
+        let host = unsafe { &*user_data.cast::<GovernedDeviceHost>() };
+        match allocate(host) {
+            Ok(allocation) => {
+                unsafe {
+                    *out = allocation;
+                }
+                KAPSL_STATUS_OK
+            }
+            Err(error) => {
+                log::error!(
+                    "native governed allocation rejected device={} model={} replica={}: {error}",
+                    host.device_id,
+                    host.model_id,
+                    host.replica_id
+                );
+                KAPSL_STATUS_BACKEND_ERROR
+            }
+        }
+    }))
+    .unwrap_or(KAPSL_STATUS_PANIC)
+}
+
+unsafe extern "C" fn free_device(
+    user_data: *mut c_void,
+    allocation: *const KapslDeviceAllocationV1,
+) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if user_data.is_null() {
+            return KAPSL_STATUS_INVALID_ARGUMENT;
+        }
+        let host = unsafe { &*user_data.cast::<GovernedDeviceHost>() };
+        let result = unsafe { read_sized(allocation) }.and_then(|allocation| host.free(allocation));
+        match result {
+            Ok(()) => KAPSL_STATUS_OK,
+            Err(error) => {
+                log::error!("native governed free rejected: {error}");
+                KAPSL_STATUS_BACKEND_ERROR
+            }
+        }
+    }))
+    .unwrap_or(KAPSL_STATUS_PANIC)
+}
+
+unsafe extern "C" fn synchronize_device(user_data: *mut c_void, device_id: u32) -> i32 {
+    catch_unwind(AssertUnwindSafe(|| {
+        if user_data.is_null() {
+            return KAPSL_STATUS_INVALID_ARGUMENT;
+        }
+        let host = unsafe { &*user_data.cast::<GovernedDeviceHost>() };
+        if device_id != host.device_id {
+            return KAPSL_STATUS_INVALID_ARGUMENT;
+        }
+        match host.allocator.synchronize() {
+            Ok(()) => KAPSL_STATUS_OK,
+            Err(error) => {
+                log::error!("native device synchronization failed: {error}");
+                KAPSL_STATUS_BACKEND_ERROR
+            }
+        }
+    }))
+    .unwrap_or(KAPSL_STATUS_PANIC)
+}
+
+#[cfg(feature = "gpu-device-pool")]
+use kapsl_hal::gpu_arena::{
+    GpuAllocation, GpuDevicePool, PoolAllocationClass, PoolBackend, PoolOwner,
+};
+
+#[cfg(feature = "gpu-device-pool")]
+fn pool_backend(backend: &str) -> PoolBackend {
+    match backend.trim().to_ascii_lowercase().as_str() {
+        "onnx" | "ort" | "onnxruntime" => PoolBackend::Onnx,
+        "llama.cpp" | "llama_cpp" | "llama-cpp" => PoolBackend::Gguf,
+        _ => PoolBackend::Native,
+    }
+}
+
+#[cfg(feature = "gpu-device-pool")]
+struct GpuAllocator {
+    pool: Arc<GpuDevicePool>,
+    backend: PoolBackend,
+    model_id: u32,
+    replica_id: u32,
+}
+
+#[cfg(feature = "gpu-device-pool")]
+struct GpuStorage {
+    pool: Arc<GpuDevicePool>,
+    allocation: GpuAllocation,
+}
+
+#[cfg(feature = "gpu-device-pool")]
+impl DeviceAllocator for GpuAllocator {
+    fn allocate(
+        &self,
+        class: u32,
+        bytes: usize,
+        alignment: usize,
+    ) -> Result<Box<dyn DeviceAllocation>, String> {
+        let class = match class {
+            KAPSL_ALLOCATION_CLASS_WEIGHTS => PoolAllocationClass::PersistentWeights,
+            KAPSL_ALLOCATION_CLASS_WORKSPACE => PoolAllocationClass::TransientWorkspace,
+            KAPSL_ALLOCATION_CLASS_KV => PoolAllocationClass::KvCache,
+            KAPSL_ALLOCATION_CLASS_REQUEST => PoolAllocationClass::RequestTransient,
+            KAPSL_ALLOCATION_CLASS_OTHER => PoolAllocationClass::ExternallyOwned,
+            _ => return Err("unknown device allocation class".into()),
+        };
+        let owner = PoolOwner::new(self.backend, self.model_id, self.replica_id, class);
+        if !self
+            .pool
+            .snapshot()
+            .owners
+            .iter()
+            .any(|entry| entry.owner.workload() == owner.workload() && entry.admitted)
+        {
+            return Err(format!(
+                "native device owner {owner:?} has no engine memory admission"
+            ));
+        }
+        // The engine holds this owner's memory lease through unload. The pool
+        // atomically enforces its aggregate quota and other owners' guarantees.
+        let allocation = self
+            .pool
+            .alloc(owner, bytes, alignment)
+            .map_err(|e| e.to_string())?;
+        // The HAL aligns offsets in its arena; validate the absolute address
+        // as well before publishing an alignment promise through the ABI.
+        let pointer = self.pool.allocation_ptr(&allocation) as usize;
+        if pointer == 0 || !pointer.is_multiple_of(alignment) {
+            self.pool.free(allocation).map_err(|e| e.to_string())?;
+            return Err("device pool cannot satisfy the requested pointer alignment".into());
+        }
+        Ok(Box::new(GpuStorage {
+            pool: Arc::clone(&self.pool),
+            allocation,
+        }))
+    }
+    fn synchronize(&self) -> Result<(), String> {
+        self.pool
+            .device()
+            .bind_to_thread()
+            .map_err(|e| e.to_string())?;
+        self.pool.device().synchronize().map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(feature = "gpu-device-pool")]
+impl DeviceAllocation for GpuStorage {
+    fn pointer(&self) -> usize {
+        self.pool.allocation_ptr(&self.allocation) as usize
+    }
+    fn bytes(&self) -> usize {
+        self.allocation.bytes()
+    }
+    fn free(&self) -> Result<(), String> {
+        self.pool
+            .free(self.allocation.clone())
+            .map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests;

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native/allocator/tests.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native/allocator/tests.rs
@@ -1,0 +1,536 @@
+use super::*;
+
+type Owner = (u32, u32);
+
+#[derive(Default)]
+pub(crate) struct FakePool {
+    state: Mutex<FakePoolState>,
+}
+
+#[derive(Default)]
+struct FakePoolState {
+    owners: HashMap<Owner, usize>,
+    live: HashMap<usize, (Owner, usize)>,
+    next: usize,
+    syncs: usize,
+    synchronized: HashSet<usize>,
+    frees: usize,
+    fail_sync: bool,
+    fail_free: bool,
+    panic_allocate: bool,
+}
+
+impl FakePool {
+    pub(crate) fn host(
+        self: &Arc<Self>,
+        model: u32,
+        replica: u32,
+        quota: usize,
+    ) -> NativeBackendHost {
+        self.state
+            .lock()
+            .unwrap()
+            .owners
+            .insert((model, replica), quota);
+        NativeBackendHost::with_allocator(
+            Arc::new(FakeAllocator {
+                pool: Arc::clone(self),
+                owner: (model, replica),
+            }),
+            0,
+            model,
+            replica,
+            true,
+        )
+    }
+
+    pub(crate) fn bytes(&self, owner: Owner) -> usize {
+        self.state
+            .lock()
+            .unwrap()
+            .live
+            .values()
+            .filter(|(o, _)| *o == owner)
+            .map(|(_, bytes)| bytes)
+            .sum()
+    }
+
+    pub(crate) fn fail_sync(&self, fail: bool) {
+        self.state.lock().unwrap().fail_sync = fail;
+    }
+}
+
+struct FakeAllocator {
+    pool: Arc<FakePool>,
+    owner: Owner,
+}
+struct FakeStorage {
+    pool: Arc<FakePool>,
+    pointer: usize,
+    bytes: usize,
+}
+
+impl DeviceAllocator for FakeAllocator {
+    fn allocate(
+        &self,
+        _class: u32,
+        bytes: usize,
+        alignment: usize,
+    ) -> Result<Box<dyn DeviceAllocation>, String> {
+        let mut state = self.pool.state.lock().unwrap();
+        if state.panic_allocate {
+            drop(state);
+            panic!("injected allocator panic");
+        }
+        let quota = *state
+            .owners
+            .get(&self.owner)
+            .ok_or("fake owner has no admission")?;
+        let used: usize = state
+            .live
+            .values()
+            .filter(|(owner, _)| *owner == self.owner)
+            .map(|(_, bytes)| bytes)
+            .sum();
+        let total: usize = state.live.values().map(|(_, bytes)| bytes).sum();
+        if bytes > quota.saturating_sub(used) || bytes > 4096_usize.saturating_sub(total) {
+            return Err("fake pool admission denied".into());
+        }
+        // No device or heap memory is exposed: adapter tests only use opaque
+        // device handles. Deliberately recycle addresses when the pool empties.
+        if state.live.is_empty() {
+            state.next = 4096;
+        }
+        let pointer = state.next.next_multiple_of(alignment);
+        state.next = pointer + bytes;
+        state.synchronized.remove(&pointer);
+        state.live.insert(pointer, (self.owner, bytes));
+        Ok(Box::new(FakeStorage {
+            pool: Arc::clone(&self.pool),
+            pointer,
+            bytes,
+        }))
+    }
+    fn synchronize(&self) -> Result<(), String> {
+        let mut state = self.pool.state.lock().unwrap();
+        state.syncs += 1;
+        if state.fail_sync {
+            Err("injected synchronization failure".into())
+        } else {
+            state.synchronized = state.live.keys().copied().collect();
+            Ok(())
+        }
+    }
+}
+
+impl DeviceAllocation for FakeStorage {
+    fn pointer(&self) -> usize {
+        self.pointer
+    }
+    fn bytes(&self) -> usize {
+        self.bytes
+    }
+    fn free(&self) -> Result<(), String> {
+        let mut state = self.pool.state.lock().unwrap();
+        if state.fail_free {
+            return Err("injected free failure".into());
+        }
+        assert!(
+            state.synchronized.remove(&self.pointer),
+            "engine must synchronize before each reuse"
+        );
+        state
+            .live
+            .remove(&self.pointer)
+            .ok_or("invalid fake free")?;
+        state.frees += 1;
+        Ok(())
+    }
+}
+
+fn request(kind: u32, id: u64, ids: &[u64]) -> KapslScopedDeviceAllocationRequestV1 {
+    KapslScopedDeviceAllocationRequestV1::new(
+        0,
+        KAPSL_MEMORY_CUDA,
+        KAPSL_ALLOCATION_CLASS_WORKSPACE,
+        KapslDeviceAllocationScopeV1::new(kind, id, 7, 2, ids),
+        128,
+        64,
+    )
+}
+
+fn allocate(
+    host: &NativeBackendHost,
+    request: &KapslScopedDeviceAllocationRequestV1,
+) -> Result<KapslDeviceAllocationV1, i32> {
+    let table = &host.table;
+    let mut result = KapslDeviceAllocationV1::empty();
+    let status = unsafe {
+        table.allocate_device_scoped.unwrap()(table.base.user_data, request, &mut result)
+    };
+    if status == KAPSL_STATUS_OK {
+        Ok(result)
+    } else {
+        assert_eq!(result.allocation_id, 0);
+        assert!(result.device_ptr.is_null());
+        Err(status)
+    }
+}
+
+fn free(host: &NativeBackendHost, allocation: &KapslDeviceAllocationV1) -> i32 {
+    unsafe { host.table.base.free_device.unwrap()(host.table.base.user_data, allocation) }
+}
+
+#[test]
+fn extended_table_and_all_scopes_preserve_charge_until_matching_free() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    let extension = unsafe { KapslBackendHostScopedAllocatorV1::from_base(host.table()) }.unwrap();
+    assert_eq!(
+        extension.base.struct_size as usize,
+        std::mem::size_of::<KapslBackendHostScopedAllocatorV1>()
+    );
+    assert_eq!(
+        extension.scoped_allocator_version,
+        KAPSL_SCOPED_DEVICE_ALLOCATOR_VERSION
+    );
+    assert!(extension.is_well_formed());
+    let model_call = host.begin_model_call().unwrap();
+    let model = allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[])).unwrap();
+    let replica = allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REPLICA, 2, &[])).unwrap();
+    drop(model_call);
+    let call = host.begin_requests([(11, None), (12, None)]).unwrap();
+    let single = allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 3, &[11])).unwrap();
+    let batch = allocate(
+        &host,
+        &request(KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH, 4, &[11, 12]),
+    )
+    .unwrap();
+    drop(call);
+    assert_eq!(pool.bytes((7, 2)), 512);
+    let report = host.actual_memory(MemoryReport::default());
+    assert_eq!(report.allocations.len(), 4);
+    assert!(report
+        .allocations
+        .iter()
+        .any(|row| row.allocation_id.contains("scope-4-4/requests-[11, 12]")));
+    for allocation in [model, replica, single, batch] {
+        assert_eq!(free(&host, &allocation), KAPSL_STATUS_OK);
+    }
+    assert_eq!(pool.bytes((7, 2)), 0);
+    assert!(host
+        .actual_memory(MemoryReport::default())
+        .allocations
+        .is_empty());
+}
+
+#[test]
+fn malformed_missing_and_foreign_scopes_never_reach_physical_allocator() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    drop(host.begin_model_call().unwrap());
+    let _call = host.begin_requests([(11, None), (12, None)]).unwrap();
+    let ids = [11, 12];
+    let valid = request(KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH, 1, &ids);
+    let mut invalid = Vec::new();
+    macro_rules! invalid { ($field:ident $(.$sub:ident)?, $value:expr) => {{ let mut r = valid; r.$field $(.$sub)? = $value; invalid.push(r); }}; }
+    invalid!(struct_size, 4);
+    invalid!(scope.struct_size, 4);
+    invalid!(device_id, 1);
+    invalid!(memory_kind, KAPSL_MEMORY_HOST);
+    invalid!(allocation_class, 99);
+    invalid!(flags, 1);
+    invalid!(reserved, 1);
+    invalid!(bytes, 0);
+    invalid!(bytes, u64::MAX);
+    invalid!(alignment, 0);
+    invalid!(alignment, 3);
+    invalid!(scope.scope_kind, 99);
+    invalid!(scope.scope_id, 0);
+    invalid!(scope.model_id, 8);
+    invalid!(scope.replica_id, 3);
+    invalid!(scope.reserved, 1);
+    invalid!(scope.request_count, 0);
+    invalid!(scope.request_count, u32::MAX);
+    invalid!(scope.request_ids, std::ptr::null());
+    invalid!(scope.scope_kind, KAPSL_ALLOCATION_SCOPE_REQUEST);
+    for r in invalid {
+        assert!(allocate(&host, &r).is_err(), "accepted {r:?}");
+    }
+    for ids in [[0, 11], [11, 11], [11, 99]] {
+        assert!(allocate(
+            &host,
+            &request(KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH, 2, &ids)
+        )
+        .is_err());
+    }
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 3, &[])).is_err());
+    assert_eq!(pool.bytes((7, 2)), 0);
+    assert!(pool.state.lock().unwrap().live.is_empty());
+}
+
+#[test]
+fn truncated_callback_objects_are_rejected_before_reading_the_tail() {
+    #[repr(C, align(8))]
+    struct Prefix(u32);
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    let prefix = Prefix(4);
+    let mut result = KapslDeviceAllocationV1::empty();
+    unsafe {
+        assert_ne!(
+            host.table.allocate_device_scoped.unwrap()(
+                host.table.base.user_data,
+                (&prefix as *const Prefix).cast(),
+                &mut result
+            ),
+            KAPSL_STATUS_OK
+        );
+        assert_ne!(
+            host.table.base.allocate_device.unwrap()(
+                host.table.base.user_data,
+                (&prefix as *const Prefix).cast(),
+                &mut result
+            ),
+            KAPSL_STATUS_OK
+        );
+        assert_ne!(
+            host.table.base.free_device.unwrap()(
+                host.table.base.user_data,
+                (&prefix as *const Prefix).cast()
+            ),
+            KAPSL_STATUS_OK
+        );
+        assert_ne!(
+            host.table.allocate_device_scoped.unwrap()(
+                host.table.base.user_data,
+                std::ptr::null(),
+                &mut result
+            ),
+            KAPSL_STATUS_OK
+        );
+        assert_ne!(
+            host.table.allocate_device_scoped.unwrap()(
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &mut result
+            ),
+            KAPSL_STATUS_OK
+        );
+        assert_ne!(
+            host.table.allocate_device_scoped.unwrap()(
+                host.table.base.user_data,
+                std::ptr::null(),
+                std::ptr::null_mut()
+            ),
+            KAPSL_STATUS_OK
+        );
+    }
+}
+
+#[test]
+fn scopes_cannot_rebind_retire_then_reappear_or_mix_concurrent_calls() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    drop(host.begin_model_call().unwrap());
+    let first_call = host.begin_requests([(11, None)]).unwrap();
+    let second_call = host.begin_requests([(12, None)]).unwrap();
+    let allocation = allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 1, &[11])).unwrap();
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 1, &[12])).is_err());
+    assert!(allocate(
+        &host,
+        &request(KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH, 2, &[11, 12])
+    )
+    .is_err());
+    drop(first_call);
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 3, &[11])).is_err());
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 1, &[12])).is_err());
+    drop(second_call);
+    assert_eq!(pool.bytes((7, 2)), 128);
+    assert_eq!(free(&host, &allocation), KAPSL_STATUS_OK);
+    host.reclaim().unwrap();
+    let _load = host.begin_model_call().unwrap();
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[])).is_err());
+}
+
+#[test]
+fn cancelled_scopes_stop_allocating_but_remain_freeable() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    drop(host.begin_model_call().unwrap());
+    let token = CancellationToken::new();
+    let call = host
+        .begin_requests([(11, Some(token.clone())), (12, None)])
+        .unwrap();
+    let allocation = allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 1, &[11])).unwrap();
+    token.cancel();
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 2, &[11])).is_err());
+    assert!(allocate(
+        &host,
+        &request(KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH, 3, &[11, 12])
+    )
+    .is_err());
+    host.allocator.as_ref().unwrap().cancel(12);
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_REQUEST, 4, &[12])).is_err());
+    assert_eq!(free(&host, &allocation), KAPSL_STATUS_OK);
+    drop(call);
+    host.reclaim().unwrap();
+}
+
+#[test]
+fn admission_limits_cross_class_usage_and_failed_frees_stay_charged() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 128);
+    let call = host.begin_model_call().unwrap();
+    let allocation = allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[])).unwrap();
+    let mut second = request(KAPSL_ALLOCATION_SCOPE_REPLICA, 2, &[]);
+    second.allocation_class = KAPSL_ALLOCATION_CLASS_KV;
+    assert!(allocate(&host, &second).is_err());
+    pool.fail_sync(true);
+    assert_ne!(free(&host, &allocation), KAPSL_STATUS_OK);
+    assert_eq!(pool.bytes((7, 2)), 128);
+    assert_eq!(host.live_allocations(), 1);
+    pool.fail_sync(false);
+    pool.state.lock().unwrap().fail_free = true;
+    assert_ne!(free(&host, &allocation), KAPSL_STATUS_OK);
+    assert_eq!(host.live_allocations(), 1);
+    pool.state.lock().unwrap().fail_free = false;
+    assert_eq!(free(&host, &allocation), KAPSL_STATUS_OK);
+    pool.state.lock().unwrap().owners.remove(&(7, 2));
+    assert!(allocate(&host, &second).is_err());
+    drop(call);
+}
+
+#[test]
+fn frees_validate_instance_identity_size_pointer_and_reused_addresses() {
+    let pool = Arc::new(FakePool::default());
+    let first = pool.host(7, 2, 1024);
+    let second = pool.host(8, 2, 1024);
+    let call = first.begin_model_call().unwrap();
+    let allocation = allocate(&first, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[])).unwrap();
+    assert_ne!(free(&second, &allocation), KAPSL_STATUS_OK);
+    for invalid in [
+        KapslDeviceAllocationV1 {
+            device_ptr: std::ptr::null_mut(),
+            ..allocation
+        },
+        KapslDeviceAllocationV1 {
+            granted_bytes: 64,
+            ..allocation
+        },
+        KapslDeviceAllocationV1 {
+            reserved: 1,
+            ..allocation
+        },
+    ] {
+        assert_ne!(free(&first, &invalid), KAPSL_STATUS_OK);
+    }
+    assert_eq!(free(&first, &allocation), KAPSL_STATUS_OK);
+    assert_ne!(free(&first, &allocation), KAPSL_STATUS_OK);
+    drop(call);
+    let call = second.begin_model_call().unwrap();
+    let mut r = request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[]);
+    r.scope.model_id = 8;
+    let replacement = allocate(&second, &r).unwrap();
+    assert_eq!(replacement.device_ptr, allocation.device_ptr);
+    assert_ne!(replacement.allocation_id, allocation.allocation_id);
+    assert_ne!(free(&second, &allocation), KAPSL_STATUS_OK);
+    drop(call);
+    second.reclaim().unwrap();
+    assert_eq!(pool.bytes((8, 2)), 0);
+}
+
+#[test]
+fn scoped_adapter_cannot_use_legacy_callback_and_failed_cleanup_can_retry() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    let call = host.begin_model_call().unwrap();
+    let legacy = KapslDeviceAllocationRequestV1 {
+        struct_size: std::mem::size_of::<KapslDeviceAllocationRequestV1>() as u32,
+        device_id: 0,
+        memory_kind: KAPSL_MEMORY_CUDA,
+        allocation_class: KAPSL_ALLOCATION_CLASS_WEIGHTS,
+        model_id: 7,
+        replica_id: 2,
+        flags: 0,
+        reserved: 0,
+        bytes: 128,
+        alignment: 64,
+    };
+    let mut out = KapslDeviceAllocationV1::empty();
+    assert_ne!(
+        unsafe {
+            host.table.base.allocate_device.unwrap()(host.table.base.user_data, &legacy, &mut out)
+        },
+        KAPSL_STATUS_OK
+    );
+    allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[])).unwrap();
+    assert!(host.reclaim().is_err());
+    drop(call);
+    pool.fail_sync(true);
+    assert!(host.reclaim().is_err());
+    assert_eq!(host.live_allocations(), 1);
+    assert!(host.begin_model_call().is_err());
+    pool.fail_sync(false);
+    host.reclaim().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+    assert!(allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 2, &[])).is_err());
+}
+
+#[test]
+fn allocator_panics_do_not_unwind_across_the_abi() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    let call = host.begin_model_call().unwrap();
+    pool.state.lock().unwrap().panic_allocate = true;
+    assert_eq!(
+        allocate(&host, &request(KAPSL_ALLOCATION_SCOPE_MODEL, 1, &[])).unwrap_err(),
+        KAPSL_STATUS_PANIC
+    );
+    pool.state.lock().unwrap().panic_allocate = false;
+    drop(call);
+    host.reclaim().unwrap();
+}
+
+#[test]
+fn retired_scope_ids_compact_without_accepting_reuse_or_order_assumptions() {
+    let mut ledger = AllocationLedger::default();
+    for id in [4, 2, 6, 1, 3, 5] {
+        ledger.remember_scope_id(id).unwrap();
+    }
+    assert_eq!(ledger.used_scope_ids, BTreeMap::from([(1, 6)]));
+    for id in 1..=6 {
+        assert!(ledger.remember_scope_id(id).is_err());
+    }
+    ledger.remember_scope_id(u64::MAX).unwrap();
+    assert!(ledger.remember_scope_id(u64::MAX).is_err());
+}
+
+#[test]
+fn synchronize_callback_enforces_device_identity_and_propagates_failure() {
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    let synchronize = host.table.base.synchronize_device.unwrap();
+    let context = host.table.base.user_data;
+    unsafe {
+        assert_eq!(synchronize(context, 1), KAPSL_STATUS_INVALID_ARGUMENT);
+        assert_eq!(
+            synchronize(std::ptr::null_mut(), 0),
+            KAPSL_STATUS_INVALID_ARGUMENT
+        );
+        assert_eq!(pool.state.lock().unwrap().syncs, 0);
+        assert_eq!(synchronize(context, 0), KAPSL_STATUS_OK);
+        pool.fail_sync(true);
+        assert_eq!(synchronize(context, 0), KAPSL_STATUS_BACKEND_ERROR);
+        pool.fail_sync(false);
+    }
+}
+
+#[test]
+fn host_without_a_device_pool_does_not_advertise_allocator_callbacks() {
+    let host = NativeBackendHost::from_allocator(None);
+    assert!(unsafe { KapslBackendHostScopedAllocatorV1::from_base(host.table()) }.is_none());
+    assert!(host.table.base.allocate_device.is_none());
+    assert!(host.table.base.free_device.is_none());
+    assert!(host.table.base.synchronize_device.is_none());
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native/boundary_tests.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native/boundary_tests.rs
@@ -41,6 +41,15 @@ fn engine(
     owner: (u32, u32),
     mode: &str,
 ) -> Result<NativePackedEngine, String> {
+    engine_with_options(pool, owner, mode, &serde_json::Map::new())
+}
+
+fn engine_with_options(
+    pool: &Arc<FakePool>,
+    owner: (u32, u32),
+    mode: &str,
+    options: &serde_json::Map<String, serde_json::Value>,
+) -> Result<NativePackedEngine, String> {
     let host = pool.host(owner.0, owner.1, 2048);
     NativePackInstance::initialize_with_host(
         pack(),
@@ -50,7 +59,7 @@ fn engine(
         0,
         owner.0,
         owner.1,
-        None,
+        options,
     )
     .map(|instance| NativePackedEngine { instance })
 }
@@ -75,6 +84,55 @@ async fn wait_started(instance: &NativePackInstance, count: u64) {
     })
     .await
     .expect("fake adapter never entered inference");
+}
+
+#[test]
+fn opaque_adapter_options_cross_the_loaded_native_boundary() {
+    let pool = Arc::new(FakePool::default());
+    let options = serde_json::json!({
+        "vendor_config": { "strategy": "paged", "shape": [2, 4], "enabled": true },
+        "extension": null,
+    });
+    let engine =
+        engine_with_options(&pool, (7, 2), "normal", options.as_object().unwrap()).unwrap();
+    let received: serde_json::Value = engine
+        .instance
+        .call_json_report(engine.instance.pack.api.model_info.unwrap())
+        .unwrap();
+    let received = &received["options"];
+    for (key, value) in options.as_object().unwrap() {
+        assert_eq!(&received[key], value);
+    }
+    assert_eq!(received["provider"], "cuda");
+    assert_eq!(received["descriptor"]["backend"], "fake-native");
+    assert_eq!(
+        received["pack_root"],
+        serde_json::json!(engine.instance.pack.root)
+    );
+    assert!(received.get("onnx_tuning").is_none());
+}
+
+#[test]
+fn adapter_options_cannot_override_engine_owned_configuration() {
+    let pool = Arc::new(FakePool::default());
+    for key in [
+        "provider",
+        "accelerator_profile",
+        "pack_version",
+        "descriptor",
+        "pack_root",
+        "entrypoint",
+    ] {
+        let options = serde_json::Map::from_iter([(key.into(), serde_json::json!("override"))]);
+        let error = engine_with_options(&pool, (7, 2), "initialize-allocates", &options)
+            .err()
+            .expect("engine-owned configuration must reject overrides");
+        assert!(
+            error.contains(&format!("adapter option `{key}` conflicts")),
+            "{error}"
+        );
+        assert_eq!(pool.bytes((7, 2)), 0);
+    }
 }
 
 #[tokio::test]

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native/boundary_tests.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native/boundary_tests.rs
@@ -1,0 +1,395 @@
+//! Load a real cdylib built against the published ABI. The only substitution
+//! is the physical pool; loading, initialization, callbacks and dispatch are
+//! the production host path. No CUDA driver, GPU or performance gates.
+use super::*;
+use allocator::tests::FakePool;
+use futures::StreamExt;
+use kapsl_engine_api::{MemoryAllocationSource, MemoryDomain};
+
+fn pack() -> Arc<ActiveNativePack> {
+    static PACK: OnceLock<Arc<ActiveNativePack>> = OnceLock::new();
+    Arc::clone(PACK.get_or_init(|| {
+        let executable = std::env::current_exe().unwrap();
+        let root = executable.parent().unwrap();
+        let filename = format!(
+            "{}kapsl_native_test_adapter{}",
+            std::env::consts::DLL_PREFIX,
+            std::env::consts::DLL_SUFFIX
+        );
+        assert!(
+            root.join(&filename).is_file(),
+            "Cargo must build the native adapter cdylib at {}",
+            root.join(&filename).display()
+        );
+        let mut manifest = tests::test_manifest("cuda", kapsl_native_test_adapter::CAPABILITIES);
+        manifest.backend = "fake-native".into();
+        manifest.entrypoint = filename;
+        load_native_backend_pack(&manifest, root).unwrap()
+    }))
+}
+
+fn model(mode: &str) -> Manifest {
+    serde_json::from_value(serde_json::json!({
+        "project_name": mode, "framework": "onnx", "version": "1.0",
+        "created_at": "2026-09-10", "model_file": "fake.onnx"
+    }))
+    .unwrap()
+}
+
+fn engine(
+    pool: &Arc<FakePool>,
+    owner: (u32, u32),
+    mode: &str,
+) -> Result<NativePackedEngine, String> {
+    let host = pool.host(owner.0, owner.1, 2048);
+    NativePackInstance::initialize_with_host(
+        pack(),
+        &model(mode),
+        "cuda",
+        host,
+        0,
+        owner.0,
+        owner.1,
+        None,
+    )
+    .map(|instance| NativePackedEngine { instance })
+}
+
+fn request() -> InferenceRequest {
+    InferenceRequest::new(BinaryTensorPacket::new(vec![1], TensorDtype::Uint8, vec![7]).unwrap())
+}
+
+fn probe(instance: &NativePackInstance, counter: u32) -> u64 {
+    unsafe {
+        let function: libloading::Symbol<'_, unsafe extern "C" fn(*mut c_void, u32) -> u64> =
+            instance.pack.library.get(b"kapsl_test_probe_v1\0").unwrap();
+        function(instance.handle, counter)
+    }
+}
+
+async fn wait_started(instance: &NativePackInstance, count: u64) {
+    tokio::time::timeout(std::time::Duration::from_secs(3), async {
+        while probe(instance, 0) < count {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("fake adapter never entered inference");
+}
+
+#[tokio::test]
+async fn loaded_adapter_exercises_reporting_batching_streaming_and_reload() {
+    let pool = Arc::new(FakePool::default());
+    let mut engine = engine(&pool, (7, 2), "normal").unwrap();
+    assert_eq!(engine.instance.pack.descriptor["backend"], "fake-native");
+    assert!(engine.infer(&request()).is_err());
+    assert_eq!(
+        engine
+            .planned_memory(Path::new("fake.onnx"))
+            .unwrap()
+            .allocations[0]
+            .bytes,
+        256
+    );
+    assert_eq!(
+        engine.planned_request_memory(&request()).allocations[0].bytes,
+        64
+    );
+    assert!(engine.health_check().is_err());
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    assert!(engine.load(Path::new("fake.onnx")).await.is_err());
+    engine.health_check().unwrap();
+    assert_eq!(
+        engine.model_info().unwrap().framework.as_deref(),
+        Some("fake")
+    );
+    assert_eq!(engine.max_batch(), 4);
+    assert!(!engine.self_batches());
+    assert_eq!(
+        engine.batching_policy().mode,
+        BatchingMode::RequestCoalescing
+    );
+    assert_eq!(engine.infer(&request()).unwrap().data, [42]);
+    let batch = engine.infer_batch(&[request(), request()]).unwrap();
+    assert_eq!(batch.len(), 2);
+    assert!(batch.iter().all(|output| output.data == [42]));
+    let chunks: Vec<_> = engine.infer_stream(&request()).collect().await;
+    assert_eq!(chunks.len(), 2);
+    assert!(chunks.into_iter().all(|chunk| chunk.unwrap().data == [42]));
+    let report = engine.actual_memory();
+    assert_eq!(
+        report.bytes_for_domain(&MemoryDomain::Cuda { device_id: 0 }),
+        512
+    );
+    assert!(report
+        .allocations
+        .iter()
+        .all(|row| row.source == MemoryAllocationSource::RuntimeManaged));
+    assert!(report
+        .allocations
+        .iter()
+        .any(|row| row.allocation_id.contains("scope-4-")
+            && row.allocation_id.contains("requests-[")));
+    let metrics = engine.metrics();
+    assert_eq!(metrics.throughput, 3.0);
+    assert_eq!(metrics.batch_size, 2);
+    assert_eq!(metrics.memory_usage, 512);
+    engine.instance.unload().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+    assert!(engine.actual_memory().allocations.is_empty());
+    assert!(engine.infer(&request()).is_err());
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    assert_eq!(engine.infer(&request()).unwrap().data, [42]);
+    drop(engine);
+    assert_eq!(pool.bytes((7, 2)), 0);
+}
+
+#[tokio::test]
+async fn shared_pool_isolates_models_and_replicas_through_unload_and_bad_ownership() {
+    let pool = Arc::new(FakePool::default());
+    let mut first = engine(&pool, (7, 2), "invalid-scope").unwrap();
+    let mut replica = engine(&pool, (7, 3), "normal").unwrap();
+    let mut other = engine(&pool, (8, 2), "normal").unwrap();
+    for engine in [&mut first, &mut replica, &mut other] {
+        engine.load(Path::new("fake.onnx")).await.unwrap();
+    }
+    assert_eq!(first.infer(&request()).unwrap().data, [42]);
+    assert_eq!(replica.infer(&request()).unwrap().data, [42]);
+    assert_eq!(other.infer(&request()).unwrap().data, [42]);
+    first.instance.unload().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+    assert_eq!(pool.bytes((7, 3)), 320);
+    assert_eq!(pool.bytes((8, 2)), 320);
+    drop(replica);
+    drop(other);
+    assert_eq!(pool.bytes((7, 3)), 0);
+    assert_eq!(pool.bytes((8, 2)), 0);
+}
+
+#[tokio::test]
+async fn failure_paths_reclaim_only_after_the_adapter_releases_ownership() {
+    let pool = Arc::new(FakePool::default());
+    for mode in ["fail-initialize", "fail-initialize-null"] {
+        assert!(engine(&pool, (7, 2), mode).is_err());
+        assert_eq!(pool.bytes((7, 2)), 0, "{mode}");
+    }
+    for mode in ["fail-load", "fail-load-cleanup"] {
+        let mut engine = engine(&pool, (7, 2), mode).unwrap();
+        assert!(engine.load(Path::new("fake.onnx")).await.is_err());
+        assert!(engine.infer(&request()).is_err());
+        assert_eq!(
+            pool.bytes((7, 2)),
+            if mode == "fail-load" { 0 } else { 256 }
+        );
+        drop(engine);
+        assert_eq!(pool.bytes((7, 2)), 0, "{mode}");
+    }
+    for mode in ["fail-infer", "leak-unload", "fail-unload"] {
+        let mut engine = engine(&pool, (7, 2), mode).unwrap();
+        engine.load(Path::new("fake.onnx")).await.unwrap();
+        assert_eq!(engine.infer(&request()).is_err(), mode == "fail-infer");
+        assert_eq!(pool.bytes((7, 2)), 320);
+        if mode == "fail-unload" {
+            assert!(engine.instance.unload().is_err());
+            assert_eq!(pool.bytes((7, 2)), 320);
+            assert!(engine.infer(&request()).is_err());
+            assert!(engine.load(Path::new("fake.onnx")).await.is_err());
+        }
+        engine.instance.unload().unwrap();
+        assert_eq!(pool.bytes((7, 2)), 0, "{mode}");
+    }
+}
+
+#[tokio::test]
+async fn synchronization_failure_blocks_reload_and_preserves_memory_reporting() {
+    let pool = Arc::new(FakePool::default());
+    let mut engine = engine(&pool, (7, 2), "leak-unload").unwrap();
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    pool.fail_sync(true);
+    assert!(engine.instance.unload().is_err());
+    assert_eq!(engine.actual_memory().allocations[0].bytes, 256);
+    assert_eq!(engine.metrics().memory_usage, 256);
+    assert!(engine.health_check().is_err());
+    assert!(engine.load(Path::new("fake.onnx")).await.is_err());
+    pool.fail_sync(false);
+    engine.instance.unload().unwrap();
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    drop(engine);
+    assert_eq!(pool.bytes((7, 2)), 0);
+}
+
+#[tokio::test]
+async fn initialization_allocations_remain_owned_through_load_and_unload() {
+    let pool = Arc::new(FakePool::default());
+    let mut engine = engine(&pool, (7, 2), "initialize-allocates").unwrap();
+    assert_eq!(pool.bytes((7, 2)), 256);
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    assert_eq!(pool.bytes((7, 2)), 512);
+    engine.instance.unload().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+}
+
+#[tokio::test]
+async fn stream_chunks_cannot_cross_request_ownership() {
+    let pool = Arc::new(FakePool::default());
+    let mut engine = engine(&pool, (7, 2), "stream-wrong-owner").unwrap();
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    let chunks: Vec<_> = engine.infer_stream(&request()).collect().await;
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks
+        .into_iter()
+        .next()
+        .unwrap()
+        .unwrap_err()
+        .to_string()
+        .contains("different request"));
+    engine.instance.unload().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+}
+
+#[tokio::test]
+async fn cancellation_covers_single_batch_and_concurrent_dispatch_ownership() {
+    let pool = Arc::new(FakePool::default());
+    let mut engine = engine(&pool, (7, 2), "wait-cancel").unwrap();
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    let mut first = request();
+    let mut second = request();
+    let first_token = CancellationToken::new();
+    let second_token = CancellationToken::new();
+    first.cancellation = Some(first_token.clone());
+    second.cancellation = Some(second_token.clone());
+    let instance = Arc::clone(&engine.instance);
+    let single = tokio::task::spawn_blocking(move || instance.infer(&first));
+    let instance = Arc::clone(&engine.instance);
+    let batch = tokio::task::spawn_blocking(move || instance.infer_batch(&[second, request()]));
+    wait_started(&engine.instance, 2).await;
+    assert_eq!(pool.bytes((7, 2)), 448);
+    first_token.cancel();
+    assert!(matches!(
+        single.await.unwrap().unwrap_err(),
+        EngineError::Cancelled { .. }
+    ));
+    second_token.cancel();
+    assert!(matches!(
+        batch.await.unwrap().unwrap_err(),
+        EngineError::Cancelled { .. }
+    ));
+    assert_eq!(probe(&engine.instance, 1), 2);
+    assert_eq!(
+        pool.bytes((7, 2)),
+        448,
+        "request completion must not free retained arenas"
+    );
+    engine.instance.unload().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+}
+
+#[tokio::test]
+async fn dropping_a_live_stream_cancels_before_unload_reclaims_memory() {
+    let pool = Arc::new(FakePool::default());
+    let mut engine = engine(&pool, (7, 2), "stream-wait-cancel").unwrap();
+    engine.load(Path::new("fake.onnx")).await.unwrap();
+    let mut stream = engine.infer_stream(&request());
+    assert_eq!(stream.next().await.unwrap().unwrap().data, [42]);
+    assert_eq!(pool.bytes((7, 2)), 320);
+    drop(stream);
+    assert_eq!(probe(&engine.instance, 1), 1);
+    engine.instance.unload().unwrap();
+    assert_eq!(pool.bytes((7, 2)), 0);
+}
+
+#[test]
+fn adapter_requires_full_versioned_host_table_and_every_allocator_callback() {
+    let pack = pack();
+    let pool = Arc::new(FakePool::default());
+    let host = pool.host(7, 2, 1024);
+    let valid = *unsafe { KapslBackendHostScopedAllocatorV1::from_base(host.table()) }.unwrap();
+    let mut invalid = Vec::new();
+    macro_rules! invalid { ($field:ident $(.$sub:ident)?, $value:expr) => {{ let mut table = valid; table.$field $(.$sub)? = $value; invalid.push(table); }}; }
+    invalid!(
+        base.struct_size,
+        std::mem::size_of::<KapslBackendHostV1>() as u32
+    );
+    invalid!(base.abi_version, 99);
+    invalid!(scoped_allocator_version, 99);
+    invalid!(reserved, 1);
+    invalid!(allocate_device_scoped, None);
+    invalid!(base.allocate_device, None);
+    invalid!(base.free_device, None);
+    invalid!(base.synchronize_device, None);
+    for table in invalid {
+        let config = KapslBackendConfigV1 {
+            struct_size: std::mem::size_of::<KapslBackendConfigV1>() as u32,
+            device_id: 0,
+            model_id: 7,
+            replica_id: 2,
+            require_governed_device_memory: 1,
+            reserved: 0,
+            profile: KapslSlice::empty(),
+            manifest_json: KapslSlice::empty(),
+            options_json: KapslSlice::empty(),
+            host: &table.base,
+        };
+        let mut handle = std::ptr::null_mut();
+        let mut error = KapslOwnedBuffer::empty();
+        assert_eq!(
+            unsafe { pack.api.initialize.unwrap()(&config, &mut handle, &mut error) },
+            KAPSL_STATUS_INCOMPATIBLE_ABI
+        );
+        assert!(handle.is_null());
+    }
+}
+
+#[test]
+fn advertised_capabilities_and_required_functions_are_audited_against_loaded_table() {
+    let pack = pack();
+    macro_rules! missing { ($($field:ident),+ $(,)?) => { $(
+        let mut api = pack.api;
+        api.$field = None;
+        assert!(validate_native_backend_api(&pack.manifest, &api).is_err(), "accepted missing {}", stringify!($field));
+    )+ }; }
+    missing!(
+        describe,
+        initialize,
+        planned_memory,
+        load_model,
+        planned_request_memory,
+        infer,
+        actual_memory,
+        metrics,
+        model_info,
+        batching_policy,
+        health_check,
+        unload,
+        shutdown,
+        release_result,
+        free_buffer,
+        infer_batch,
+        release_batch_result,
+        infer_stream,
+        cancel
+    );
+    let mut api = pack.api;
+    api.capabilities |= KAPSL_BACKEND_CAP_KV_PARTICIPANT;
+    let mut manifest = pack.manifest.clone();
+    manifest.capabilities = pack_capabilities_from_abi(api.capabilities);
+    assert!(validate_native_backend_api(&manifest, &api).is_err());
+    for field in [
+        "backend",
+        "profiles",
+        "schema_version",
+        "backend_abi",
+        "wire_format",
+        "execution_mode",
+        "formats",
+        "tasks",
+        "governed_device_memory",
+    ] {
+        let mut descriptor = pack.descriptor.clone();
+        descriptor[field] = serde_json::Value::Null;
+        assert!(
+            validate_native_backend_descriptor(&pack.manifest, &pack.api, &descriptor).is_err(),
+            "accepted descriptor mismatch: {field}"
+        );
+    }
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/onnx.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/onnx.rs
@@ -29,6 +29,24 @@ const SCOPED_DEVICE_ALLOCATOR_V1: &str = "kapsl-scoped-device-allocator-v1";
 
 static OFFLINE: AtomicBool = AtomicBool::new(false);
 
+/// Translate legacy ONNX configuration at the compatibility boundary. The
+/// native host passes these values without linking to the backend's Rust types.
+pub(crate) fn onnx_adapter_options(
+    tuning: Option<&kapsl_backends::OnnxRuntimeTuning>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let tuning = tuning.map(|tuning| {
+        serde_json::json!({
+            "memory_pattern": tuning.memory_pattern,
+            "disable_cpu_mem_arena": tuning.disable_cpu_mem_arena,
+            "session_buckets": tuning.session_buckets,
+            "bucket_dim_granularity": tuning.bucket_dim_granularity,
+            "bucket_max_dims": tuning.bucket_max_dims,
+            "peak_concurrency_hint": tuning.peak_concurrency_hint,
+        })
+    });
+    serde_json::Map::from_iter([("onnx_tuning".into(), serde_json::json!(tuning))])
+}
+
 /// The route is resolved once per model load and carried to backend creation;
 /// backend construction may not infer a different route from process state.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
@@ -440,7 +440,13 @@ pub(super) fn create_runtime_backend_for_device(
                     reason
                 );
                 return create_native_backend_pack_engine(
-                    identity, manifest, resources, device_id, model_id, replica_id, tuning,
+                    identity,
+                    manifest,
+                    resources,
+                    device_id,
+                    model_id,
+                    replica_id,
+                    &onnx_adapter_options(tuning),
                 );
             }
             OnnxBackendRoute::EmbeddedRollback { reason } => {

--- a/kapsl-runtime/docs/native-host-tests.md
+++ b/kapsl-runtime/docs/native-host-tests.md
@@ -1,0 +1,66 @@
+# Native allocator host regression tests
+
+The generic native host implements the scoped allocator extension published in
+`kapsl-backend-abi = 0.2.0`. Its frozen ABI-v1 prefix points to a retained
+`KapslBackendHostScopedAllocatorV1`; the advertised size covers the extension,
+and the scoped allocator version is 1. This implementation needs no SDK change.
+
+The host checks device, model and replica identity before allocation. Model and
+replica scopes are admitted during initialization and load. Request scopes must
+refer to live engine-dispatched request IDs; a batch scope must contain distinct
+IDs from the same dispatch. Cancellation revokes new request allocations.
+Retired scope IDs cannot be rebound, including after unload/reload. Scoped
+adapters cannot use the legacy callback to omit request attribution.
+
+Allocation scope, request IDs and class remain attached to each live handle,
+including arenas retained after inference returns. The host's live-memory report
+uses those records for governed CUDA bytes. Physical allocation requires an
+engine-admitted pool owner, and the existing pool enforces aggregate quotas and
+other owners' reservations. Free validates the instance's handle, address and
+byte count and synchronizes before returning memory to the pool. Failed frees
+stay charged and can be retried.
+
+Unload drains calls and stops new allocations. Successful adapter unload permits
+the host to reclaim outstanding handles; failed adapter unload retains memory
+until a successful retry or shutdown. Reload and inference are blocked while
+cleanup is incomplete. A synchronization failure never makes a range reusable;
+terminal cleanup failure retains its charge and storage until process teardown.
+
+## Run locally
+
+From the repository root:
+
+```sh
+cargo test --manifest-path kapsl-runtime/Cargo.toml -p kapsl backend::native --locked
+cargo test --manifest-path kapsl-runtime/Cargo.toml -p kapsl --features gpu-device-pool --locked -- --test-threads=1
+```
+
+Both commands are host-only. The second compiles the production CUDA pool
+binding and runs its host tests without a driver, toolkit or GPU. The normal
+Linux/macOS/Windows PR test matrix also includes the native host tests.
+
+`tests/native-adapter` builds a test-only `cdylib` against the
+published ABI. The tests load it through the production library loader and use
+the production initialization, inference and lifecycle bridge. Only the physical
+allocator is replaced with a fake admitted pool. The fixture is a dev dependency
+and is not built or packaged by engine release builds.
+
+| Advertised surface | Executed assertions |
+| --- | --- |
+| CUDA / governed / scoped allocator | Extended table size, versions and every required callback; valid model, replica, request and batch allocations; malformed and foreign scopes; quota denial; invalid frees; synchronization and cleanup failures |
+| Concurrent inference | Single and batch calls overlap on one instance with separate ownership; unrelated dispatches cannot become one allocation batch |
+| Batching | Multiple outputs and the matching release callback; declared batching policy and metrics |
+| Streaming | Borrowed chunks, bounded delivery, cancellation on consumer drop, and rejection of a chunk for another request |
+| Cancellation | Single, batch and stream cancellation reaches the adapter; cancelled scopes cannot allocate; retained arenas stay charged |
+| Memory reporting | Planned model and request reports; live host ledger; metrics retain leaked bytes during failed cleanup |
+| Required lifecycle and reports | Descriptor validation, model information, health, load/unload/reload, initialization/load/inference failure cleanup |
+
+Every advertised optional function and every required ABI function is removed
+in turn to verify host rejection. KV participation is not advertised by this
+fixture; adding that capability without its functions is also rejected.
+
+These tests exercise the loader after the signed-installation boundary. The fake
+library is a local test artifact, not a published signed pack. They establish no
+ORT provider, platform, output or performance qualification. Stable signed-pack
+qualification remains a separate release gate, including the existing 1.5x
+startup threshold and infrastructure teardown checks.

--- a/kapsl-runtime/docs/native-host-tests.md
+++ b/kapsl-runtime/docs/native-host-tests.md
@@ -59,6 +59,12 @@ Every advertised optional function and every required ABI function is removed
 in turn to verify host rejection. KV participation is not advertised by this
 fixture; adding that capability without its functions is also rejected.
 
+Adapter-specific initialization options pass through the generic host as JSON.
+The loaded fixture verifies nested values arrive unchanged and that an adapter
+cannot override the engine's selected provider, signed descriptor, pack version,
+pack root or entrypoint. Legacy ONNX tuning is translated outside the native
+host, which has no dependency on `OnnxRuntimeTuning` or `kapsl-backends`.
+
 These tests exercise the loader after the signed-installation boundary. The fake
 library is a local test artifact, not a published signed pack. They establish no
 ORT provider, platform, output or performance qualification. Stable signed-pack

--- a/kapsl-runtime/tests/native-adapter/Cargo.toml
+++ b/kapsl-runtime/tests/native-adapter/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kapsl-native-test-adapter"
+version = "0.0.0"
+edition = "2021"
+publish = false
+rust-version = "1.92"
+
+# Keep this dev dependency out of engine `--workspace` release builds.
+[workspace]
+resolver = "2"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+kapsl-backend-abi = "=0.2.0"
+kapsl-engine-api = "0.3.0"
+serde_json = "1"

--- a/kapsl-runtime/tests/native-adapter/src/lib.rs
+++ b/kapsl-runtime/tests/native-adapter/src/lib.rs
@@ -24,6 +24,7 @@ struct State {
     model: u32,
     replica: u32,
     mode: String,
+    options: serde_json::Value,
     scope: AtomicU64,
     loaded: AtomicBool,
     allocations: Mutex<Vec<KapslDeviceAllocationV1>>,
@@ -173,6 +174,8 @@ unsafe extern "C" fn initialize(
         model: config.model_id,
         replica: config.replica_id,
         mode: manifest["project_name"].as_str().unwrap_or("normal").into(),
+        options: serde_json::from_slice(unsafe { config.options_json.as_bytes() }.unwrap())
+            .unwrap(),
         scope: AtomicU64::new(1),
         loaded: AtomicBool::new(false),
         allocations: Mutex::new(Vec::new()),
@@ -501,11 +504,11 @@ unsafe extern "C" fn metrics(
 }
 
 unsafe extern "C" fn model_info(
-    _handle: *mut c_void,
+    handle: *mut c_void,
     out: *mut KapslOwnedBuffer,
     _error: *mut KapslOwnedBuffer,
 ) -> i32 {
-    output(serde_json::to_vec(&json!({"input_names": ["input"], "output_names": ["output"], "input_shapes": [[1]], "output_shapes": [[1]], "input_dtypes": ["uint8"], "output_dtypes": ["uint8"], "framework": "fake"})).unwrap(), out);
+    output(serde_json::to_vec(&json!({"input_names": ["input"], "output_names": ["output"], "input_shapes": [[1]], "output_shapes": [[1]], "input_dtypes": ["uint8"], "output_dtypes": ["uint8"], "framework": "fake", "options": unsafe { state(handle) }.options})).unwrap(), out);
     KAPSL_STATUS_OK
 }
 

--- a/kapsl-runtime/tests/native-adapter/src/lib.rs
+++ b/kapsl-runtime/tests/native-adapter/src/lib.rs
@@ -1,0 +1,600 @@
+//! A host-only ABI conformance fixture. Device addresses are opaque handles
+//! supplied by the engine's fake pool; this library has no compute backend.
+use kapsl_backend_abi::*;
+use kapsl_engine_api::{EngineMetrics, MemoryAllocationClass, MemoryDomain, MemoryReport};
+use serde_json::json;
+use std::collections::HashSet;
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Condvar, Mutex};
+use std::time::Duration;
+
+pub const CAPABILITIES: u64 = KAPSL_BACKEND_CAP_CUDA
+    | KAPSL_BACKEND_CAP_GOVERNED_DEVICE_ALLOCATOR
+    | KAPSL_BACKEND_CAP_SCOPED_DEVICE_ALLOCATOR
+    | KAPSL_BACKEND_CAP_MEMORY_REPORTING
+    | KAPSL_BACKEND_CAP_BATCHING
+    | KAPSL_BACKEND_CAP_STREAMING
+    | KAPSL_BACKEND_CAP_CANCELLATION
+    | KAPSL_BACKEND_CAP_CONCURRENT_INFERENCE;
+
+struct State {
+    host: KapslBackendHostScopedAllocatorV1,
+    device: u32,
+    model: u32,
+    replica: u32,
+    mode: String,
+    scope: AtomicU64,
+    loaded: AtomicBool,
+    allocations: Mutex<Vec<KapslDeviceAllocationV1>>,
+    cancelled: Mutex<HashSet<u64>>,
+    changed: Condvar,
+    calls: AtomicU64,
+    cancels: AtomicU64,
+    unloads: AtomicU64,
+    chunks: AtomicU64,
+    last_batch: AtomicU64,
+}
+
+// The host retains the callback table/context through shutdown. All mutable
+// state is atomic or mutex-protected, including concurrently accessed handles.
+unsafe impl Send for State {}
+unsafe impl Sync for State {}
+
+unsafe fn state<'a>(handle: *mut c_void) -> &'a State {
+    unsafe { &*handle.cast::<State>() }
+}
+
+fn output(bytes: Vec<u8>, out: *mut KapslOwnedBuffer) {
+    let mut bytes = bytes;
+    unsafe {
+        *out = KapslOwnedBuffer {
+            ptr: bytes.as_mut_ptr(),
+            len: bytes.len(),
+            capacity: bytes.capacity(),
+        };
+    }
+    std::mem::forget(bytes);
+}
+
+unsafe extern "C" fn free_buffer(buffer: KapslOwnedBuffer) {
+    if !buffer.ptr.is_null() {
+        unsafe {
+            drop(Vec::from_raw_parts(buffer.ptr, buffer.len, buffer.capacity));
+        }
+    }
+}
+
+unsafe extern "C" fn describe(out: *mut KapslOwnedBuffer, _error: *mut KapslOwnedBuffer) -> i32 {
+    output(
+        serde_json::to_vec(&json!({
+            "schema_version": KAPSL_BACKEND_DESCRIPTOR_SCHEMA_V1,
+            "backend": "fake-native", "profiles": ["cuda12"],
+            "backend_abi": KAPSL_BACKEND_ABI_VERSION,
+            "wire_format": KAPSL_BACKEND_WIRE_FORMAT_TENSORS_V1,
+            "execution_mode": "native", "governed_device_memory": true,
+            "formats": ["onnx"], "tasks": ["forward"]
+        }))
+        .unwrap(),
+        out,
+    );
+    KAPSL_STATUS_OK
+}
+
+impl State {
+    fn allocate(&self, kind: u32, requests: &[u64], bytes: u64) -> i32 {
+        let scope = KapslDeviceAllocationScopeV1::new(
+            kind,
+            self.scope.fetch_add(1, Ordering::Relaxed),
+            self.model,
+            self.replica,
+            requests,
+        );
+        let class = if requests.is_empty() {
+            KAPSL_ALLOCATION_CLASS_WEIGHTS
+        } else {
+            KAPSL_ALLOCATION_CLASS_WORKSPACE
+        };
+        let request = KapslScopedDeviceAllocationRequestV1::new(
+            self.device,
+            KAPSL_MEMORY_CUDA,
+            class,
+            scope,
+            bytes,
+            64,
+        );
+        let mut allocation = KapslDeviceAllocationV1::empty();
+        let status = unsafe {
+            self.host.allocate_device_scoped.unwrap()(
+                self.host.base.user_data,
+                &request,
+                &mut allocation,
+            )
+        };
+        if status == KAPSL_STATUS_OK {
+            self.allocations.lock().unwrap().push(allocation);
+        }
+        status
+    }
+
+    fn release_allocations(&self) -> i32 {
+        let mut allocations = self.allocations.lock().unwrap();
+        allocations.retain(|allocation| unsafe { self.host.base.free_device.unwrap()(self.host.base.user_data, allocation) } != KAPSL_STATUS_OK);
+        if allocations.is_empty() {
+            KAPSL_STATUS_OK
+        } else {
+            KAPSL_STATUS_BACKEND_ERROR
+        }
+    }
+
+    fn wait_for_cancel(&self, request_id: u64) -> i32 {
+        let guard = self.cancelled.lock().unwrap();
+        let (guard, _) = self
+            .changed
+            .wait_timeout_while(guard, Duration::from_secs(5), |ids| {
+                !ids.contains(&request_id)
+            })
+            .unwrap();
+        if guard.contains(&request_id) {
+            // Cancellation revokes new allocation authority before the
+            // adapter callback runs, while existing allocations stay charged.
+            if self.allocate(KAPSL_ALLOCATION_SCOPE_REQUEST, &[request_id], 64) == KAPSL_STATUS_OK {
+                return KAPSL_STATUS_BACKEND_ERROR;
+            }
+            KAPSL_STATUS_CANCELLED
+        } else {
+            KAPSL_STATUS_BACKEND_ERROR
+        }
+    }
+}
+
+unsafe extern "C" fn initialize(
+    config: *const KapslBackendConfigV1,
+    handle: *mut *mut c_void,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let config = unsafe { &*config };
+    let Some(host) = (unsafe { KapslBackendHostScopedAllocatorV1::from_base(config.host) }) else {
+        return KAPSL_STATUS_INCOMPATIBLE_ABI;
+    };
+    if config.require_governed_device_memory != 1
+        || host.base.struct_size as usize
+            != std::mem::size_of::<KapslBackendHostScopedAllocatorV1>()
+        || host.base.user_data.is_null()
+        || host.base.log.is_none()
+    {
+        return KAPSL_STATUS_INCOMPATIBLE_ABI;
+    }
+    let manifest: serde_json::Value =
+        serde_json::from_slice(unsafe { config.manifest_json.as_bytes() }.unwrap()).unwrap();
+    let state = Box::new(State {
+        host: *host,
+        device: config.device_id,
+        model: config.model_id,
+        replica: config.replica_id,
+        mode: manifest["project_name"].as_str().unwrap_or("normal").into(),
+        scope: AtomicU64::new(1),
+        loaded: AtomicBool::new(false),
+        allocations: Mutex::new(Vec::new()),
+        cancelled: Mutex::new(HashSet::new()),
+        changed: Condvar::new(),
+        calls: AtomicU64::new(0),
+        cancels: AtomicU64::new(0),
+        unloads: AtomicU64::new(0),
+        chunks: AtomicU64::new(0),
+        last_batch: AtomicU64::new(0),
+    });
+    if state.mode.starts_with("fail-initialize") || state.mode == "initialize-allocates" {
+        let status = state.allocate(KAPSL_ALLOCATION_SCOPE_MODEL, &[], 256);
+        if status != KAPSL_STATUS_OK {
+            return status;
+        }
+        if state.mode == "initialize-allocates" {
+            unsafe {
+                *handle = Box::into_raw(state).cast();
+            }
+            return KAPSL_STATUS_OK;
+        }
+        if state.mode != "fail-initialize-null" {
+            unsafe {
+                *handle = Box::into_raw(state).cast();
+            }
+        }
+        return KAPSL_STATUS_BACKEND_ERROR;
+    }
+    unsafe {
+        *handle = Box::into_raw(state).cast();
+    }
+    KAPSL_STATUS_OK
+}
+
+fn report_memory(state: &State, bytes: usize, out: *mut KapslOwnedBuffer) {
+    output(
+        serde_json::to_vec(&MemoryReport::runtime(
+            "fake-memory",
+            MemoryDomain::Cuda {
+                device_id: state.device as usize,
+            },
+            MemoryAllocationClass::PersistentWeights,
+            bytes,
+        ))
+        .unwrap(),
+        out,
+    );
+}
+
+unsafe extern "C" fn planned_memory(
+    handle: *mut c_void,
+    _path: KapslSlice,
+    out: *mut KapslOwnedBuffer,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    report_memory(unsafe { state(handle) }, 256, out);
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn load(
+    handle: *mut c_void,
+    _path: KapslSlice,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let state = unsafe { state(handle) };
+    let status = state.allocate(KAPSL_ALLOCATION_SCOPE_MODEL, &[], 256);
+    if status != KAPSL_STATUS_OK {
+        return status;
+    }
+    if state.mode == "fail-load" || state.mode == "fail-load-cleanup" {
+        return KAPSL_STATUS_BACKEND_ERROR;
+    }
+    state.loaded.store(true, Ordering::Release);
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn planned_request_memory(
+    handle: *mut c_void,
+    _request: *const KapslInferenceRequestV1,
+    out: *mut KapslOwnedBuffer,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    report_memory(unsafe { state(handle) }, 64, out);
+    KAPSL_STATUS_OK
+}
+
+struct OwnedResult {
+    tensor: KapslNamedTensorViewV1,
+    shape: [i64; 1],
+    data: [u8; 1],
+}
+
+fn result() -> KapslInferenceResultV1 {
+    let mut owned = Box::new(OwnedResult {
+        shape: [1],
+        data: [42],
+        tensor: KapslNamedTensorViewV1 {
+            struct_size: std::mem::size_of::<KapslNamedTensorViewV1>() as u32,
+            reserved: 0,
+            name: KapslSlice::from_bytes(b"output"),
+            tensor: KapslTensorViewV1 {
+                struct_size: std::mem::size_of::<KapslTensorViewV1>() as u32,
+                dtype: KAPSL_DTYPE_U8,
+                memory_kind: KAPSL_MEMORY_HOST,
+                flags: KAPSL_TENSOR_FLAG_CONTIGUOUS,
+                device_id: -1,
+                rank: 1,
+                shape: std::ptr::null(),
+                strides: std::ptr::null(),
+                data: std::ptr::null(),
+                byte_len: 1,
+            },
+        },
+    });
+    owned.tensor.tensor.shape = owned.shape.as_ptr();
+    owned.tensor.tensor.data = owned.data.as_ptr().cast();
+    KapslInferenceResultV1 {
+        struct_size: std::mem::size_of::<KapslInferenceResultV1>() as u32,
+        output_count: 1,
+        outputs: &owned.tensor,
+        metadata_json: KapslSlice::empty(),
+        owner_context: Box::into_raw(owned).cast(),
+    }
+}
+
+unsafe extern "C" fn release(_handle: *mut c_void, result: *mut KapslInferenceResultV1) {
+    let result = unsafe { &mut *result };
+    if !result.owner_context.is_null() {
+        unsafe {
+            drop(Box::from_raw(result.owner_context.cast::<OwnedResult>()));
+        }
+    }
+    *result = KapslInferenceResultV1::empty();
+}
+
+unsafe extern "C" fn infer(
+    handle: *mut c_void,
+    request: *const KapslInferenceRequestV1,
+    out: *mut KapslInferenceResultV1,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let state = unsafe { state(handle) };
+    let request = unsafe { &*request };
+    if !state.loaded.load(Ordering::Acquire) {
+        return KAPSL_STATUS_BACKEND_ERROR;
+    }
+    let status = state.allocate(KAPSL_ALLOCATION_SCOPE_REQUEST, &[request.request_id], 64);
+    if status != KAPSL_STATUS_OK {
+        return status;
+    }
+    state.calls.fetch_add(1, Ordering::Release);
+    if state.mode == "wait-cancel" {
+        return state.wait_for_cancel(request.request_id);
+    }
+    if state.mode == "fail-infer" {
+        return KAPSL_STATUS_BACKEND_ERROR;
+    }
+    if state.mode == "invalid-scope" {
+        let ids = [request.request_id];
+        let scope = KapslDeviceAllocationScopeV1::new(
+            KAPSL_ALLOCATION_SCOPE_REQUEST,
+            900,
+            state.model + 1,
+            state.replica,
+            &ids,
+        );
+        let request = KapslScopedDeviceAllocationRequestV1::new(
+            state.device,
+            KAPSL_MEMORY_CUDA,
+            KAPSL_ALLOCATION_CLASS_WORKSPACE,
+            scope,
+            64,
+            64,
+        );
+        let mut allocation = KapslDeviceAllocationV1::empty();
+        if unsafe {
+            state.host.allocate_device_scoped.unwrap()(
+                state.host.base.user_data,
+                &request,
+                &mut allocation,
+            )
+        } == KAPSL_STATUS_OK
+        {
+            return KAPSL_STATUS_BACKEND_ERROR;
+        }
+    }
+    unsafe {
+        *out = result();
+    }
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn infer_batch(
+    handle: *mut c_void,
+    batch: *const KapslInferenceBatchV1,
+    out: *mut KapslInferenceBatchResultV1,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let state = unsafe { state(handle) };
+    let batch = unsafe { &*batch };
+    let requests =
+        unsafe { std::slice::from_raw_parts(batch.requests, batch.request_count as usize) };
+    let ids: Vec<_> = requests.iter().map(|r| r.request_id).collect();
+    let kind = if ids.len() == 1 {
+        KAPSL_ALLOCATION_SCOPE_REQUEST
+    } else {
+        KAPSL_ALLOCATION_SCOPE_REQUEST_BATCH
+    };
+    let status = state.allocate(kind, &ids, 64 * ids.len() as u64);
+    if status != KAPSL_STATUS_OK {
+        return status;
+    }
+    state.last_batch.store(ids.len() as u64, Ordering::Release);
+    state.calls.fetch_add(1, Ordering::Release);
+    if state.mode == "wait-cancel" {
+        return state.wait_for_cancel(ids[0]);
+    }
+    let results: Vec<_> = requests.iter().map(|_| result()).collect();
+    let owned = Box::new(results);
+    unsafe {
+        *out = KapslInferenceBatchResultV1 {
+            struct_size: std::mem::size_of::<KapslInferenceBatchResultV1>() as u32,
+            result_count: owned.len() as u32,
+            results: owned.as_ptr(),
+            owner_context: Box::into_raw(owned).cast(),
+        };
+    }
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn release_batch(handle: *mut c_void, result: *mut KapslInferenceBatchResultV1) {
+    let result = unsafe { &mut *result };
+    let mut owned =
+        unsafe { Box::from_raw(result.owner_context.cast::<Vec<KapslInferenceResultV1>>()) };
+    for result in owned.iter_mut() {
+        unsafe {
+            release(handle, result);
+        }
+    }
+    *result = KapslInferenceBatchResultV1::empty();
+}
+
+unsafe extern "C" fn infer_stream(
+    handle: *mut c_void,
+    request: *const KapslInferenceRequestV1,
+    user: *mut c_void,
+    on_chunk: Option<KapslBackendStreamChunkFn>,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let state = unsafe { state(handle) };
+    let id = unsafe { (*request).request_id };
+    let status = state.allocate(KAPSL_ALLOCATION_SCOPE_REQUEST, &[id], 64);
+    if status != KAPSL_STATUS_OK {
+        return status;
+    }
+    state.calls.fetch_add(1, Ordering::Release);
+    for _ in 0..2 {
+        let mut result = result();
+        let chunk_id = if state.mode == "stream-wrong-owner" {
+            id + 1
+        } else {
+            id
+        };
+        let status = unsafe { on_chunk.unwrap()(user, chunk_id, &result) };
+        unsafe {
+            release(handle, &mut result);
+        }
+        if status != KAPSL_STATUS_OK {
+            return status;
+        }
+        state.chunks.fetch_add(1, Ordering::Release);
+        if state.mode == "stream-wait-cancel" {
+            return state.wait_for_cancel(id);
+        }
+    }
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn cancel(handle: *mut c_void, id: u64) -> i32 {
+    let state = unsafe { state(handle) };
+    state.cancelled.lock().unwrap().insert(id);
+    state.cancels.fetch_add(1, Ordering::Release);
+    state.changed.notify_all();
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn actual_memory(
+    handle: *mut c_void,
+    out: *mut KapslOwnedBuffer,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let state = unsafe { state(handle) };
+    report_memory(
+        state,
+        state
+            .allocations
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|a| a.granted_bytes as usize)
+            .sum(),
+        out,
+    );
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn metrics(
+    handle: *mut c_void,
+    out: *mut KapslOwnedBuffer,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    let state = unsafe { state(handle) };
+    let mut metrics = EngineMetrics::new();
+    metrics.throughput = state.calls.load(Ordering::Acquire) as f64;
+    metrics.batch_size = state.last_batch.load(Ordering::Acquire) as usize;
+    metrics.memory_usage = state
+        .allocations
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|a| a.granted_bytes as usize)
+        .sum();
+    output(serde_json::to_vec(&metrics).unwrap(), out);
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn model_info(
+    _handle: *mut c_void,
+    out: *mut KapslOwnedBuffer,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    output(serde_json::to_vec(&json!({"input_names": ["input"], "output_names": ["output"], "input_shapes": [[1]], "output_shapes": [[1]], "input_dtypes": ["uint8"], "output_dtypes": ["uint8"], "framework": "fake"})).unwrap(), out);
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn batching(
+    _handle: *mut c_void,
+    out: *mut KapslOwnedBuffer,
+    _error: *mut KapslOwnedBuffer,
+) -> i32 {
+    output(
+        br#"{"mode":"request_coalescing","max_requests":4}"#.to_vec(),
+        out,
+    );
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn health(handle: *mut c_void, _error: *mut KapslOwnedBuffer) -> i32 {
+    if unsafe { state(handle) }.loaded.load(Ordering::Acquire) {
+        KAPSL_STATUS_OK
+    } else {
+        KAPSL_STATUS_BACKEND_ERROR
+    }
+}
+
+unsafe extern "C" fn unload(handle: *mut c_void, _error: *mut KapslOwnedBuffer) -> i32 {
+    let state = unsafe { state(handle) };
+    let previous = state.unloads.fetch_add(1, Ordering::AcqRel);
+    if state.mode == "fail-load-cleanup" || (state.mode == "fail-unload" && previous == 0) {
+        return KAPSL_STATUS_BACKEND_ERROR;
+    }
+    if state.mode == "leak-unload" {
+        state.allocations.lock().unwrap().clear();
+    } else {
+        let status = state.release_allocations();
+        if status != KAPSL_STATUS_OK {
+            return status;
+        }
+    }
+    state.loaded.store(false, Ordering::Release);
+    KAPSL_STATUS_OK
+}
+
+unsafe extern "C" fn shutdown(handle: *mut c_void) {
+    let state = unsafe { Box::from_raw(handle.cast::<State>()) };
+    state.release_allocations();
+}
+
+/// Inspect synchronization points without making a control/report call that
+/// would intentionally wait for the engine's in-flight inference guard.
+#[no_mangle]
+pub unsafe extern "C" fn kapsl_test_probe_v1(handle: *mut c_void, counter: u32) -> u64 {
+    let state = unsafe { state(handle) };
+    match counter {
+        0 => state.calls.load(Ordering::Acquire),
+        1 => state.cancels.load(Ordering::Acquire),
+        2 => state.unloads.load(Ordering::Acquire),
+        _ => state.chunks.load(Ordering::Acquire),
+    }
+}
+
+static API: KapslBackendApiV1 = KapslBackendApiV1 {
+    magic: KAPSL_BACKEND_ENTRYPOINT_MAGIC,
+    abi_version: KAPSL_BACKEND_ABI_VERSION,
+    struct_size: std::mem::size_of::<KapslBackendApiV1>() as u32,
+    wire_format: KAPSL_BACKEND_WIRE_FORMAT_TENSORS_V1,
+    capabilities: CAPABILITIES,
+    describe: Some(describe),
+    initialize: Some(initialize),
+    planned_memory: Some(planned_memory),
+    load_model: Some(load),
+    planned_request_memory: Some(planned_request_memory),
+    infer: Some(infer),
+    infer_batch: Some(infer_batch),
+    infer_stream: Some(infer_stream),
+    cancel: Some(cancel),
+    actual_memory: Some(actual_memory),
+    metrics: Some(metrics),
+    model_info: Some(model_info),
+    kv_capabilities: None,
+    kv_topology: None,
+    batching_policy: Some(batching),
+    health_check: Some(health),
+    unload: Some(unload),
+    shutdown: Some(shutdown),
+    release_result: Some(release),
+    release_batch_result: Some(release_batch),
+    free_buffer: Some(free_buffer),
+};
+
+#[no_mangle]
+pub extern "C" fn kapsl_backend_v1() -> *const KapslBackendApiV1 {
+    &API
+}


### PR DESCRIPTION
The generic native host currently imports `kapsl_backends::OnnxRuntimeTuning` and constructs ORT configuration itself. This change accepts opaque adapter options at that boundary and moves the existing ONNX translation into the ONNX compatibility module. The published ORT option layout is preserved.

The host rejects attempts to override engine-owned provider, descriptor, version or installation paths. Regression tests load the fake native cdylib and verify both nested option delivery and override rejection.

Validation: all 39 native host tests passed with `gpu-device-pool` enabled and no GPU; the ONNX packaging contract check, formatting and `git diff --check` passed.

Depends on #225. This is a preparation step for the unreleased neutral engine candidate. It does not remove embedded backends, change release versions, publish packs or start a release.



### Remaining engine retirement inventory

Audited at `0e1274b47911a41b10149fa67a68203d146d4eb6` (this PR, engine version 0.2.10), including normal runtime dependencies with `cargo tree -p kapsl -e normal -i ort`. This is an inventory; this PR removes only the typed ORT tuning dependency from the generic host. The complete engine migration remains unfinished.

| Surface | Classification and disposition |
| --- | --- |
| `backend/native.rs`, `backend/native/allocator.rs`, signed pack validation in `backend/manager.rs` | Generic host functionality remains. Complete generic extension/KV hosting and audit every descriptor capability through actual loaded adapters. Preserve allocation scopes, admission, synchronization, ownership, cancellation and failed-cleanup accounting. |
| `runtime/memory/*`, `runtime/kv/*`, scheduling/admission and process supervision | Engine authority remains. Remove ORT allocator registration and product-name checks; retain device pools, leases, shared mappings, memory reports, health and teardown. KV ABI remains a memory protocol. |
| Direct `ort` dependency in CLI Cargo; `kapsl-backends/onnx-cuda-pool`; `kapsl_backends::ort_pool_allocator` in `runtime/memory/device.rs` | Backend implementation moves to integrations. Delete all engine registration/feature edges when signed adapters replace those routes. |
| `kapsl-backends` and `kapsl-llm` normal dependencies | Both retain ORT transitively. The runtime tree has three ORT paths: CLI direct, CLI → backends, CLI → llm (also through backends). Dropping the direct dependency alone fails acceptance. Remove compute crates from the engine after moving all compute factories into integrations. |
| `runtime/model/backend.rs`, `runtime/model/replica.rs`, `main.rs` | Embedded ORT/GGUF/SafeTensors factories and pipeline generation are temporary backend compute. Replace with selected signed native/managed adapters, then remove embedded factories and rollback switches. |
| `app/config/onnx_session.rs`, `backend/onnx.rs`, `runtime/model/load_plan.rs`, `runtime/serving/worker.rs` | ORT tuning/provider translation belongs in the adapter. Existing manifest keys can remain as metadata translation; no `OnnxRuntimeTuning` may cross the generic host or drive hidden fallback. |
| Engine workspace crate `kapsl-backend-llama-cpp`; `backend/llama_cpp/{mod,shared_pool}.rs` | Move adapter/packaging to integrations. Replace the product-specific loader and callback table with backend ABI plus native KV extension. Keep physical memory authority in the host. SDK #145 provides scheduler request-to-slot bindings; SDK #144 defines generic host/KV contracts. |
| `runtime/managed/{mod,bridge}.rs` and product-specific startup/bootstrap handling | vLLM Python discovery, command construction and configuration translation move to its adapter. Engine retains generic process supervision. vLLM and SGLang must implement the same published managed protocol, including cancellation, memory and shutdown. |
| `backend/selection.rs`, `backend/bundle.rs`, manager/startup/model dispatch | Replace `Builtin`, `LlamaCpp`, `Vllm` dispatch with generic IDs and signed capabilities. Filter format/task/model requirements, platform, hardware, ABI, batching/streaming/allocation/KV requirements and explicit pins. Reject incompatible pins and unresolved ambiguity. Dispatch by native versus managed execution. |
| LLM helpers used by `http/openai/{types,embeddings}.rs`, `features/rag/{inference,query}.rs`, and scheduler setup in `main.rs` | Separate compute-free prompt/model-asset/RAG helpers or relocate appropriate frontend logic. Remove obsolete embedded scheduler glue once integrations own scheduling internals. These helpers cannot justify retaining a backend compute dependency. |
| Engine `.github/scripts/package-*onnx*`, `package-*ort*`, `collect-ort-sidecars.sh`, accelerator/provider build steps | Compilation, provider validation, dependency collection, licensing, signatures and provenance move to integrations. Engine installers consume immutable verified pack artifacts. |
| Tests, docs, old manifest names and report labels | Rewrite tests around generic signed native/managed packs and capabilities. Preserve old manifests through explicit metadata translation. Product names may remain in user configuration/reporting; they must not select hidden embedded code. |

The pinned ORT release currently covers Linux x86-64. Integrations #23 adds authenticated CPU runtime inputs for Linux ARM, macOS and Windows, but those platforms still need complete signed packs, loader/dependency verification and task coverage including generation. Platform support is not narrowed.

Per the final-release direction, no intermediate engine beta/bridge release is planned. Engine #227 makes beta packaging manual before runtime PRs merge. Required SDK contracts must be published first, followed by immutable integration artifacts and exact engine locks. Final qualification must exercise an already-built neutral engine with signed fake native and managed packs, prove accelerator pack selection/governed ownership/isolation/cancellation/reclamation, and pass existing output/performance gates. The startup threshold remains 1.5×. PR checks stay host/CPU only; official GPU qualification and complete resource teardown remain required before public release publication. Never reuse v0.2.10.
