### PR TITLE
fix(test): authenticate GPU pool conformance requests

### DIFF
--- a/.github/scripts/test-gpu-device-pool-integration.sh
+++ b/.github/scripts/test-gpu-device-pool-integration.sh
@@ -32,6 +32,7 @@ set -Eeuo pipefail
 
 script_name="$(basename "$0")"
 runtime_pid=""
+api_admin_token=""
 created_output_dir=0
 
 usage() {
@@ -638,13 +639,13 @@ cleanup() {
 }
 
 api_get() {
-  curl -fsS --max-time 15 "$base_url$1"
+  curl -fsS --max-time 15 -H "Authorization: Bearer $api_admin_token" "$base_url$1"
 }
 
 api_post() {
   local path="$1"
   shift
-  curl -fsS --max-time 30 -X POST "$base_url$path" "$@"
+  curl -fsS --max-time 30 -H "Authorization: Bearer $api_admin_token" -X POST "$base_url$path" "$@"
 }
 
 runtime_is_alive() {
@@ -922,6 +923,7 @@ main() {
   require_command jq
   require_command nvidia-smi
   require_command awk
+  require_command python3
 
   binary="${KAPSL_GPU_TEST_BINARY:-}"
   bundle="${KAPSL_GPU_TEST_BUNDLE:-}"
@@ -1025,6 +1027,9 @@ main() {
   fi
 
   note "starting ORT model 0 and GGUF model 1 on CUDA_VISIBLE_DEVICES=$cuda_visible_devices"
+  # The engine requires authentication even on loopback. Keep this disposable
+  # test credential in memory and use the same token for the server and client.
+  api_admin_token="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
   env_args=(
     "CUDA_VISIBLE_DEVICES=$cuda_visible_devices"
     "KAPSL_GPU_DEVICE_POOL_MODE=$pool_mode"
@@ -1044,7 +1049,7 @@ main() {
     "KAPSL_PROVIDER_POLICY=fastest"
     "KAPSL_API_TOKEN_READER="
     "KAPSL_API_TOKEN_WRITER="
-    "KAPSL_API_TOKEN_ADMIN="
+    "KAPSL_API_TOKEN_ADMIN=$api_admin_token"
     "KAPSL_DISCARD_PACKAGE_AFTER_LOAD=0"
     "KAPSL_LITE_DISCARD_PACKAGE_AFTER_LOAD=0"
     "KAPSL_ALLOW_INSECURE_HTTP=1"

--- a/.github/scripts/test_release_pipeline.py
+++ b/.github/scripts/test_release_pipeline.py
@@ -5,6 +5,7 @@ import base64
 import fnmatch
 import glob
 import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import importlib.util
 import json
 import os
@@ -16,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
 from unittest import TestCase, main, mock
 
 
@@ -52,6 +54,62 @@ def step(source, name):
     if not match:
         raise AssertionError(f"Step {name} is missing")
     return match[1]
+
+
+class GpuHarnessAuthenticationTests(TestCase):
+    def test_lifecycle_client_authenticates_and_rejects_invalid_credentials(self):
+        token = "host-only-disposable-test-token"
+        requests = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def handle_request(self):
+                payload = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+                authorized = self.headers.get("Authorization") == "Bearer " + token
+                requests.append((self.command, self.path, payload, authorized))
+                self.send_response(200 if authorized else 401)
+                self.end_headers()
+                self.wfile.write(b'{"ok":true}' if authorized else b'{"error":"unauthorized"}')
+
+            do_GET = handle_request
+            do_POST = handle_request
+
+            def log_message(self, *_args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            env = os.environ | {
+                "KAPSL_GPU_INTEGRATION": "0",
+                "KAPSL_TEST_HARNESS": str(ROOT / ".github/scripts/test-gpu-device-pool-integration.sh"),
+                "KAPSL_TEST_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+            }
+            preamble = '''source "$KAPSL_TEST_HARNESS" ''
+base_url="$KAPSL_TEST_BASE_URL"
+api_admin_token="$KAPSL_TEST_TOKEN"
+'''
+            for credential in ("", "wrong-test-token", token):
+                for command in (
+                    "api_get /api/models",
+                    '''api_post /api/models/0/stop -H 'Content-Type: application/json' --data-binary '{"probe":true}' ''',
+                ):
+                    with self.subTest(authorized=credential == token, command=command):
+                        result = subprocess.run(
+                            ["bash", "-c", preamble + command],
+                            env=env | {"KAPSL_TEST_TOKEN": credential},
+                            text=True, capture_output=True, timeout=10,
+                        )
+                        self.assertEqual(result.returncode, 0 if credential == token else 22)
+                        self.assertNotIn(token, result.stdout + result.stderr)
+            self.assertEqual(requests[-2:], [
+                ("GET", "/api/models", b"", True),
+                ("POST", "/api/models/0/stop", b'{"probe":true}', True),
+            ])
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
 
 
 class PublishedSdkTests(TestCase):


### PR DESCRIPTION
The GPU pool conformance harness sent unauthenticated requests and cleared the engine's admin token, so the authenticated engine could not pass readiness or lifecycle checks. Generate a disposable token for each test process and send it with every harness GET and POST.

The token stays in process memory. Pool ownership, reclamation, output and performance assertions remain unchanged.

Validation: 44 host-only release pipeline tests passed, including an HTTP fixture that accepts authenticated lifecycle requests and rejects missing/wrong credentials; pool harness `--self-test`, shell syntax and `git diff --check` passed. No GPU workflow was dispatched for this PR.
