### PR TITLE
fix(runtime): scope embedded ORT pool registration to backend lifetime

### DIFF
--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/device.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/device.rs
@@ -126,6 +126,19 @@ struct ExternalReservation {
     owns_charge: bool,
 }
 
+struct ManagedDevicePool {
+    backing: Arc<GpuDevicePool>,
+    clients: Arc<PoolClients>,
+}
+
+impl std::ops::Deref for ManagedDevicePool {
+    type Target = GpuDevicePool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.backing
+    }
+}
+
 /// Runtime memory authority for each CUDA device.
 ///
 /// Backends receive cloned elastic-pool handles where available, while this
@@ -133,7 +146,7 @@ struct ExternalReservation {
 /// cannot yet live in that pool (notably llama.cpp weights and compute scratch).
 pub(crate) struct DeviceMemoryManager {
     devices: HashMap<usize, DeviceAuthority>,
-    pools: Mutex<HashMap<usize, Arc<GpuDevicePool>>>,
+    pools: Mutex<HashMap<usize, Arc<ManagedDevicePool>>>,
     budget: Mutex<DeviceBudgetLedger>,
     admission_refs: Mutex<HashMap<(usize, PoolOwner), usize>>,
     next_fallback_allocation: AtomicU64,
@@ -142,8 +155,9 @@ pub(crate) struct DeviceMemoryManager {
 
 impl DeviceMemoryManager {
     /// Create one authority for every CUDA device. Fixed and model-aware
-    /// automatic pools are built and registered with ORT before any model
-    /// session is constructed; external-memory accounting remains active when
+    /// automatic pools are built before any model session is constructed.
+    /// Backend registrations are acquired separately by their consumers;
+    /// external-memory accounting remains active when
     /// no physical pool is materialized.
     pub(crate) fn from_env_with_plan(
         device_info: &DeviceInfo,
@@ -243,10 +257,10 @@ impl DeviceMemoryManager {
             }
         }
 
-        // Validate every deterministic sizing decision before registering the
-        // first process-global ORT allocator. Physical allocation failures can
-        // still happen later if live free VRAM changes, but a bad configuration
-        // cannot leave startup half-registered across devices.
+        // Validate every deterministic sizing decision before allocating the
+        // first device pool. Physical allocation failures can still happen
+        // later if live free VRAM changes, but a bad configuration cannot leave
+        // startup partially allocated across devices.
         for (&device_id, authority) in &self.devices {
             let demand = bootstrap.demand(device_id);
             match authority.pool_mode {
@@ -466,10 +480,13 @@ impl DeviceMemoryManager {
                 "automatic CUDA pool on device {device_id} is {current_capacity} bytes but the dynamic load requires at least {required_capacity} bytes; the pool still has live allocations and cannot be rematerialized"
             ));
         }
-        kapsl_backends::ort_pool_allocator::unregister_pool_allocator(device_id as i32, &pool)
-            .map_err(|error| {
-                format!("cannot rematerialize automatic CUDA pool on device {device_id}: {error}")
-            })?;
+        if !pool.clients.retire().map_err(|error| {
+            format!("cannot rematerialize automatic CUDA pool on device {device_id}: {error}")
+        })? {
+            return Err(format!(
+                "cannot rematerialize automatic CUDA pool on device {device_id}: backend clients are still live"
+            ));
+        }
         self.pools.lock().unwrap().remove(&device_id);
         if let Some(metrics) = self.metrics.lock().unwrap().clone() {
             metrics.remove_gpu_device_pool_metrics(&device_id.to_string());
@@ -588,17 +605,13 @@ impl DeviceMemoryManager {
                 ));
             }
         };
-        if let Err(error) =
-            kapsl_backends::ort_pool_allocator::register_pool_allocator(device_id as i32, &pool)
-        {
-            let _ = self
-                .budget
-                .lock()
-                .unwrap()
-                .set_pooled_bytes(device_id, previous.pooled_bytes);
-            return Err(error);
-        }
-        self.pools.lock().unwrap().insert(device_id, pool);
+        self.pools.lock().unwrap().insert(
+            device_id,
+            Arc::new(ManagedDevicePool {
+                backing: pool,
+                clients: Arc::new(PoolClients::default()),
+            }),
+        );
         self.publish_metrics(device_id, charged);
         Ok(())
     }
@@ -623,7 +636,7 @@ impl DeviceMemoryManager {
     }
 
     /// Refresh inference-time allocator metrics immediately before a
-    /// Prometheus scrape. Budget metrics are event-driven, but ORT and KV
+    /// Prometheus scrape. Budget metrics are event-driven, but backend and KV
     /// suballocations can change on every inference, so they must be sampled
     /// from the live pool instead of waiting for another model lifecycle event.
     pub(crate) fn refresh_pool_metrics(&self) {
@@ -649,7 +662,36 @@ impl DeviceMemoryManager {
 
     #[cfg(feature = "gpu-device-pool")]
     pub(crate) fn pool(&self, device_id: usize) -> Option<Arc<GpuDevicePool>> {
-        self.pools.lock().unwrap().get(&device_id).cloned()
+        self.pools
+            .lock()
+            .unwrap()
+            .get(&device_id)
+            .map(|pool| pool.backing.clone())
+    }
+
+    pub(crate) fn acquire_pool_client(
+        self: &Arc<Self>,
+        device_id: usize,
+        client: &'static str,
+        register: impl FnOnce(&Arc<GpuDevicePool>) -> Result<PoolClientCleanup, String>,
+    ) -> Result<Option<PoolClientLease>, String> {
+        let Some(authority) = self.devices.get(&device_id) else {
+            return Ok(None);
+        };
+        let _init_guard = authority.pool_init_lock.lock().unwrap();
+        let Some(pool) = self.pools.lock().unwrap().get(&device_id).cloned() else {
+            return Ok(None);
+        };
+        let manager = Arc::downgrade(self);
+        pool.clients
+            .acquire(client, || register(&pool.backing))
+            .map(|lease| {
+                Some(lease.on_release(move || {
+                    if let Some(manager) = manager.upgrade() {
+                        manager.try_reclaim_pool(device_id);
+                    }
+                }))
+            })
     }
 
     pub(crate) fn has_pool(&self, device_id: usize) -> bool {
@@ -1259,8 +1301,8 @@ impl DeviceMemoryManager {
     }
 
     /// Drop an idle backing allocation after the final admitted consumer has
-    /// torn down. ORT must be unregistered before its stable allocator Box and
-    /// pool Arc can be released.
+    /// torn down. Backend clients must retire their registrations before the
+    /// backing allocation and its accounting can be released.
     fn try_reclaim_pool(&self, device_id: usize) {
         if self
             .admission_refs
@@ -1281,15 +1323,17 @@ impl DeviceMemoryManager {
         if pool.free_bytes() != pool.capacity_bytes() {
             return;
         }
-        if let Err(error) =
-            kapsl_backends::ort_pool_allocator::unregister_pool_allocator(device_id as i32, &pool)
-        {
-            log::warn!(
-                "[device-memory] cannot reclaim idle CUDA pool on device {}: {}",
-                device_id,
-                error
-            );
-            return;
+        match pool.clients.retire() {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                log::warn!(
+                    "[device-memory] cannot reclaim idle CUDA pool on device {}: {}",
+                    device_id,
+                    error
+                );
+                return;
+            }
         }
         self.pools.lock().unwrap().remove(&device_id);
         if let Some(metrics) = self.metrics.lock().unwrap().clone() {
@@ -1694,7 +1738,7 @@ fn configured_quota(
     };
     let max = configured_bytes(max_name, device_id)?.unwrap_or(pool.capacity_bytes());
     // Protect a useful share for each admitted backend by default. Four-way
-    // sharing covers the common ORT + multiple KV-owner deployment while
+    // sharing covers backend sessions plus multiple KV owners while
     // explicit per-owner settings retain full control (including zero).
     let guaranteed = configured_bytes(guaranteed_name, device_id)?
         .unwrap_or_else(|| (pool.capacity_bytes() / 4).min(max));

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/device.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/device.rs
@@ -1071,6 +1071,12 @@ impl DeviceMemoryManager {
     }
 
     fn admit_pool(&self, device_id: usize, owner: PoolOwner) -> Result<(), String> {
+        let Some(authority) = self.devices.get(&device_id) else {
+            return Ok(());
+        };
+        // Admission must retain the same backing that it protects. Serialize
+        // pool lookup and owner admission with retirement and replacement.
+        let _init_guard = authority.pool_init_lock.lock().unwrap();
         let Some(pool) = self.pools.lock().unwrap().get(&device_id).cloned() else {
             return Ok(());
         };
@@ -1304,6 +1310,10 @@ impl DeviceMemoryManager {
     /// torn down. Backend clients must retire their registrations before the
     /// backing allocation and its accounting can be released.
     fn try_reclaim_pool(&self, device_id: usize) {
+        let Some(authority) = self.devices.get(&device_id) else {
+            return;
+        };
+        let _init_guard = authority.pool_init_lock.lock().unwrap();
         if self
             .admission_refs
             .lock()
@@ -1313,10 +1323,6 @@ impl DeviceMemoryManager {
         {
             return;
         }
-        let Some(authority) = self.devices.get(&device_id) else {
-            return;
-        };
-        let _init_guard = authority.pool_init_lock.lock().unwrap();
         let Some(pool) = self.pools.lock().unwrap().get(&device_id).cloned() else {
             return;
         };

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/mod.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/mod.rs
@@ -15,11 +15,17 @@ mod device;
 mod device_budget;
 mod device_limits;
 pub(crate) mod host;
+#[cfg(any(feature = "gpu-device-pool", test))]
+mod pool_clients;
 mod priority;
 
 #[cfg(feature = "gpu-device-pool")]
 pub(crate) use device::*;
 pub(crate) use device_limits::*;
+#[cfg(feature = "gpu-device-pool")]
+pub(crate) use pool_clients::PoolClientCleanup;
+#[cfg(any(feature = "gpu-device-pool", test))]
+pub(crate) use pool_clients::{PoolClientLease, PoolClients};
 pub(crate) use priority::*;
 
 use self::host::{HostMemoryLease, HostMemoryLoadAdmission, HostMemoryManager};
@@ -2410,6 +2416,21 @@ impl MemoryAuthority {
         self.cuda
             .as_ref()
             .is_some_and(|manager| manager.has_pool(device_id))
+    }
+
+    #[cfg(feature = "gpu-device-pool")]
+    pub(crate) fn acquire_cuda_pool_client(
+        &self,
+        device_id: usize,
+        client: &'static str,
+        register: impl FnOnce(
+            &Arc<kapsl_hal::gpu_arena::GpuDevicePool>,
+        ) -> Result<PoolClientCleanup, String>,
+    ) -> Result<Option<PoolClientLease>, String> {
+        match self.cuda.as_ref() {
+            Some(manager) => manager.acquire_pool_client(device_id, client, register),
+            None => Ok(None),
+        }
     }
 
     #[cfg(feature = "gpu-device-pool")]

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/pool_clients.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/memory/pool_clients.rs
@@ -1,0 +1,261 @@
+//! Backend-owned registrations attached to one physical device pool.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+pub(crate) type PoolClientCleanup = Box<dyn Fn() -> Result<(), String> + Send + Sync>;
+
+struct Registration {
+    users: usize,
+    cleanup: PoolClientCleanup,
+}
+
+#[derive(Default)]
+pub(crate) struct PoolClients {
+    registrations: Mutex<BTreeMap<&'static str, Registration>>,
+}
+
+impl PoolClients {
+    pub(crate) fn acquire(
+        self: &Arc<Self>,
+        client: &'static str,
+        register: impl FnOnce() -> Result<PoolClientCleanup, String>,
+    ) -> Result<PoolClientLease, String> {
+        let mut registrations = self.registrations.lock().unwrap();
+        if let Some(registration) = registrations.get_mut(client) {
+            if registration.users > 0 {
+                registration.users = registration.users.checked_add(1).ok_or_else(|| {
+                    format!("device pool client {client} reference count overflow")
+                })?;
+                return Ok(PoolClientLease::new(self.clone(), client));
+            }
+            // A failed terminal cleanup must complete before another model
+            // can reuse the registration. Keep its storage on failure.
+            (registration.cleanup)()?;
+            registrations.remove(client);
+        }
+        let cleanup = register()?;
+        registrations.insert(client, Registration { users: 1, cleanup });
+        Ok(PoolClientLease::new(self.clone(), client))
+    }
+
+    fn release(&self, client: &'static str) {
+        let mut registrations = self.registrations.lock().unwrap();
+        let registration = registrations
+            .get_mut(client)
+            .expect("a pool client lease retains its registration");
+        registration.users -= 1;
+        if registration.users == 0 {
+            match (registration.cleanup)() {
+                Ok(()) => {
+                    registrations.remove(client);
+                }
+                Err(error) => log::warn!(
+                    "[device-memory] retaining device pool client {client} after cleanup failed: {error}"
+                ),
+            }
+        }
+    }
+
+    /// Pool retirement is forbidden while clients are live. Failed cleanup
+    /// retains both the callback and its captured resources for a later retry.
+    pub(crate) fn retire(&self) -> Result<bool, String> {
+        let mut registrations = self.registrations.lock().unwrap();
+        if registrations
+            .values()
+            .any(|registration| registration.users > 0)
+        {
+            return Ok(false);
+        }
+        while let Some((&client, registration)) = registrations.first_key_value() {
+            (registration.cleanup)()?;
+            registrations.remove(client);
+        }
+        Ok(true)
+    }
+}
+
+pub(crate) struct PoolClientLease {
+    clients: Arc<PoolClients>,
+    client: &'static str,
+    on_release: Option<Box<dyn FnOnce() + Send + Sync>>,
+}
+
+impl PoolClientLease {
+    fn new(clients: Arc<PoolClients>, client: &'static str) -> Self {
+        Self {
+            clients,
+            client,
+            on_release: None,
+        }
+    }
+
+    pub(crate) fn on_release(mut self, callback: impl FnOnce() + Send + Sync + 'static) -> Self {
+        self.on_release = Some(Box::new(callback));
+        self
+    }
+}
+
+impl Drop for PoolClientLease {
+    fn drop(&mut self) {
+        self.clients.release(self.client);
+        // Retirement can take the pool's initialization lock. Never invoke it
+        // while holding the registration mutex used by acquisition.
+        if let Some(callback) = self.on_release.take() {
+            callback();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Barrier;
+
+    #[derive(Default)]
+    struct Probe {
+        registered: AtomicUsize,
+        cleaned: AtomicUsize,
+        fail_cleanup: AtomicBool,
+    }
+
+    impl Probe {
+        fn register(self: &Arc<Self>) -> Result<PoolClientCleanup, String> {
+            self.registered.fetch_add(1, Ordering::SeqCst);
+            let probe = self.clone();
+            Ok(Box::new(move || {
+                if probe.fail_cleanup.load(Ordering::SeqCst) {
+                    return Err("client still owns device storage".into());
+                }
+                probe.cleaned.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }))
+        }
+    }
+
+    #[test]
+    fn shared_registration_outlives_each_model_and_does_not_retire_other_clients() {
+        let clients = Arc::new(PoolClients::default());
+        assert!(clients.retire().unwrap());
+        let ort = Arc::new(Probe::default());
+        let other = Arc::new(Probe::default());
+        let model = clients.acquire("embedded-ort", || ort.register()).unwrap();
+        let replica = clients.acquire("embedded-ort", || ort.register()).unwrap();
+        let other_model = clients
+            .acquire("other-backend", || other.register())
+            .unwrap();
+        assert_eq!(ort.registered.load(Ordering::SeqCst), 1);
+        assert!(!clients.retire().unwrap());
+        drop(model);
+        assert_eq!(ort.cleaned.load(Ordering::SeqCst), 0);
+        drop(replica);
+        assert_eq!(ort.cleaned.load(Ordering::SeqCst), 1);
+        assert_eq!(other.cleaned.load(Ordering::SeqCst), 0);
+        assert!(!clients.retire().unwrap());
+        drop(other_model);
+        assert!(clients.retire().unwrap());
+        assert_eq!(other.cleaned.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn independent_pools_and_reloads_get_independent_registrations() {
+        let first = Arc::new(PoolClients::default());
+        let second = Arc::new(PoolClients::default());
+        let probe = Arc::new(Probe::default());
+        let a = first.acquire("backend", || probe.register()).unwrap();
+        let b = second.acquire("backend", || probe.register()).unwrap();
+        drop(a);
+        assert!(first.retire().unwrap());
+        assert!(!second.retire().unwrap());
+        let reloaded = first.acquire("backend", || probe.register()).unwrap();
+        assert_eq!(probe.registered.load(Ordering::SeqCst), 3);
+        drop((b, reloaded));
+        assert_eq!(probe.cleaned.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn registration_failure_leaves_no_client_or_cleanup_callback() {
+        let clients = Arc::new(PoolClients::default());
+        assert!(clients
+            .acquire("backend", || Err("registration failed".into()))
+            .is_err());
+        assert!(clients.retire().unwrap());
+        let probe = Arc::new(Probe::default());
+        drop(clients.acquire("backend", || probe.register()).unwrap());
+        assert_eq!(probe.registered.load(Ordering::SeqCst), 1);
+        assert_eq!(probe.cleaned.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn failed_cleanup_retains_resources_and_blocks_reuse_until_retry_succeeds() {
+        let clients = Arc::new(PoolClients::default());
+        let probe = Arc::new(Probe::default());
+        probe.fail_cleanup.store(true, Ordering::SeqCst);
+        let storage = Arc::new(vec![0u8; 32]);
+        let retained = Arc::downgrade(&storage);
+        let cleanup = probe.register().unwrap();
+        let lease = clients
+            .acquire("backend", || {
+                Ok(Box::new(move || {
+                    let _keep_storage_live = &storage;
+                    cleanup()
+                }))
+            })
+            .unwrap();
+        drop(lease);
+        assert!(retained.upgrade().is_some());
+        assert!(clients.retire().is_err());
+        assert!(clients.acquire("backend", || probe.register()).is_err());
+        assert_eq!(probe.registered.load(Ordering::SeqCst), 1);
+        assert!(retained.upgrade().is_some());
+        probe.fail_cleanup.store(false, Ordering::SeqCst);
+        let reloaded = clients.acquire("backend", || probe.register()).unwrap();
+        assert!(retained.upgrade().is_none());
+        assert_eq!(probe.registered.load(Ordering::SeqCst), 2);
+        drop(reloaded);
+        assert!(clients.retire().unwrap());
+        assert_eq!(probe.cleaned.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn release_notification_can_reenter_retirement_without_holding_client_lock() {
+        let clients = Arc::new(PoolClients::default());
+        let probe = Arc::new(Probe::default());
+        let notified = Arc::new(AtomicBool::new(false));
+        let callback_clients = clients.clone();
+        let callback_notified = notified.clone();
+        let lease = clients
+            .acquire("backend", || probe.register())
+            .unwrap()
+            .on_release(move || {
+                assert!(callback_clients.retire().unwrap());
+                callback_notified.store(true, Ordering::SeqCst);
+            });
+        drop(lease);
+        assert!(notified.load(Ordering::SeqCst));
+        assert_eq!(probe.cleaned.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn concurrent_model_preparation_shares_one_registration_until_last_release() {
+        let clients = Arc::new(PoolClients::default());
+        let probe = Arc::new(Probe::default());
+        let loaded = Arc::new(Barrier::new(8));
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let clients = clients.clone();
+                let probe = probe.clone();
+                let loaded = loaded.clone();
+                scope.spawn(move || {
+                    let lease = clients.acquire("backend", || probe.register()).unwrap();
+                    loaded.wait();
+                    drop(lease);
+                });
+            }
+        });
+        assert_eq!(probe.registered.load(Ordering::SeqCst), 1);
+        assert_eq!(probe.cleaned.load(Ordering::SeqCst), 1);
+        assert!(clients.retire().unwrap());
+    }
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
@@ -5,8 +5,91 @@ use kapsl_engine_api::{
     OpenAiWireStreamResponse, RequestMemoryAdmission,
 };
 
-struct MemoryTrackedEngine {
+/// A backend and the pool registrations it needs from planning through final
+/// destruction. Drop the engine before releasing allocator callback storage.
+pub(super) struct PreparedBackend {
     inner: Box<dyn kapsl_engine_api::Engine>,
+    #[cfg(any(feature = "gpu-device-pool", test))]
+    _pool_clients: Vec<PoolClientLease>,
+}
+
+impl PreparedBackend {
+    #[cfg(any(feature = "gpu-device-pool", test))]
+    pub(super) fn with_pool_clients(mut self, clients: Vec<PoolClientLease>) -> Self {
+        self._pool_clients.extend(clients);
+        self
+    }
+}
+
+impl From<Box<dyn kapsl_engine_api::Engine>> for PreparedBackend {
+    fn from(inner: Box<dyn kapsl_engine_api::Engine>) -> Self {
+        Self {
+            inner,
+            #[cfg(any(feature = "gpu-device-pool", test))]
+            _pool_clients: Vec::new(),
+        }
+    }
+}
+
+impl<T: kapsl_engine_api::Engine + 'static> From<Box<T>> for PreparedBackend {
+    fn from(inner: Box<T>) -> Self {
+        Self::from(inner as Box<dyn kapsl_engine_api::Engine>)
+    }
+}
+
+impl std::ops::Deref for PreparedBackend {
+    type Target = dyn kapsl_engine_api::Engine;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref()
+    }
+}
+
+impl std::ops::DerefMut for PreparedBackend {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut()
+    }
+}
+
+impl Drop for PreparedBackend {
+    fn drop(&mut self) {
+        self.inner.unload();
+        // Fields drop in declaration order: engine first, then client leases.
+    }
+}
+
+#[cfg(feature = "gpu-device-pool")]
+pub(super) fn acquire_embedded_ort_pool_clients(
+    resources: &RuntimeResources,
+    provider: &str,
+    device_ids: &[usize],
+) -> Result<Vec<PoolClientLease>, String> {
+    if !provider.eq_ignore_ascii_case("cuda") && !provider.eq_ignore_ascii_case("tensorrt") {
+        return Ok(Vec::new());
+    }
+    let mut clients = Vec::new();
+    for &device_id in device_ids {
+        let device =
+            i32::try_from(device_id).map_err(|_| "ORT device ID exceeds i32".to_string())?;
+        if let Some(client) =
+            resources
+                .memory()
+                .acquire_cuda_pool_client(device_id, "embedded-ort", |pool| {
+                    kapsl_backends::ort_pool_allocator::register_pool_allocator(device, pool)?;
+                    let pool = pool.clone();
+                    Ok(Box::new(move || {
+                        kapsl_backends::ort_pool_allocator::unregister_pool_allocator(device, &pool)
+                    }))
+                })?
+        {
+            clients.push(client);
+        }
+    }
+    Ok(clients)
+}
+
+struct MemoryTrackedEngine {
+    inner: PreparedBackend,
     lease: std::sync::Mutex<Option<MemoryLease>>,
     resources: Arc<RuntimeResources>,
     owner: MemoryOwner,
@@ -19,7 +102,7 @@ struct MemoryTrackedEngine {
 
 impl MemoryTrackedEngine {
     fn new(
-        inner: Box<dyn kapsl_engine_api::Engine>,
+        inner: impl Into<PreparedBackend>,
         lease: MemoryLease,
         resources: Arc<RuntimeResources>,
         owner: MemoryOwner,
@@ -27,7 +110,7 @@ impl MemoryTrackedEngine {
         priority_lease: ModelPriorityLease,
     ) -> Self {
         Self {
-            inner,
+            inner: inner.into(),
             lease: std::sync::Mutex::new(Some(lease)),
             resources,
             owner,
@@ -358,7 +441,7 @@ pub(super) fn create_runtime_backend_for_device(
     resources: &RuntimeResources,
     model_id: u32,
     replica_id: u32,
-) -> Result<Box<dyn kapsl_engine_api::Engine>, String> {
+) -> Result<PreparedBackend, String> {
     let engine_kind = EngineKind::resolve(manifest);
     #[cfg(not(any(
         feature = "native",
@@ -376,7 +459,7 @@ pub(super) fn create_runtime_backend_for_device(
             model_id,
             replica_id,
         )? {
-            return Ok(backend);
+            return Ok(backend.into());
         }
     }
 
@@ -392,7 +475,7 @@ pub(super) fn create_runtime_backend_for_device(
         } else {
             BackendFactory::create_gguf_native(device_id as i32, None)?
         };
-        return Ok(Box::new(backend));
+        return Ok(Box::new(backend).into());
     }
 
     #[cfg(all(feature = "gguf-cuda-shared-kv", not(feature = "gguf-native")))]
@@ -407,7 +490,7 @@ pub(super) fn create_runtime_backend_for_device(
         } else {
             BackendFactory::create_gguf_cuda_shared_kv(device_id as i32, None)?
         };
-        return Ok(Box::new(backend));
+        return Ok(Box::new(backend).into());
     }
 
     #[cfg(feature = "native")]
@@ -419,7 +502,7 @@ pub(super) fn create_runtime_backend_for_device(
                 model_id,
                 replica_id,
             )
-            .map(|backend| Box::new(backend) as Box<dyn kapsl_engine_api::Engine>);
+            .map(|backend| PreparedBackend::from(Box::new(backend)));
         }
     }
 
@@ -447,7 +530,8 @@ pub(super) fn create_runtime_backend_for_device(
                     model_id,
                     replica_id,
                     &onnx_adapter_options(tuning),
-                );
+                )
+                .map(PreparedBackend::from);
             }
             OnnxBackendRoute::EmbeddedRollback { reason } => {
                 log::warn!(
@@ -464,6 +548,15 @@ pub(super) fn create_runtime_backend_for_device(
         ));
     }
 
+    #[cfg(feature = "gpu-device-pool")]
+    let pool_clients = if engine_kind.uses_onnx_session() {
+        // Signed packs returned above. Only the explicit embedded route can
+        // register the legacy environment allocator, before memory planning.
+        acquire_embedded_ort_pool_clients(resources, provider, &[device_id])?
+    } else {
+        Vec::new()
+    };
+
     if engine_kind.is_onnx_generate() {
         // The SDK's automatic ONNX-generate constructor may fall back to CPU.
         // Bind the exact provider chosen by Kapsl policy so a missing CUDA or
@@ -472,7 +565,10 @@ pub(super) fn create_runtime_backend_for_device(
             .with_memory_owner(model_id, replica_id);
         #[cfg(feature = "gpu-device-pool")]
         let backend = backend.with_env_allocators(resources.uses_env_allocators(device_id));
-        return Ok(Box::new(backend));
+        let backend = PreparedBackend::from(Box::new(backend));
+        #[cfg(feature = "gpu-device-pool")]
+        let backend = backend.with_pool_clients(pool_clients);
+        return Ok(backend);
     }
 
     let default_tuning = OnnxRuntimeTuning::default();
@@ -489,7 +585,7 @@ pub(super) fn create_runtime_backend_for_device(
         None => &default_tuning,
     };
 
-    BackendFactory::create_backend_for_device_with_tuning_and_owner(
+    let backend = BackendFactory::create_backend_for_device_with_tuning_and_owner(
         manifest,
         provider,
         device_id,
@@ -497,7 +593,11 @@ pub(super) fn create_runtime_backend_for_device(
         tuning,
         model_id,
         replica_id,
-    )
+    )?;
+    let backend = PreparedBackend::from(backend);
+    #[cfg(feature = "gpu-device-pool")]
+    let backend = backend.with_pool_clients(pool_clients);
+    Ok(backend)
 }
 
 /// Execute the runtime-owned backend load transaction.
@@ -508,7 +608,7 @@ pub(super) fn create_runtime_backend_for_device(
 /// returned engine.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn load_runtime_backend(
-    mut backend: Box<dyn kapsl_engine_api::Engine>,
+    mut backend: PreparedBackend,
     model_file_path: &Path,
     admission_domains: &[MemoryDomain],
     resources: &Arc<RuntimeResources>,
@@ -613,6 +713,197 @@ mod tests {
     }
 
     struct WireStreamEngine;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum LoadFailure {
+        None,
+        Planning,
+        Admission,
+        Loading,
+        Cancellation,
+        Reconciliation,
+    }
+
+    struct PoolAwareEngine {
+        clients: Arc<PoolClients>,
+        events: Arc<std::sync::Mutex<Vec<&'static str>>>,
+        failure: LoadFailure,
+    }
+
+    impl PoolAwareEngine {
+        fn report(&self, live: bool) -> MemoryReport {
+            MemoryReport {
+                allocations: [
+                    ("weights", EngineMemoryClass::PersistentWeights),
+                    ("scratch", EngineMemoryClass::TransientWorkspace),
+                ]
+                .into_iter()
+                .map(|(id, class)| MemoryAllocation {
+                    allocation_id: id.to_string(),
+                    domain: EngineMemoryDomain::Host,
+                    class,
+                    source: MemoryAllocationSource::BackendManaged,
+                    bytes: if self.failure == LoadFailure::Admission
+                        || (live && self.failure == LoadFailure::Reconciliation)
+                    {
+                        usize::MAX / 4
+                    } else {
+                        128
+                    },
+                })
+                .collect(),
+            }
+        }
+    }
+
+    impl Drop for PoolAwareEngine {
+        fn drop(&mut self) {
+            self.events.lock().unwrap().push("destroy");
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl kapsl_engine_api::Engine for PoolAwareEngine {
+        fn planned_memory(&self, _path: &Path) -> Result<MemoryReport, EngineError> {
+            assert!(
+                !self.clients.retire().unwrap(),
+                "registration must precede planning"
+            );
+            self.events.lock().unwrap().push("plan");
+            if self.failure == LoadFailure::Planning {
+                return Err(EngineError::backend("planned failure"));
+            }
+            Ok(self.report(false))
+        }
+
+        async fn load(&mut self, _path: &Path) -> Result<(), EngineError> {
+            assert!(
+                !self.clients.retire().unwrap(),
+                "registration must survive loading"
+            );
+            self.events.lock().unwrap().push("load");
+            if self.failure == LoadFailure::Cancellation {
+                return std::future::pending().await;
+            }
+            if self.failure == LoadFailure::Loading {
+                return Err(EngineError::backend("load failure"));
+            }
+            Ok(())
+        }
+
+        fn actual_memory(&self) -> MemoryReport {
+            self.report(true)
+        }
+
+        fn infer(&self, request: &InferenceRequest) -> Result<BinaryTensorPacket, EngineError> {
+            Ok(request.input.clone())
+        }
+
+        fn infer_stream(&self, request: &InferenceRequest) -> EngineStream {
+            let output = request.input.clone();
+            Box::pin(stream::once(async move { Ok(output) }))
+        }
+
+        fn unload(&mut self) {
+            self.events.lock().unwrap().push("unload");
+        }
+
+        fn metrics(&self) -> EngineMetrics {
+            EngineMetrics::default()
+        }
+
+        fn health_check(&self) -> Result<(), EngineError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn pool_registration_survives_planning_and_releases_after_backend_destruction() {
+        use kapsl_engine_api::Engine;
+        let file = tempfile::NamedTempFile::new().unwrap();
+        for failure in [
+            LoadFailure::None,
+            LoadFailure::Planning,
+            LoadFailure::Admission,
+            LoadFailure::Loading,
+            LoadFailure::Cancellation,
+            LoadFailure::Reconciliation,
+        ] {
+            let resources = RuntimeResources::new(&device_info()).unwrap();
+            let clients = Arc::new(PoolClients::default());
+            let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let cleanup_events = events.clone();
+            let client = clients
+                .acquire("fake-adapter", || {
+                    events.lock().unwrap().push("register");
+                    Ok(Box::new(move || {
+                        let mut events = cleanup_events.lock().unwrap();
+                        assert_eq!(
+                            events.last(),
+                            Some(&"destroy"),
+                            "allocator outlives backend destructor"
+                        );
+                        events.push("unregister");
+                        Ok(())
+                    }))
+                })
+                .unwrap();
+            let prepared = PreparedBackend::from(Box::new(PoolAwareEngine {
+                clients: clients.clone(),
+                events: events.clone(),
+                failure,
+            }))
+            .with_pool_clients(vec![client]);
+            let mut loading = Box::pin(load_runtime_backend(
+                prepared,
+                file.path(),
+                &[MemoryDomain::Host],
+                &resources,
+                61,
+                0,
+                EngineKind::Native,
+                1,
+                "fake adapter lifecycle",
+            ));
+            if failure == LoadFailure::Cancellation {
+                assert!(futures::poll!(loading.as_mut()).is_pending());
+                assert!(events.lock().unwrap().contains(&"load"));
+                assert!(!clients.retire().unwrap());
+                drop(loading);
+            } else {
+                let result = loading.await;
+                if failure == LoadFailure::None {
+                    let mut backend = result.unwrap();
+                    assert!(!clients.retire().unwrap());
+                    backend.unload();
+                    assert!(
+                        !clients.retire().unwrap(),
+                        "backend can still hold allocator pointers until destruction"
+                    );
+                    drop(backend);
+                } else {
+                    assert!(result.is_err(), "{failure:?} should reject loading");
+                }
+            }
+            assert!(clients.retire().unwrap());
+            let events = events.lock().unwrap();
+            assert_eq!(events.first(), Some(&"register"));
+            assert_eq!(&events[events.len() - 2..], &["destroy", "unregister"]);
+            if matches!(failure, LoadFailure::Planning | LoadFailure::Admission) {
+                assert!(
+                    !events.contains(&"load"),
+                    "failure before admission must not load the backend"
+                );
+            }
+            assert!(resources
+                .memory()
+                .snapshot()
+                .rows
+                .iter()
+                .filter(|row| row.owner == MemoryOwner::new(61, 0))
+                .all(|row| row.reserved_bytes == 0));
+        }
+    }
 
     #[cfg(feature = "gpu-device-pool")]
     struct PeakThenSettledSwapEngine {

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/replica.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/replica.rs
@@ -182,12 +182,13 @@ pub(super) async fn load_replica(
             .collect();
         let backend = create_pipeline_backend(
             &plan,
+            onnx_route.as_ref(),
             logical_provider
                 .as_deref()
                 .expect("pipeline loads always select a provider"),
             &device_ids,
             &resources,
-        );
+        )?;
         let backend = load_runtime_backend(
             backend,
             &plan.model_file_path,
@@ -393,7 +394,7 @@ async fn load_managed_vllm_replica(
         shared_metrics.clone(),
     )?;
     let backend = load_runtime_backend(
-        backend,
+        backend.into(),
         &plan.model_file_path,
         &memory_domains,
         &resources,
@@ -440,10 +441,18 @@ async fn load_managed_vllm_replica(
 
 fn create_pipeline_backend(
     plan: &ModelLoadPlan,
+    onnx_route: Option<&OnnxBackendRoute>,
     logical_provider: &str,
     device_ids: &[usize],
     resources: &RuntimeResources,
-) -> Box<dyn kapsl_engine_api::Engine> {
+) -> Result<PreparedBackend, String> {
+    validate_pipeline_backend_route(EngineKind::resolve(&plan.loader.manifest), onnx_route)?;
+    #[cfg(feature = "gpu-device-pool")]
+    let pool_clients = if matches!(onnx_route, Some(OnnxBackendRoute::EmbeddedRollback { .. })) {
+        acquire_embedded_ort_pool_clients(resources, logical_provider, device_ids)?
+    } else {
+        Vec::new()
+    };
     let backend_device_ids: Vec<i32> = device_ids.iter().map(|&id| id as i32).collect();
     let mut backend = if EngineKind::resolve(&plan.loader.manifest).uses_onnx_session()
         || provider_policy() == "manifest"
@@ -479,7 +488,25 @@ fn create_pipeline_backend(
             let kv = resources.kv().clone();
             Arc::new(move |engine_id| kv.detach_engine(engine_id))
         });
-    Box::new(backend)
+    let backend = PreparedBackend::from(Box::new(backend));
+    #[cfg(feature = "gpu-device-pool")]
+    let backend = backend.with_pool_clients(pool_clients);
+    Ok(backend)
+}
+
+fn validate_pipeline_backend_route(
+    engine_kind: EngineKind,
+    onnx_route: Option<&OnnxBackendRoute>,
+) -> Result<(), String> {
+    match (engine_kind.uses_onnx_session(), onnx_route) {
+        (true, Some(OnnxBackendRoute::EmbeddedRollback { .. })) | (false, None) => Ok(()),
+        (true, Some(OnnxBackendRoute::SignedPack { .. })) => Err(
+            "signed native ONNX packs do not support the embedded pipeline executor; refusing embedded ORT fallback"
+                .to_string(),
+        ),
+        (true, None) => Err("ONNX pipeline requires an immutable backend route decision".to_string()),
+        (false, Some(_)) => Err("non-ONNX pipeline received an ONNX backend route".to_string()),
+    }
 }
 
 fn model_info_for_plan(
@@ -595,6 +622,49 @@ mod tests {
         let info = model_info_for_plan(&test_plan(), ReplicaLoadRole::Primary, "cpu");
 
         assert_eq!(info.device, "cpu");
+    }
+
+    #[test]
+    fn signed_pipeline_selection_cannot_construct_an_embedded_backend() {
+        let plan = test_plan();
+        let device_info = DeviceInfo {
+            cpu_cores: 1,
+            total_memory: 1024 * 1024 * 1024,
+            os_type: "test".into(),
+            os_release: "test".into(),
+            has_cuda: false,
+            has_metal: false,
+            has_rocm: false,
+            has_directml: false,
+            devices: Vec::new(),
+        };
+        let resources = RuntimeResources::new(&device_info).unwrap();
+        for profile in ["cpu", "cuda12", "tensorrt10"] {
+            let route = OnnxBackendRoute::SignedPack {
+                identity: crate::backend::NativeBackendPackIdentity {
+                    backend: "onnx".into(),
+                    profile: profile.into(),
+                    pack_version: "test".into(),
+                },
+                reason: "explicit signed selection".into(),
+            };
+            let error = create_pipeline_backend(&plan, Some(&route), "cuda", &[0], &resources)
+                .err()
+                .expect("signed route cannot enter embedded pipeline construction");
+            assert!(error.contains("refusing embedded ORT fallback"));
+        }
+        assert!(
+            create_pipeline_backend(&plan, None, "cpu", &[0], &resources)
+                .err()
+                .unwrap()
+                .contains("immutable backend route")
+        );
+        let rollback = OnnxBackendRoute::EmbeddedRollback {
+            reason: "explicit rollback".into(),
+        };
+        assert!(create_pipeline_backend(&plan, Some(&rollback), "cpu", &[0], &resources).is_ok());
+        assert!(validate_pipeline_backend_route(EngineKind::Native, Some(&rollback)).is_err());
+        assert!(validate_pipeline_backend_route(EngineKind::Native, None).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Creating a governed CUDA pool currently registers embedded ORT even when every model uses signed packs or another backend. Acquire the registration only for explicit embedded ONNX loads, before memory planning, and retain it until the final sharing backend is destroyed. This removes the eager embedded allocator registration encountered during the mixed native-pack/GGUF trial.

Generic pool-client leases keep callback storage and pool accounting alive across model/replica sharing, failed loads, cancellation, and failed cleanup. Active registrations block pool replacement or reclamation; failed cleanup retains its resources and must succeed before reuse. Pool admission and retirement share the initialization lock so another backend cannot admit a workload against backing being removed. The embedded ONNX pipeline acquires the same leases. A pipeline selected for a signed pack now returns a compatibility error instead of silently constructing the embedded executor.

Regression coverage exercises the actual runtime load transaction with a fake backend, including planning, admission, load, reconciliation, and cancellation failures; destruction before callback cleanup; concurrent preparation; cross-client/pool isolation; reload; and cleanup retry. This PR does not retire embedded ORT or qualify the accelerator packs.

Validation:

- CLI host suite: 485 tests passed.
- CLI host suite with `gpu-device-pool`: 502 tests passed, including the final cancellation and reconciliation cases.
- `gpu-device-pool` feature check passed; it reports the existing unused `plan_onnx` warning.
- Release pipeline tests: 44 passed; GPU integration harness self-test passed.
- `cargo fmt --all -- --check` and `git diff --check` passed.

No GPU instance was provisioned for this PR. Release workflows, artifact locks, package versions, and the 1.5× startup threshold are unchanged.
