### PR TITLE
Add bounded timing for native request hosting

### DIFF
--- a/docs/native-request-profiling.md
+++ b/docs/native-request-profiling.md
@@ -1,0 +1,32 @@
+# Native request diagnosis
+
+`KAPSL_REQUEST_PROFILING=1` enables bounded timing for manual diagnosis.
+`engine.dispatch` records request planning, the memory admission callback and
+backend execution. `engine.native` separates request conversion, call-lock
+acquisition, ownership registration, cancellation registration, adapter calls,
+result conversion and return cleanup. Request-memory reports have their own
+conversion and adapter-call timings. Existing scheduler queue-wait metrics and
+client request durations cover time outside these engine calls.
+
+Each model/replica collector reserves at most 8,192 records across its complete
+lifetime. Disabled collectors perform no request timing or sample allocation.
+Only operation names, numeric ownership/request IDs and durations are captured.
+No tensor data, prompts, session IDs or user metadata enter the profile.
+
+Records remain in memory during inference. Unload the model before terminating
+the process to emit `KAPSL_REQUEST_PROFILE` JSON through normal logging; abrupt
+termination can lose samples. Native and adapter profiles share ABI request
+IDs. Dispatch records use ID zero and can be matched chronologically for serial
+workloads. Each collector publishes its own clock origin for correlation.
+Nested measurements must not be added to their enclosing durations.
+
+Use the analyzer in `kapsl-integrations/integrations/ort/conformance/` and retain
+raw logs, binary/source hashes, model hashes and host resource observations.
+Its default windows assume 40 warmups followed by 1,000-request serial trials.
+The ORT integration also has an ignored CPU-only direct-adapter diagnostic that
+excludes the engine, for comparison with actual signed-pack hosting.
+
+Profiling is diagnostic only. Existing qualification runs keep this switch
+disabled, preserve every trial, and retain the 1.5× startup threshold and other
+gates. This change does not alter allocator ownership, memory admission,
+cancellation, pack verification or platform compatibility policy.

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/mod.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/mod.rs
@@ -7,6 +7,7 @@ mod llama_cpp;
 mod manager;
 mod native;
 mod onnx;
+pub(crate) mod request_profile;
 mod selection;
 
 pub(crate) use bundle::*;

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/native.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/native.rs
@@ -5,6 +5,7 @@
 //! runtime-owned device allocator through `KapslBackendHostV1`. ORT is the
 //! first consumer, but no ORT-specific type crosses this boundary.
 
+use super::request_profile::RequestProfile;
 use super::{BackendExecutionMode, BackendPackManifest};
 use crate::runtime::RuntimeResources;
 use kapsl_backend_abi::*;
@@ -450,6 +451,7 @@ struct NativePackInstance {
     loaded: AtomicBool,
     cleanup_required: AtomicBool,
     call_lock: RwLock<()>,
+    request_profile: RequestProfile,
 }
 
 // The adapter owns its handle. Concurrent inference tables take shared call
@@ -784,6 +786,7 @@ impl NativePackInstance {
             loaded: AtomicBool::new(false),
             cleanup_required: AtomicBool::new(false),
             call_lock: RwLock::new(()),
+            request_profile: RequestProfile::new("engine.native", model_id, replica_id),
         }))
     }
 
@@ -872,9 +875,14 @@ impl NativePackInstance {
         request: &InferenceRequest,
     ) -> Result<T, EngineError> {
         let request_id = self.next_request_id()?;
+        let mut timing = self
+            .request_profile
+            .start("planned_request_memory", request_id);
         let mut bridge = RequestBridge::new(request)?;
         let wire = bridge.wire(request_id);
+        timing.mark("request_conversion");
         let _guard = self.exclusive_guard();
+        timing.mark("call_lock");
         let mut output = KapslOwnedBuffer::empty();
         let mut error = KapslOwnedBuffer::empty();
         // SAFETY: all request views and callback context remain live through
@@ -890,7 +898,10 @@ impl NativePackInstance {
                 &mut error,
             )
         };
-        self.decode_json(status, output, error)
+        timing.mark("adapter_report");
+        let result = self.decode_json(status, output, error);
+        timing.mark("report_conversion");
+        result
     }
 
     fn decode_json<T: DeserializeOwned>(
@@ -918,6 +929,7 @@ impl NativePackInstance {
     }
 
     fn infer(&self, request: &InferenceRequest) -> Result<BinaryTensorPacket, EngineError> {
+        let mut timing = self.request_profile.start("infer", 0);
         if request
             .cancellation
             .as_ref()
@@ -928,19 +940,24 @@ impl NativePackInstance {
             ));
         }
         let request_id = self.next_request_id()?;
+        timing.request_id(request_id);
         let mut bridge = RequestBridge::new(request)?;
         let wire = bridge.wire(request_id);
+        timing.mark("request_conversion");
         let _guard = self.inference_guard();
         self.require_loaded()?;
+        timing.mark("call_lock");
         let _allocation_call = self
             .host
             .begin_requests([(request_id, request.cancellation.clone())])?;
+        timing.mark("ownership_registration");
         let _cancellation_watches = self.watch_cancellations(
             request
                 .cancellation
                 .clone()
                 .map(|cancellation| (request_id, cancellation)),
         );
+        timing.mark("cancellation_registration");
         let mut result = KapslInferenceResultV1::empty();
         let mut error = KapslOwnedBuffer::empty();
         // SAFETY: request and result storage follows the synchronous ABI lifetime.
@@ -952,6 +969,7 @@ impl NativePackInstance {
                 &mut error,
             )
         };
+        timing.mark("adapter_infer");
         if status != KAPSL_STATUS_OK {
             return Err(status_engine_error(
                 status,
@@ -971,7 +989,9 @@ impl NativePackInstance {
                 "native backend request was cancelled during execution",
             ));
         }
-        copy_single_result(&result)
+        let output = copy_single_result(&result);
+        timing.mark("result_conversion");
+        output
     }
 
     fn infer_stream(self: &Arc<Self>, request: InferenceRequest) -> EngineStream {
@@ -1215,7 +1235,9 @@ impl NativePackInstance {
     fn unload(&self) -> Result<(), EngineError> {
         let _guard = self.exclusive_guard();
         let _cancel_pause = self.cancel_target.pause();
-        self.unload_locked()
+        let result = self.unload_locked();
+        self.request_profile.flush(|line| log::info!("{line}"));
+        result
     }
 
     fn unload_locked(&self) -> Result<(), EngineError> {

--- a/kapsl-runtime/crates/kapsl-cli/src/backend/request_profile.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/backend/request_profile.rs
@@ -1,0 +1,201 @@
+//! Opt-in, bounded request timing for manual diagnosis. No request data is recorded.
+//!
+//! Records stay in memory until explicit lifecycle teardown, so diagnostic log
+//! I/O does not occur inside measured inference. This is not a qualification mode.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+const LIMIT: usize = 8192;
+const MAX_PHASES: usize = 16;
+
+pub(crate) struct RequestProfile {
+    component: &'static str,
+    model_id: u32,
+    replica_id: u32,
+    origin: Instant,
+    origin_unix_ns: u128,
+    limit: usize,
+    started: AtomicUsize,
+    records: Mutex<Vec<Record>>,
+}
+
+#[derive(Serialize)]
+struct Record {
+    operation: &'static str,
+    request_id: u64,
+    sequence: usize,
+    started_ns: u64,
+    wall_ns: u64,
+    phases: Vec<Phase>,
+}
+
+#[derive(Serialize)]
+struct Phase {
+    name: &'static str,
+    wall_ns: u64,
+}
+
+pub(crate) struct RequestTiming<'a> {
+    active: Option<ActiveTiming<'a>>,
+}
+
+struct ActiveTiming<'a> {
+    profile: &'a RequestProfile,
+    started: Instant,
+    previous: Instant,
+    record: Record,
+}
+
+fn ns(value: std::time::Duration) -> u64 {
+    value.as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+impl RequestProfile {
+    pub(crate) fn new(component: &'static str, model_id: u32, replica_id: u32) -> Self {
+        Self::with_limit(
+            component,
+            model_id,
+            replica_id,
+            if std::env::var("KAPSL_REQUEST_PROFILING").as_deref() == Ok("1") {
+                LIMIT
+            } else {
+                0
+            },
+        )
+    }
+
+    fn with_limit(component: &'static str, model_id: u32, replica_id: u32, limit: usize) -> Self {
+        Self {
+            component,
+            model_id,
+            replica_id,
+            origin: Instant::now(),
+            origin_unix_ns: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos(),
+            limit: limit.min(LIMIT),
+            started: AtomicUsize::new(0),
+            records: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(crate) fn start(&self, operation: &'static str, request_id: u64) -> RequestTiming<'_> {
+        if self.limit == 0 {
+            return RequestTiming { active: None };
+        }
+        // Reserve before collecting phases: concurrent calls cannot exceed the
+        // memory bound, including records whose spans have not finished yet.
+        let sequence = self.started.fetch_add(1, Ordering::Relaxed);
+        if sequence >= self.limit {
+            return RequestTiming { active: None };
+        }
+        let started = Instant::now();
+        RequestTiming {
+            active: Some(ActiveTiming {
+                profile: self,
+                started,
+                previous: started,
+                record: Record {
+                    operation,
+                    request_id,
+                    sequence,
+                    started_ns: ns(started.duration_since(self.origin)),
+                    wall_ns: 0,
+                    phases: Vec::with_capacity(MAX_PHASES),
+                },
+            }),
+        }
+    }
+
+    /// Call only after inference has drained. Keep one lifetime-wide sample
+    /// budget across reloads; flushing cannot start unbounded new collection.
+    pub(crate) fn flush(&self, mut emit: impl FnMut(&str)) {
+        let records = std::mem::take(&mut *self.records.lock().unwrap_or_else(|p| p.into_inner()));
+        for chunk in records.chunks(128) {
+            let report = serde_json::json!({
+                "schema_version": 1,
+                "component": self.component,
+                "process_id": std::process::id(),
+                "model_id": self.model_id,
+                "replica_id": self.replica_id,
+                "origin_unix_ns": self.origin_unix_ns.to_string(),
+                "sample_limit": self.limit,
+                "started_samples": self.started.load(Ordering::Relaxed),
+                "records": chunk,
+            });
+            emit(&format!("KAPSL_REQUEST_PROFILE {report}"));
+        }
+    }
+}
+
+impl RequestTiming<'_> {
+    pub(crate) fn request_id(&mut self, id: u64) {
+        if let Some(active) = &mut self.active {
+            active.record.request_id = id;
+        }
+    }
+
+    pub(crate) fn mark(&mut self, name: &'static str) {
+        if let Some(active) = &mut self.active {
+            let now = Instant::now();
+            if active.record.phases.len() < MAX_PHASES {
+                active.record.phases.push(Phase {
+                    name,
+                    wall_ns: ns(now.duration_since(active.previous)),
+                });
+            }
+            active.previous = now;
+        }
+    }
+}
+
+impl Drop for RequestTiming<'_> {
+    fn drop(&mut self) {
+        self.mark("return_cleanup");
+        if let Some(mut active) = self.active.take() {
+            active.record.wall_ns = ns(active.started.elapsed());
+            active
+                .profile
+                .records
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(active.record);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_profiles_collect_nothing_and_reservations_bound_concurrent_spans() {
+        let disabled = RequestProfile::with_limit("test", 1, 2, 0);
+        drop(disabled.start("infer", 9));
+        disabled.flush(|_| panic!("disabled profiling emitted output"));
+        let profile = RequestProfile::with_limit("test", 1, 2, 2);
+        let mut first = profile.start("infer", 0);
+        let second = profile.start("infer", 10);
+        drop(profile.start("infer", 11));
+        first.request_id(9);
+        first.mark("execute");
+        drop(second);
+        drop(first);
+        let mut reports = Vec::new();
+        profile.flush(|line| reports.push(line.to_owned()));
+        let report: serde_json::Value =
+            serde_json::from_str(reports[0].strip_prefix("KAPSL_REQUEST_PROFILE ").unwrap())
+                .unwrap();
+        assert_eq!(report["model_id"], 1);
+        assert_eq!(report["replica_id"], 2);
+        let records = report["records"].as_array().unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().any(|record| record["request_id"] == 9));
+        drop(profile.start("infer", 12));
+        profile.flush(|_| panic!("flush reset the lifetime collection limit"));
+    }
+}

--- a/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
+++ b/kapsl-runtime/crates/kapsl-cli/src/runtime/model/backend.rs
@@ -94,6 +94,7 @@ struct MemoryTrackedEngine {
     resources: Arc<RuntimeResources>,
     owner: MemoryOwner,
     engine_kind: EngineKind,
+    request_profile: Arc<crate::backend::request_profile::RequestProfile>,
     priority_lease: std::sync::Mutex<Option<ModelPriorityLease>>,
     reconciliation_error: std::sync::Mutex<Option<String>>,
     #[cfg(feature = "gpu-device-pool")]
@@ -115,6 +116,11 @@ impl MemoryTrackedEngine {
             resources,
             owner,
             engine_kind,
+            request_profile: Arc::new(crate::backend::request_profile::RequestProfile::new(
+                "engine.dispatch",
+                owner.model_id,
+                owner.replica_id,
+            )),
             priority_lease: std::sync::Mutex::new(Some(priority_lease)),
             reconciliation_error: std::sync::Mutex::new(None),
             #[cfg(feature = "gpu-device-pool")]
@@ -124,6 +130,7 @@ impl MemoryTrackedEngine {
 
     fn unload_and_release(&mut self) {
         self.inner.unload();
+        self.request_profile.flush(|line| log::info!("{line}"));
         #[cfg(feature = "gpu-device-pool")]
         self.staged_memory_lease.get_mut().unwrap().take();
         self.lease.get_mut().unwrap().take();
@@ -183,7 +190,13 @@ impl MemoryTrackedEngine {
     fn request_admission(&self, request: &InferenceRequest) -> RequestMemoryAdmission {
         let resources = Arc::clone(&self.resources);
         let plan = self.request_plan(std::slice::from_ref(request));
-        RequestMemoryAdmission::new(move || Self::acquire_request_plan(&resources, &plan))
+        let profile = Arc::clone(&self.request_profile);
+        RequestMemoryAdmission::new(move || {
+            let mut timing = profile.start("memory_admission", 0);
+            let result = Self::acquire_request_plan(&resources, &plan);
+            timing.mark("acquire_request_plan");
+            result
+        })
     }
 
     fn openai_wire_request_plan(&self, request: &OpenAiWireRequest) -> MemoryPlan {
@@ -275,8 +288,12 @@ impl kapsl_engine_api::Engine for MemoryTrackedEngine {
         self.inner.planned_request_memory(request)
     }
     fn infer(&self, request: &InferenceRequest) -> Result<BinaryTensorPacket, EngineError> {
-        self.inner
-            .infer_with_memory_admission(request, self.request_admission(request))
+        let mut timing = self.request_profile.start("infer", 0);
+        let admission = self.request_admission(request);
+        timing.mark("request_planning");
+        let result = self.inner.infer_with_memory_admission(request, admission);
+        timing.mark("admission_and_backend");
+        result
     }
     fn supports_openai_wire(&self) -> bool {
         self.inner.supports_openai_wire()


### PR DESCRIPTION
Native-pack latency currently combines engine admission, ABI hosting and adapter execution, making a slow request difficult to attribute. Add `KAPSL_REQUEST_PROFILING=1` to separate these phases and request-memory reporting, with at most 8,192 records per model/replica collector. Normal requests collect no timing data when the switch is disabled; enabled records stay in memory until unload, so profiling log I/O occurs after inference.

The companion ORT adapter uses the same record schema and ABI request IDs. Records contain ownership IDs and durations only. Allocator, admission, cancellation, signature verification and platform policy remain intact. This PR is stacked on #234.

Validation: 112 engine boundary tests pass; formatting and diff checks pass. Manual Linux CPU diagnosis exercised the actual signed-pack installer, inference and explicit unload. The ORT companion passed 42 CPU, 38 CUDA host and 39 TensorRT host tests with no GPU inference. Measurements are diagnostic; the previous accelerator qualification failures remain unresolved and all release gates, including 1.5× startup, remain unchanged.

Manual CPU control: the exact previously tested engine binary and signed CPU pack passed the original full 40-start parity workload on the Ryzen host with profiling disabled. Signed/embedded throughput was 0.8558 at concurrency 1 and 0.9449 at concurrency 4; startup was 1.0138× against the unchanged 1.5× limit. This control does not demonstrate a speedup from the profiling commits. The earlier multi-second first-trial spike did not reproduce; its cause remains unconfirmed. The GPU startup/performance failures remain unresolved. All 385 evidence files were verified locally before Vast instance 50737464 was destroyed and confirmed absent. Archive SHA-256: `affa35da4f668d4bbd4bf5a0dce4b1cf626b071fa1752956b68240fef0192456`.
