### PR TITLE
fix(runtime): preserve packaged assets through native loading

### DIFF
--- a/kapsl-runtime/Cargo.lock
+++ b/kapsl-runtime/Cargo.lock
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "kapsl-core"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82444501a45f1da8cae90b36aad081b87ddac1450c9ba101e06f9251b5e23cb"
+checksum = "4328c2d4b6cec499618ecce62fdc852c6c1ee3f7b67f78fc573e0acfbf6b4192"
 dependencies = [
  "flate2",
  "fs2",

--- a/kapsl-runtime/crates/kapsl-cli/Cargo.toml
+++ b/kapsl-runtime/crates/kapsl-cli/Cargo.toml
@@ -36,7 +36,7 @@ cc = "1"
 
 [dependencies]
 kapsl-grpc = { version = "0.3.0", optional = true }
-kapsl-core = "0.3.0"
+kapsl-core = "=0.3.1"
 kapsl-hal = "0.3.0"
 kapsl-engine-api = "0.3.0"
 kapsl-backends = "0.3.0"

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native/boundary_tests.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native/boundary_tests.rs
@@ -86,6 +86,69 @@ async fn wait_started(instance: &NativePackInstance, count: u64) {
     .expect("fake adapter never entered inference");
 }
 
+#[tokio::test]
+async fn packaged_assets_reach_the_adapter_after_source_and_extraction_cleanup() {
+    use crate::features::packaging::{
+        create_kapsl_package_from_context, ContextPackageRequest, TempDirGuard,
+    };
+    use kapsl_core::PackageLoader;
+
+    let temp = TempDirGuard::new("native-package-assets").unwrap();
+    let context = temp.path().join("source");
+    std::fs::create_dir_all(context.join("graphs")).unwrap();
+    std::fs::create_dir_all(context.join("assets")).unwrap();
+    for (relative, contents) in [
+        ("graphs/model.onnx", "fake model"),
+        ("vocab.json", "root vocabulary"),
+        ("graphs/vocab.json", "graph vocabulary"),
+        ("assets/config.json", "model configuration"),
+    ] {
+        std::fs::write(context.join(relative), contents).unwrap();
+    }
+    let mut manifest = model("package-assets");
+    manifest.model_file = "graphs/model.onnx".into();
+    std::fs::write(
+        context.join("metadata.json"),
+        serde_json::to_vec(&manifest).unwrap(),
+    )
+    .unwrap();
+    let package = temp.path().join("model.aimod");
+    create_kapsl_package_from_context(ContextPackageRequest {
+        output_override: Some(&package),
+        ..ContextPackageRequest::new(&context)
+    })
+    .unwrap();
+    let loader = PackageLoader::load(&package).unwrap();
+    let model_path = loader.get_model_path();
+    let extracted = loader.extracted_path.clone();
+    let pool = Arc::new(FakePool::default());
+    let instance = NativePackInstance::initialize_with_host(
+        pack(),
+        &loader.manifest,
+        "cuda",
+        pool.host(7, 2, 2048),
+        0,
+        7,
+        2,
+        &serde_json::Map::new(),
+    )
+    .unwrap();
+    drop(loader);
+    assert!(!extracted.exists());
+    std::fs::remove_dir_all(&context).unwrap();
+    std::fs::remove_file(&package).unwrap();
+
+    let mut engine = NativePackedEngine { instance };
+    // The loaded cdylib reads the model and root/nested assets from the exact
+    // path passed through the production native ABI, using only the cache.
+    for _ in 0..2 {
+        engine.load(&model_path).await.unwrap();
+        assert_eq!(engine.infer(&request()).unwrap().data, vec![42]);
+        engine.unload();
+        assert_eq!(pool.bytes((7, 2)), 0);
+    }
+}
+
 #[test]
 fn opaque_adapter_options_cross_the_loaded_native_boundary() {
     let pool = Arc::new(FakePool::default());

--- a/kapsl-runtime/tests/native-adapter/src/lib.rs
+++ b/kapsl-runtime/tests/native-adapter/src/lib.rs
@@ -238,8 +238,8 @@ unsafe extern "C" fn planned_memory(
 
 unsafe extern "C" fn load(
     handle: *mut c_void,
-    _path: KapslSlice,
-    _error: *mut KapslOwnedBuffer,
+    path: KapslSlice,
+    error: *mut KapslOwnedBuffer,
 ) -> i32 {
     let state = unsafe { state(handle) };
     let status = state.allocate(KAPSL_ALLOCATION_SCOPE_MODEL, &[], 256);
@@ -248,6 +248,26 @@ unsafe extern "C" fn load(
     }
     if state.mode == "fail-load" || state.mode == "fail-load-cleanup" {
         return KAPSL_STATUS_BACKEND_ERROR;
+    }
+    if state.mode == "package-assets" {
+        let path =
+            std::path::Path::new(std::str::from_utf8(unsafe { path.as_bytes() }.unwrap()).unwrap());
+        let root = path.parent().and_then(std::path::Path::parent).unwrap();
+        let assets: &[(&str, &[u8])] = &[
+            ("graphs/model.onnx", b"fake model"),
+            ("vocab.json", b"root vocabulary"),
+            ("graphs/vocab.json", b"graph vocabulary"),
+            ("assets/config.json", b"model configuration"),
+        ];
+        for (relative, expected) in assets {
+            if std::fs::read(root.join(relative)).ok().as_deref() != Some(*expected) {
+                output(
+                    format!("missing package asset: {relative}").into_bytes(),
+                    error,
+                );
+                return KAPSL_STATUS_BACKEND_ERROR;
+            }
+        }
     }
     state.loaded.store(true, Ordering::Release);
     KAPSL_STATUS_OK


### PR DESCRIPTION
The Vast generation trial exposed packages whose model is nested below the package root: the previous model cache kept only the primary model's directory, losing root tokenizer/configuration assets before the native adapter loaded the model.

Pin the now-published `kapsl-core = 0.3.1` and its verified registry checksum. Its cache preserves the complete package-relative asset layout and accounts for every asset. A new host-only regression builds a package with nested model files and duplicate asset basenames, removes the source directory, archive and temporary extraction, then loads, exercises, unloads and reloads the real fake-adapter cdylib through the production native host. The adapter itself reads the required assets from the path supplied over the ABI.

Validation: all 473 engine tests pass, including 40 native-host tests; formatting and diff checks pass. `kapsl-core 0.3.1` was published from SDK merge fd7163e61acf6404d3c23b42f28b1e845564d77f after its 74 packaged tests, and the downloaded registry artifact matches SHA-256 4328c2d4b6cec499618ecce62fdc852c6c1ee3f7b67f78fc573e0acfbf6b4192. No temporary Cargo patch or sibling dependency is introduced. The engine version and release gates are unchanged; accelerator generation and memory lifecycle still need qualification.
