### PR TITLE
fix(ci): require manual dispatch for beta packaging

### DIFF
--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -505,18 +505,13 @@ class WorkflowTests(TestCase):
         self.assertRegex(cache, r'save-pr-cache:\n    required: false\n    default: "false"')
         self.assertNotIn("PRIVATE_KEY", cache)
 
-    def test_ci_only_changes_do_not_automatically_build_betas(self):
+    def test_beta_packaging_requires_deliberate_dispatch_on_develop(self):
         source = workflow("beta-runtime-installers")
-        paths = source.split("    paths:\n", 1)[1].split("\npermissions:", 1)[0]
-        patterns = re.findall(r'^      - "([^"]+)"', paths, re.MULTILINE)
-        for path in ("kapsl-runtime/crates/kapsl-cli/src/main.rs", "rust-toolchain.toml",
-                     "installers/install.sh", ".github/scripts/package-linux-cuda-runtime.sh"):
-            self.assertTrue(any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns), path)
-        for path in (".github/workflows/gpu-device-pool-integration.yml",
-                     ".github/scripts/preflight_release_environment.py", "docs/architecture.md"):
-            self.assertFalse(any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns), path)
-        self.assertIn("workflow_dispatch:", source)
-        self.assertIn("if: github.ref == 'refs/heads/develop'", source)
+        trigger = source.split("\non:\n", 1)[1].split("\npermissions:", 1)[0]
+        self.assertEqual(re.findall(r"^  ([a-z_]+):", trigger, re.MULTILINE),
+                         ["workflow_dispatch"])
+        self.assertIn("if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop'",
+                      job(source, "prepare-version"))
 
 
 class CpuSmokeWorkflowTests(TestCase):

--- a/.github/workflows/beta-runtime-installers.yml
+++ b/.github/workflows/beta-runtime-installers.yml
@@ -1,27 +1,9 @@
 name: Beta Runtime Installers
 
 on:
+  # Packaging is deliberate. Runtime changes on develop are validated by CI;
+  # they must not publish an intermediate installer during the neutral migration.
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-    # CI/authentication-only changes use host-only checks. Full beta packaging
-    # remains available deliberately through workflow_dispatch on develop.
-    paths:
-      - "kapsl-runtime/**"
-      - "rust-toolchain.toml"
-      - ".cargo/**"
-      - "installers/**"
-      - ".github/licenses/**"
-      - ".github/ort*.lock*"
-      - ".github/ort-release-public-key.txt"
-      - ".github/scripts/package-*"
-      - ".github/scripts/collect-*"
-      - ".github/scripts/bootstrap-vllm-backend.sh"
-      - ".github/scripts/managed-vllm-cu130.lock"
-      - ".github/scripts/generate-backend-index.py"
-      - "LICENSE"
-      - "NOTICE"
 
 permissions:
   contents: write
@@ -43,7 +25,7 @@ env:
 jobs:
   prepare-version:
     name: Resolve beta version
-    if: github.ref == 'refs/heads/develop'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Every runtime merge into `develop` currently starts full beta installer packaging. During the backend-neutral migration this repeatedly builds and publishes intermediate artifacts before the candidate is ready for qualification.

Make beta packaging available only by deliberate manual dispatch on `develop`, with an event check on the preparation job as well as the trigger. Ordinary PR and branch correctness checks remain active. Stable release qualification, performance thresholds and teardown requirements are unchanged.

Validation: release pipeline tests, 24 ephemeral-runner policy tests, 6 JIT-runner tests and `git diff --check` passed. No packaging or GPU workflow was dispatched.

Merge before runtime PRs #225 and #226 to avoid triggering intermediate beta builds.
