### PR TITLE
fix: validate live KV ownership and process VRAM in conformance

### DIFF
--- a/.github/scripts/gpu-process-vram.py
+++ b/.github/scripts/gpu-process-vram.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Attribute NVML memory, including an explicitly exclusive container GPU."""
+
+import argparse
+import csv
+import io
+import json
+import pathlib
+
+
+def rows(snapshot):
+    result = []
+    for row in csv.reader(io.StringIO(snapshot)):
+        if not row:
+            continue
+        assert len(row) == 3, "invalid NVML process snapshot"
+        gpu, pid, memory = (value.strip() for value in row)
+        assert gpu.startswith("GPU-") and pid.isdecimal() and memory.isdecimal(), (
+            "NVML process identity or memory is unavailable"
+        )
+        result.append((gpu, int(pid), int(memory) * 1024 * 1024))
+    return result
+
+
+def measure(baseline, current, runtime_pid, previous=None, exclusive=False):
+    before, active = rows(baseline), rows(current)
+    if exclusive:
+        # NVML reports host PIDs on some container providers. This mode requires
+        # a dedicated GPU with no processes before launch and exactly one now.
+        assert not before, "exclusive GPU was already in use before launch"
+        assert len(active) == 1, "exclusive GPU process identity is ambiguous"
+        selected = active[0]
+        method = "initially-idle-exclusive-gpu"
+    else:
+        matches = [row for row in active if row[1] == runtime_pid]
+        assert len(matches) == 1, "runtime PID is absent or ambiguous in NVML"
+        selected = matches[0]
+        method = "runtime-pid"
+    gpu, nvml_pid, memory = selected
+    identity = {
+        "runtime_pid": runtime_pid,
+        "nvml_pid": nvml_pid,
+        "gpu_uuid": gpu,
+        "method": method,
+    }
+    assert previous is None or identity == previous, "GPU process identity changed"
+    return identity, memory
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, type=pathlib.Path)
+    parser.add_argument("--snapshot", required=True, type=pathlib.Path)
+    parser.add_argument("--identity", required=True, type=pathlib.Path)
+    parser.add_argument("--runtime-pid", required=True, type=int)
+    parser.add_argument("--exclusive", action="store_true")
+    args = parser.parse_args()
+    previous = json.loads(args.identity.read_text()) if args.identity.exists() else None
+    identity, memory = measure(
+        args.baseline.read_text(),
+        args.snapshot.read_text(),
+        args.runtime_pid,
+        previous,
+        args.exclusive,
+    )
+    if previous is None:
+        with args.identity.open("x") as output:
+            output.write(json.dumps(identity, indent=2) + "\n")
+    print(memory)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/probe-live-kv-owner.py
+++ b/.github/scripts/probe-live-kv-owner.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Capture live request KV ownership, then prove disconnect reclamation."""
+
+import argparse
+import base64
+import json
+import os
+import pathlib
+import re
+import time
+import urllib.request
+import uuid
+
+
+def owner_usage(metrics, owner):
+    pattern = (
+        r'^kapsl_gpu_device_pool_owner_usage_bytes\{[^\n]*owner="'
+        + re.escape(owner)
+        + r'"[^\n]*\}\s+(\S+)$'
+    )
+    values = re.findall(pattern, metrics, re.M)
+    return sum(int(float(value)) for value in values)
+
+
+def probe(base_url, token, model_id, owner, output, poll_seconds=30):
+    output.mkdir(parents=True, exist_ok=False)
+    headers = {"Authorization": "Bearer " + token, "Content-Type": "application/json"}
+
+    def metrics():
+        request = urllib.request.Request(base_url + "/metrics", headers=headers)
+        with urllib.request.urlopen(request, timeout=15) as response:
+            return response.read().decode()
+
+    prompt = "Continue counting integers in order, starting with one."
+    payload = {
+        "session_id": "live-kv-" + uuid.uuid4().hex,
+        "input": {
+            "shape": [1, 1],
+            "dtype": "string",
+            "data_base64": base64.b64encode(prompt.encode()).decode(),
+        },
+        "metadata": {"max_tokens": 1024, "min_tokens": 1024, "temperature": 0.0},
+    }
+    request = urllib.request.Request(
+        base_url + f"/api/models/{model_id}/infer/stream",
+        data=json.dumps(payload).encode(),
+        headers=headers,
+    )
+    # Reading an event proves generation has begun. Metrics are captured while
+    # the response remains open; completed requests are expected to own no KV.
+    with urllib.request.urlopen(request, timeout=60) as stream:
+        for raw in stream:
+            if not raw.startswith(b"data:"):
+                continue
+            data = raw.removeprefix(b"data:").strip()
+            if data == b"[DONE]":
+                raise AssertionError(
+                    "generation ended before live KV ownership was observed"
+                )
+            event = json.loads(data)
+            if isinstance(event, dict) and event.get("error"):
+                raise AssertionError(
+                    "generation returned an error before KV ownership was observed"
+                )
+            (output / "first-event.json").write_text(json.dumps(event, indent=2) + "\n")
+            active = metrics()
+            (output / "metrics-active.txt").write_text(active)
+            assert owner_usage(active, owner) > 0, (
+                "no live allocation for the expected model/replica KV owner"
+            )
+            break
+        else:
+            raise AssertionError("generation stream produced no event")
+
+    # Closing the unfinished stream cancels it. A missing owner is the normal
+    # idle state when cross-session prefix caching is disabled.
+    for attempt in range(6):
+        idle = metrics()
+        (output / f"metrics-cancelled-{attempt}.txt").write_text(idle)
+        if owner_usage(idle, owner) == 0:
+            return
+        if attempt < 5:
+            time.sleep(poll_seconds)
+    raise AssertionError("cancelled generation retained request KV allocations")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--model-id", type=int, required=True)
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    token = os.environ.get("KAPSL_GPU_TEST_API_TOKEN")
+    if not token:
+        parser.error("KAPSL_GPU_TEST_API_TOKEN is required")
+    probe(args.base_url, token, args.model_id, args.owner, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-gpu-device-pool-integration.sh
+++ b/.github/scripts/test-gpu-device-pool-integration.sh
@@ -31,6 +31,7 @@
 set -Eeuo pipefail
 
 script_name="$(basename "$0")"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
 runtime_pid=""
 api_admin_token=""
 created_output_dir=0
@@ -53,7 +54,8 @@ Usage:
 
 The GPU run fails unless all of these are observed in one process:
   * exactly one runtime GPU backing allocation
-  * positive model/replica-scoped ONNX and GGUF owner bytes
+  * positive model/replica-scoped ONNX bytes and GGUF KV bytes during generation
+  * GGUF request KV reclaimed after stream cancellation, with no idle KV owner
   * GGUF reporting kv_path=shared-kv, both before and after reload
   * each owner disappears on unload and live/free state recovers on reload
   * stable pool capacity and external-memory accounting across both reloads
@@ -292,11 +294,11 @@ require_owner_prefix_absent() {
   ! grep -F -q -- "owner=\"$owner_prefix" "$file"
 }
 
-require_active_workload_owners() {
+require_idle_workload_owners() {
   local file="$1"
   require_active_owner "$file" "$onnx_allocation_owner" \
     && require_admitted_owner "$file" "$gguf_admission_owner" \
-    && require_active_owner "$file" "$gguf_kv_owner"
+    && require_owner_absent "$file" "$gguf_kv_owner"
 }
 
 assert_fragmentation_not_worse() {
@@ -351,7 +353,7 @@ reloaded_pool_snapshot_matches() {
     && [[ "$live" == "$initial_live" ]] \
     && [[ "$free" == "$initial_free" ]] \
     && assert_pool_snapshot_consistent "$candidate" "$backing_bytes" \
-    && require_active_workload_owners "$candidate"
+    && require_idle_workload_owners "$candidate"
 }
 
 ort_reloaded_pool_snapshot_matches() {
@@ -376,7 +378,7 @@ ort_reloaded_pool_snapshot_matches() {
     && [[ "$live" == "$initial_live" ]] \
     && [[ "$free" == "$initial_free" ]] \
     && assert_pool_snapshot_consistent "$candidate" "$backing_bytes" \
-    && require_active_workload_owners "$candidate"
+    && require_idle_workload_owners "$candidate"
 }
 
 ort_stopped_pool_snapshot_matches() {
@@ -407,7 +409,7 @@ ort_stopped_pool_snapshot_matches() {
     && assert_pool_snapshot_consistent "$candidate" "$backing_bytes" \
     && require_owner_prefix_absent "$candidate" "$onnx_owner_prefix" \
     && require_admitted_owner "$candidate" "$gguf_admission_owner" \
-    && require_active_owner "$candidate" "$gguf_kv_owner"
+    && require_owner_absent "$candidate" "$gguf_kv_owner"
 }
 
 run_self_test() {
@@ -551,12 +553,18 @@ EOF
   stopped_pool_snapshot_matches \
     "$fixture/stopped-metrics.txt" 2000 3221225472 7 1073741824 4294967296 \
     || die "self-test rejected a valid unload snapshot"
+  sed 's/kapsl_device_memory_external_bytes{device="0"} 0/kapsl_device_memory_external_bytes{device="0"} 2000/' \
+    "$fixture/stopped-metrics.txt" >"$fixture/idle-metrics.txt"
+  awk '/owner="gguf:1:0:persistent-weights"/' "$fixture/metrics.txt" >>"$fixture/idle-metrics.txt"
   reloaded_pool_snapshot_matches \
-    "$fixture/metrics.txt" 2000 3221225472 7 1073741824 4294967296 \
+    "$fixture/idle-metrics.txt" 2000 2147483648 3 2147483648 4294967296 \
     || die "self-test rejected a valid reuse snapshot"
   if stopped_pool_snapshot_matches \
     "$fixture/metrics.txt" 2000 3221225472 7 1073741824 4294967296; then
     die "self-test accepted a snapshot that retained the GGUF owner"
+  fi
+  if require_idle_workload_owners "$fixture/metrics.txt"; then
+    die "self-test accepted unreclaimed request KV in an idle snapshot"
   fi
   assert_fragmentation_not_worse 0.25 0.255 0.01 \
     || die "self-test rejected fragmentation within tolerance"
@@ -584,18 +592,25 @@ kapsl_gpu_device_pool_owner_quota_max_bytes{device="0",owner="gguf:1:0:kv-cache"
 kapsl_gpu_device_pool_owner_admitted{device="0",owner="gguf:1:0:kv-cache"} 1
 kapsl_gpu_device_pool_owner_allocatable_bytes{device="0",owner="gguf:1:0:kv-cache"} 3221225472
 EOF
+  sed -e '/owner="gguf:1:0:kv-cache"/d' \
+    -e 's/allocated_bytes{device="0"} 1073741824/allocated_bytes{device="0"} 0/' \
+    -e 's/live_allocations{device="0"} 4/live_allocations{device="0"} 0/' \
+    -e 's/free_bytes{device="0"} 3221225472/free_bytes{device="0"} 4294967296/' \
+    -e 's/largest_free_range_bytes{device="0"} 3221225472/largest_free_range_bytes{device="0"} 4294967296/' \
+    "$fixture/ort-stopped-metrics.txt" >"$fixture/ort-stopped-idle.txt"
+  cp "$fixture/ort-stopped-idle.txt" "$fixture/ort-stopped-metrics.txt"
   ort_stopped_pool_snapshot_matches \
-    "$fixture/ort-stopped-metrics.txt" 2000 3221225472 7 1073741824 4294967296 \
+    "$fixture/ort-stopped-metrics.txt" 2000 2147483648 3 2147483648 4294967296 \
     || die "self-test rejected a valid ORT unload snapshot"
   sed 's/kapsl_device_memory_external_bytes{device="0"} 2000/kapsl_device_memory_external_bytes{device="0"} 1500/' \
     "$fixture/ort-stopped-metrics.txt" >"$fixture/ort-stopped-external-released.txt"
   ort_stopped_pool_snapshot_matches \
-    "$fixture/ort-stopped-external-released.txt" 2000 3221225472 7 1073741824 4294967296 \
+    "$fixture/ort-stopped-external-released.txt" 2000 2147483648 3 2147483648 4294967296 \
     || die "self-test rejected ORT external CUDA state released on unload"
   sed 's/kapsl_device_memory_external_bytes{device="0"} 2000/kapsl_device_memory_external_bytes{device="0"} 1750/' \
-    "$fixture/metrics.txt" >"$fixture/ort-reloaded-external-reused.txt"
+    "$fixture/idle-metrics.txt" >"$fixture/ort-reloaded-external-reused.txt"
   ort_reloaded_pool_snapshot_matches \
-    "$fixture/ort-reloaded-external-reused.txt" 2000 1500 3221225472 7 1073741824 4294967296 \
+    "$fixture/ort-reloaded-external-reused.txt" 2000 1500 2147483648 3 2147483648 4294967296 \
     || die "self-test rejected lower ORT external CUDA state after reload"
 
   printf '%s\n' '{"shape":[1,1],"dtype":"string","data_base64":"Q1VEQQ=="}' \
@@ -856,6 +871,16 @@ run_gguf_concurrency_transition_test() {
   done
 }
 
+run_gguf_live_ownership_probe() {
+  local destination="$1"
+  KAPSL_GPU_TEST_API_TOKEN="$api_admin_token" \
+    python3 "$script_dir/probe-live-kv-owner.py" \
+      --base-url "$base_url" --model-id "$gguf_model_id" \
+      --owner "$gguf_kv_owner" --output "$destination"
+  require_active_owner "$destination/metrics-active.txt" "$gguf_kv_owner" \
+    || die "in-flight GGUF request lacked governed model/replica KV ownership"
+}
+
 run_onnx_inference_if_configured() {
   local destination="$1"
   local request_file="${KAPSL_GPU_TEST_ORT_REQUEST:-}"
@@ -1046,6 +1071,7 @@ main() {
     "KAPSL_GPU_GGUF_MAX_BYTES="
     "KAPSL_GPU_GGUF_MAX_BYTES_0="
     "KAPSL_GGUF_DISABLE_SHARED_KV=0"
+    "KAPSL_GGUF_ALLOW_CROSS_SESSION_PREFIX_CACHE=0"
     "KAPSL_PROVIDER_POLICY=fastest"
     "KAPSL_API_TOKEN_READER="
     "KAPSL_API_TOKEN_WRITER="
@@ -1124,6 +1150,7 @@ main() {
   run_gguf_inference "$output_dir/gguf-inference-initial.json"
   assert_gguf_response_correct "$output_dir/gguf-inference-initial.json"
   run_gguf_concurrency_transition_test "$output_dir/gguf-concurrency-transition"
+  run_gguf_live_ownership_probe "$output_dir/gguf-live-initial"
   sleep "$settle_seconds"
   api_get /metrics >"$output_dir/metrics-initial.txt"
 
@@ -1143,10 +1170,11 @@ main() {
     || die "ONNX has no positive live allocation/admission in the shared pool"
   require_admitted_owner "$output_dir/metrics-initial.txt" "$gguf_admission_owner" \
     || die "GGUF model/replica admission owner is missing or invalid"
-  require_active_owner "$output_dir/metrics-initial.txt" "$gguf_kv_owner" \
-    || die "GGUF shared-KV allocation owner is missing or inactive"
+  require_owner_absent "$output_dir/metrics-initial.txt" "$gguf_kv_owner" \
+    || die "completed GGUF requests retained KV allocations"
   initial_onnx_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$onnx_allocation_owner" "$output_dir/metrics-initial.txt")"
   initial_gguf_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$gguf_kv_owner" "$output_dir/metrics-initial.txt")"
+  initial_gguf_usage="${initial_gguf_usage:-0}"
   if grep -F -q -- 'owner="native:unattributed:' "$output_dir/metrics-initial.txt" \
     || grep -F -q -- 'owner="onnx:unattributed:' "$output_dir/metrics-initial.txt"; then
     die "unattributed native/ONNX allocation unexpectedly appeared in the shared-pool run"
@@ -1183,6 +1211,7 @@ main() {
   wait_for_model_status "$onnx_model_id" active || die "ORT model stopped during GGUF reload"
   wait_for_log_count "kv_path=shared-kv" 2 || die "reloaded GGUF did not return to shared-KV"
   run_gguf_inference "$output_dir/gguf-inference-reloaded.json"
+  run_gguf_live_ownership_probe "$output_dir/gguf-live-reloaded"
   sleep "$settle_seconds"
 
   api_get /api/models >"$output_dir/models-reloaded.json"
@@ -1200,6 +1229,7 @@ main() {
   reloaded_fragmentation="$(metric_from_file kapsl_gpu_device_pool_fragmentation_ratio "$output_dir/metrics-reloaded.txt")"
   reloaded_onnx_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$onnx_allocation_owner" "$output_dir/metrics-reloaded.txt")"
   reloaded_gguf_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$gguf_kv_owner" "$output_dir/metrics-reloaded.txt")"
+  reloaded_gguf_usage="${reloaded_gguf_usage:-0}"
   reloaded_vram="$(process_vram_bytes || true)"
 
   [[ "$reloaded_pool" == "$initial_pool" ]] \
@@ -1234,7 +1264,9 @@ main() {
   ort_stopped_free="$(metric_from_file kapsl_gpu_device_pool_free_bytes "$output_dir/metrics-ort-stopped.txt")"
   ort_stopped_external="$(metric_from_file kapsl_device_memory_external_bytes "$output_dir/metrics-ort-stopped.txt")"
   ort_stopped_gguf_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$gguf_kv_owner" "$output_dir/metrics-ort-stopped.txt")"
+  ort_stopped_gguf_usage="${ort_stopped_gguf_usage:-0}"
   api_get /api/models >"$output_dir/models-ort-stopped.json"
+  run_gguf_live_ownership_probe "$output_dir/gguf-live-without-ort"
 
   note "reloading ORT model id $onnx_model_id"
   ort_start_payload="$(jq -cn --arg path "$ort_model" --argjson id "$onnx_model_id" \
@@ -1268,6 +1300,7 @@ main() {
   final_fragmentation="$(metric_from_file kapsl_gpu_device_pool_fragmentation_ratio "$output_dir/metrics-final.txt")"
   final_onnx_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$onnx_allocation_owner" "$output_dir/metrics-final.txt")"
   final_gguf_usage="$(owner_metric_from_file kapsl_gpu_device_pool_owner_usage_bytes "$gguf_kv_owner" "$output_dir/metrics-final.txt")"
+  final_gguf_usage="${final_gguf_usage:-0}"
   final_vram="$(process_vram_bytes || true)"
 
   [[ "$final_pool" == "$initial_pool" ]] || die "ORT reload replaced the pool backing"

--- a/.github/scripts/test-gpu-device-pool-integration.sh
+++ b/.github/scripts/test-gpu-device-pool-integration.sh
@@ -15,6 +15,7 @@
 #   KAPSL_GPU_TEST_POOL_BYTES        exact fixed backing size (default: strict auto)
 #   KAPSL_GPU_TEST_CUDA_VISIBLE_DEVICES  one physical GPU/UUID (default: 0)
 #   KAPSL_GPU_TEST_VRAM_GROWTH_BYTES reload tolerance (default: 256 MiB)
+#   KAPSL_GPU_TEST_EXCLUSIVE_GPU    opt in to host-PID attribution on an idle dedicated GPU
 #   KAPSL_GPU_TEST_FRAGMENTATION_TOLERANCE allowed ratio increase (default: 0.01)
 #   KAPSL_GPU_TEST_REQUIRE_LAZY_LLAMA_PACK require signed lazy-pack markers
 #   KAPSL_GPU_TEST_REQUIRE_SIGNED_ORT_PACK require the generic signed ORT route
@@ -826,19 +827,20 @@ wait_for_ort_stopped_pool_snapshot() {
 }
 
 process_vram_bytes() {
-  nvidia-smi --query-compute-apps=pid,used_gpu_memory --format=csv,noheader,nounits 2>/dev/null \
-    | awk -F, -v wanted="$runtime_pid" '
-        {
-          pid=$1; memory=$2
-          gsub(/[[:space:]]/, "", pid)
-          gsub(/[[:space:]]/, "", memory)
-          if (pid == wanted && memory ~ /^[0-9]+$/) {
-            total += memory
-            found = 1
-          }
-        }
-        END { if (found) printf "%.0f\n", total * 1024 * 1024 }
-      '
+  local snapshot
+  local -a identity_args=()
+  runtime_is_alive || return 1
+  snapshot="$(mktemp "$output_dir/gpu-process-snapshot.XXXXXX")"
+  nvidia-smi -i "$cuda_visible_devices" \
+    --query-compute-apps=gpu_uuid,pid,used_gpu_memory --format=csv,noheader,nounits \
+    >"$snapshot" || return 1
+  if is_true "${KAPSL_GPU_TEST_EXCLUSIVE_GPU:-0}"; then
+    identity_args+=(--exclusive)
+  fi
+  python3 "$script_dir/gpu-process-vram.py" \
+    --baseline "$output_dir/gpu-process-baseline.csv" \
+    --snapshot "$snapshot" --identity "$output_dir/gpu-process-identity.json" \
+    --runtime-pid "$runtime_pid" "${identity_args[@]}"
 }
 
 run_gguf_inference() {
@@ -1058,6 +1060,13 @@ main() {
   gguf_kv_owner="${gguf_owner_prefix}kv-cache"
 
   nvidia-smi -L >"$output_dir/nvidia-smi.txt"
+  nvidia-smi -i "$cuda_visible_devices" \
+    --query-compute-apps=gpu_uuid,pid,used_gpu_memory --format=csv,noheader,nounits \
+    >"$output_dir/gpu-process-baseline.csv"
+  if is_true "${KAPSL_GPU_TEST_EXCLUSIVE_GPU:-0}"; then
+    [[ ! -s "$output_dir/gpu-process-baseline.csv" ]] \
+      || die "exclusive GPU already has a compute process before runtime launch"
+  fi
   "$binary" --version >"$output_dir/kapsl-version.txt" 2>&1 || true
 
   pool_mode=auto

--- a/.github/scripts/test-gpu-device-pool-integration.sh
+++ b/.github/scripts/test-gpu-device-pool-integration.sh
@@ -347,7 +347,11 @@ reloaded_pool_snapshot_matches() {
   allocated="$(metric_from_file kapsl_gpu_device_pool_allocated_bytes "$candidate")"
   live="$(metric_from_file kapsl_gpu_device_pool_live_allocations "$candidate")"
   free="$(metric_from_file kapsl_gpu_device_pool_free_bytes "$candidate")"
-  [[ "$external" == "$initial_external" ]] \
+  # CUDA can release external provider/context state across a GGUF reload.
+  # Keep the original upper bound while accepting reclaimed external bytes;
+  # governed pool ranges and ownership must still match the idle snapshot.
+  [[ "$external" =~ ^[1-9][0-9]*$ ]] \
+    && (( external <= initial_external )) \
     && [[ "$pooled" == "$backing_bytes" ]] \
     && [[ "$allocated" == "$initial_allocated" ]] \
     && [[ "$live" == "$initial_live" ]] \
@@ -559,6 +563,17 @@ EOF
   reloaded_pool_snapshot_matches \
     "$fixture/idle-metrics.txt" 2000 2147483648 3 2147483648 4294967296 \
     || die "self-test rejected a valid reuse snapshot"
+  sed 's/kapsl_device_memory_external_bytes{device="0"} 2000/kapsl_device_memory_external_bytes{device="0"} 1750/' \
+    "$fixture/idle-metrics.txt" >"$fixture/gguf-reloaded-reclaimed.txt"
+  reloaded_pool_snapshot_matches \
+    "$fixture/gguf-reloaded-reclaimed.txt" 2000 2147483648 3 2147483648 4294967296 \
+    || die "self-test rejected reclaimed external CUDA state after GGUF reload"
+  sed 's/kapsl_device_memory_external_bytes{device="0"} 2000/kapsl_device_memory_external_bytes{device="0"} 2001/' \
+    "$fixture/idle-metrics.txt" >"$fixture/gguf-reloaded-growth.txt"
+  if reloaded_pool_snapshot_matches \
+    "$fixture/gguf-reloaded-growth.txt" 2000 2147483648 3 2147483648 4294967296; then
+    die "self-test accepted external memory growth after GGUF reload"
+  fi
   if stopped_pool_snapshot_matches \
     "$fixture/metrics.txt" 2000 3221225472 7 1073741824 4294967296; then
     die "self-test accepted a snapshot that retained the GGUF owner"
@@ -1234,8 +1249,8 @@ main() {
 
   [[ "$reloaded_pool" == "$initial_pool" ]] \
     || die "reload grew/replaced the pool backing: $initial_pool -> $reloaded_pool"
-  [[ "$reloaded_external" == "$initial_external" ]] \
-    || die "reload changed external-memory accounting: $initial_external -> $reloaded_external"
+  (( reloaded_external <= initial_external )) \
+    || die "reload grew external-memory accounting: $initial_external -> $reloaded_external"
   assert_fragmentation_not_worse \
     "$initial_fragmentation" "$reloaded_fragmentation" "$fragmentation_tolerance" \
     || die "fragmentation grew after GGUF reload: $initial_fragmentation -> $reloaded_fragmentation"

--- a/.github/scripts/test_gpu_process_vram.py
+++ b/.github/scripts/test_gpu_process_vram.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Host-only regressions for container GPU memory attribution."""
+
+import importlib.util
+import pathlib
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    "gpu_process_vram", pathlib.Path(__file__).with_name("gpu-process-vram.py")
+)
+PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROBE)
+
+
+class GpuProcessVramTests(unittest.TestCase):
+    def test_native_runtime_pid(self):
+        identity, memory = PROBE.measure("", "GPU-a, 42, 123\n", 42)
+        self.assertEqual(identity["method"], "runtime-pid")
+        self.assertEqual(memory, 123 * 1024 * 1024)
+
+    def test_host_pid_requires_explicit_exclusive_mode(self):
+        with self.assertRaisesRegex(AssertionError, "absent"):
+            PROBE.measure("", "GPU-a, 99, 123\n", 42)
+        identity, _ = PROBE.measure("", "GPU-a, 99, 123\n", 42, exclusive=True)
+        self.assertEqual(identity["runtime_pid"], 42)
+        self.assertEqual(identity["nvml_pid"], 99)
+
+    def test_exclusive_gpu_must_start_idle(self):
+        with self.assertRaisesRegex(AssertionError, "already in use"):
+            PROBE.measure("GPU-a, 99, 1\n", "GPU-a, 99, 123\n", 42, exclusive=True)
+
+    def test_multiple_or_missing_processes_are_rejected(self):
+        for snapshot in ("", "GPU-a, 99, 123\nGPU-a, 100, 1\n"):
+            with self.subTest(snapshot=snapshot):
+                with self.assertRaisesRegex(AssertionError, "ambiguous"):
+                    PROBE.measure("", snapshot, 42, exclusive=True)
+
+    def test_gpu_or_process_identity_cannot_change(self):
+        identity, _ = PROBE.measure("", "GPU-a, 99, 123\n", 42, exclusive=True)
+        for snapshot in ("GPU-a, 100, 123\n", "GPU-b, 99, 123\n"):
+            with self.subTest(snapshot=snapshot):
+                with self.assertRaisesRegex(AssertionError, "identity changed"):
+                    PROBE.measure("", snapshot, 42, identity, exclusive=True)
+        _, memory = PROBE.measure("", "GPU-a, 99, 100\n", 42, identity, exclusive=True)
+        self.assertEqual(memory, 100 * 1024 * 1024)
+
+    def test_unavailable_memory_is_rejected(self):
+        with self.assertRaisesRegex(AssertionError, "unavailable"):
+            PROBE.measure("", "GPU-a, 99, [N/A]\n", 42, exclusive=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_live_kv_owner.py
+++ b/.github/scripts/test_live_kv_owner.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Host-only streaming/cancellation regressions for the GPU evidence probe."""
+
+import contextlib
+import http.server
+import importlib.util
+import pathlib
+import tempfile
+import threading
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("probe-live-kv-owner.py")
+SPEC = importlib.util.spec_from_file_location("probe_live_kv_owner", SCRIPT)
+PROBE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROBE)
+OWNER = "gguf:1:0:kv-cache"
+
+
+@contextlib.contextmanager
+def endpoint(*, wrong_owner=False, leak=False, done=False):
+    active = threading.Event()
+    closed = threading.Event()
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_GET(self):
+            self.assert_authorized()
+            self.send_response(200)
+            self.end_headers()
+            owner = "gguf:2:0:kv-cache" if wrong_owner else OWNER
+            body = ""
+            if active.is_set():
+                body = f'kapsl_gpu_device_pool_owner_usage_bytes{{device="0",owner="{owner}"}} 64\n'
+            self.wfile.write(body.encode())
+
+        def assert_authorized(self):
+            assert self.headers["Authorization"] == "Bearer test-token"
+
+        def do_POST(self):
+            self.assert_authorized()
+            assert self.path == "/api/models/1/infer/stream"
+            self.rfile.read(int(self.headers["Content-Length"]))
+            active.set()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(
+                b"data: [DONE]\n\n" if done else b'data: {"token":"one"}\n\n'
+            )
+            self.wfile.flush()
+            self.connection.settimeout(5)
+            try:
+                self.connection.recv(1)
+            finally:
+                if not leak:
+                    active.clear()
+                closed.set()
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", closed
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class LiveKvOwnerTests(unittest.TestCase):
+    def run_probe(self, base, root):
+        PROBE.probe(
+            base,
+            "test-token",
+            1,
+            OWNER,
+            pathlib.Path(root) / "evidence",
+            poll_seconds=0.001,
+        )
+
+    def test_observes_live_owner_then_disconnect_reclaims_it(self):
+        with tempfile.TemporaryDirectory() as root, endpoint() as (base, closed):
+            self.run_probe(base, root)
+            self.assertTrue(closed.wait(1))
+            metrics = (pathlib.Path(root) / "evidence/metrics-active.txt").read_text()
+            self.assertEqual(PROBE.owner_usage(metrics, OWNER), 64)
+
+    def test_other_model_allocations_do_not_qualify(self):
+        with (
+            tempfile.TemporaryDirectory() as root,
+            endpoint(wrong_owner=True) as (base, closed),
+        ):
+            with self.assertRaisesRegex(AssertionError, "no live allocation"):
+                self.run_probe(base, root)
+            self.assertTrue(closed.wait(1))
+
+    def test_retained_allocations_after_cancellation_fail(self):
+        with (
+            tempfile.TemporaryDirectory() as root,
+            endpoint(leak=True) as (base, _closed),
+        ):
+            with self.assertRaisesRegex(AssertionError, "retained request KV"):
+                self.run_probe(base, root)
+
+    def test_completed_stream_is_not_live_ownership_proof(self):
+        with (
+            tempfile.TemporaryDirectory() as root,
+            endpoint(done=True) as (base, closed),
+        ):
+            with self.assertRaisesRegex(AssertionError, "generation ended"):
+                self.run_probe(base, root)
+            self.assertTrue(closed.wait(1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           .github/scripts/test-gpu-device-pool-integration.sh --self-test
           python3 .github/scripts/test_live_kv_owner.py
+          python3 .github/scripts/test_gpu_process_vram.py
 
       - name: Check runtime CLI (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
 
       - name: Test GPU integration harness contract
         if: runner.os == 'Linux'
-        run: .github/scripts/test-gpu-device-pool-integration.sh --self-test
+        run: |
+          .github/scripts/test-gpu-device-pool-integration.sh --self-test
+          python3 .github/scripts/test_live_kv_owner.py
 
       - name: Check runtime CLI (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
The mixed ORT/GGUF GPU harness checks for live GGUF KV allocations after every request has finished. With cross-session prefix caching disabled, the backend correctly releases those allocations, causing a false qualification failure.

Capture model/replica KV ownership while a generation stream is active, close the unfinished stream, and verify reclamation. Repeat this before and after GGUF reload and while ORT is unloaded. Compare idle pool snapshots with no request KV owner, while retaining admission, exact pool accounting, fragmentation, VRAM growth and signed-pack route checks. External CUDA state may decrease after reload; retain the original no-growth ceiling and add regressions accepting reclamation and rejecting growth.

For explicitly exclusive container GPUs, allow NVML host-PID attribution only when the device starts idle, exactly one process appears, and its GPU UUID/PID stays unchanged across every memory sample. Retain raw snapshots and the mapping; missing memory, ambiguity, preexisting workloads and identity changes still fail. Default attribution continues to require the runtime PID.

Validation: four host-only fake HTTP-server regressions and six NVML attribution regressions pass, including other-model rejection, retained-allocation rejection, ambiguity and identity-change rejection; the harness self-test, Ruff checks, `cargo fmt --all -- --check`, and `git diff --check` pass. CI runs only the host regressions. Vast observed 589,824 bytes of governed GGUF request KV before and after reload, reclaimed after each stream cancellation. The first revised run exposed 2 MiB of reclaimed external CUDA state with exact pool geometry preserved; the corrected ceiling check passed. The next run demonstrated Vast host/container PID translation; full mixed validation with the explicit exclusive mode passed on H100 for both CUDA 12 and TensorRT 10. Each run proved live KV at all three stages, isolated unload/reload in both directions, VRAM growth within the existing bound, final pool size zero, and no remaining GPU process after cleanup. All PR checks are green at `ace6682`. The 1.5× startup threshold is unchanged.
