### PR TITLE
fix(ci): generate valid UTF-8 qualification requests

### DIFF
--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -615,6 +615,29 @@ class CpuSmokeWorkflowTests(TestCase):
 
 
 class ConformanceToolingTests(TestCase):
+    def test_ort_qualification_request_matches_the_utf8_tensor_contract(self):
+        source = step(workflow("vllm-shared-pool-conformance"),
+                      "Build exact CUDA and TensorRT offline qualification bundles")
+        script = textwrap.dedent(source.split("        run: |\n", 1)[1])
+        command = next(line.strip() for line in script.replace("\\\n", " ").splitlines()
+                       if line.strip().startswith("jq -cn --arg prompt "))
+        arguments = shlex.split(command)
+        arguments = arguments[:arguments.index(">")]
+        self.assertIsNotNone(shutil.which(arguments[0]), "jq is required by release conformance")
+        prompt_index = arguments.index("prompt") + 1
+        for prompt in (arguments[prompt_index], "GPU mémoire 🦙"):
+            with self.subTest(prompt=prompt):
+                invocation = arguments.copy()
+                invocation[prompt_index] = prompt
+                result = subprocess.run(invocation, capture_output=True, text=True, check=True)
+                request = json.loads(result.stdout)
+                tensor = request["input"]
+                payload = base64.b64decode(tensor["data_base64"], validate=True)
+                self.assertEqual(payload, prompt.encode("utf-8"))
+                self.assertEqual(tensor["dtype"], "string")
+                self.assertEqual(tensor["shape"], [1, len(payload)])
+                self.assertEqual(request["metadata"]["max_new_tokens"], 8)
+
     def setUp(self):
         self.gpu = job(workflow("vllm-shared-pool-conformance"), "flash-attn")
         self.bash = shutil.which("bash")

--- a/.github/workflows/vllm-shared-pool-conformance.yml
+++ b/.github/workflows/vllm-shared-pool-conformance.yml
@@ -1573,7 +1573,7 @@ jobs:
               ' "$ORT_BRIDGE_EVIDENCE_DIR/bundle-$profile.json" >/dev/null
           done
           jq -cn --arg prompt "The bridge release uses signed backend packs." \
-            '{input:{shape:[1,1],dtype:"string",data_base64:($prompt|@base64)},session_id:"ort-stable-qualification",metadata:{max_new_tokens:8,min_new_tokens:8,temperature:0.0,seed:7}}' \
+            '{input:{shape:[1,($prompt|utf8bytelength)],dtype:"string",data_base64:($prompt|@base64)},session_id:"ort-stable-qualification",metadata:{max_new_tokens:8,min_new_tokens:8,temperature:0.0,seed:7}}' \
             > "$ORT_BRIDGE_WORK_DIR/ort-request.json"
           sha256sum "$cuda_aimod" "$tensorrt_aimod" "$cuda_bundle" "$tensorrt_bundle" \
             > "$ORT_BRIDGE_EVIDENCE_DIR/qualification-inputs.sha256"


### PR DESCRIPTION
The signed ORT generation qualification request encodes a 45-byte UTF-8 prompt with tensor shape `[1,1]`. The native adapter validates the published tensor contract and rejects it with `Data length mismatch: expected 1 bytes ... but got 45 bytes`, preventing the stable test from reaching inference.

Derive the shape from the UTF-8 byte length. A host-only regression executes the workflow's actual request-generation command for both its release prompt and a multibyte prompt, then checks the decoded payload and tensor dimensions independently.

Validation: all 43 release-pipeline tests pass, along with actionlint and diff checks. The existing stable GPU gating and 1.5× startup threshold are unchanged. The Vast trial still exposes separate package-asset and accelerator conformance failures; this change does not qualify an engine release.
